### PR TITLE
Release polish and alpha-0.8 prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show toolchain
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  swift:
+    name: Swift build and tests
+    runs-on: macos-26
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test
+
+      - name: Build release app bundle
+        run: ./Scripts/build-release-app.sh
+
+      - name: Verify signatures
+        run: |
+          codesign --verify --strict --verbose=2 .build/release-app/GlassEQ.app/Contents/Helpers/GlassEQSettings.app
+          codesign --verify --strict --verbose=2 .build/release-app/GlassEQ.app

--- a/Docs/Distribution.md
+++ b/Docs/Distribution.md
@@ -1,6 +1,6 @@
 # Distribution Notes
 
-GlassEQ alpha-0.7 is intended for ad hoc-signed distribution to technical testers. It is not Developer ID signed and is not notarized. A later non-alpha build will move to Developer ID distribution outside the Mac App Store.
+GlassEQ alpha-0.8 is intended for ad hoc-signed distribution to technical testers. It is not Developer ID signed and is not notarized. A later non-alpha build will move to Developer ID distribution outside the Mac App Store.
 
 ## Current Alpha Distribution
 
@@ -13,7 +13,7 @@ Build the alpha artifact:
 The script produces:
 
 - `.build/release-app/GlassEQ.app`
-- `.build/dist/GlassEQ-alpha-0.7-macos26-arm64.zip`
+- `.build/dist/GlassEQ-alpha-0.8-macos26-arm64.zip`
 
 The bundle is ad hoc-signed with `codesign --sign -`. It is not Developer ID signed and is not notarized, so this command should reject it:
 

--- a/Docs/Distribution.md
+++ b/Docs/Distribution.md
@@ -81,7 +81,8 @@ For alpha packaging, also run:
 
 ```sh
 ./Scripts/build-release-app.sh
-codesign --verify --strict --deep --verbose=2 .build/release-app/GlassEQ.app
+codesign --verify --strict --verbose=2 .build/release-app/GlassEQ.app/Contents/Helpers/GlassEQSettings.app
+codesign --verify --strict --verbose=2 .build/release-app/GlassEQ.app
 codesign -d --entitlements :- .build/release-app/GlassEQ.app
 spctl --assess --type execute --verbose=4 .build/release-app/GlassEQ.app
 ```

--- a/Docs/ReleaseNotes-alpha-0.8.md
+++ b/Docs/ReleaseNotes-alpha-0.8.md
@@ -1,0 +1,55 @@
+# GlassEQ alpha-0.8 Release Notes
+
+This is a technical alpha for Apple Silicon Macs running macOS 26.
+
+## Distribution Warning
+
+This build is ad hoc-signed, not Developer ID signed, and not notarized. macOS Gatekeeper will reject it by default. Install only if you are comfortable testing ad hoc-signed macOS software and granting system audio capture permission.
+
+## Changes Since alpha-0.7
+
+- Hardened settings-helper IPC startup, token bootstrap, ordered pipe reads, broken-pipe handling, and write cleanup.
+- Improved audio route recovery, device restoration persistence, and output rebuild ordering.
+- Fixed profile-store repair so valid profiles survive malformed or duplicate entries.
+- Tightened AutoEQ / REW import parsing and graphic EQ round-tripping.
+- Improved lifecycle safety around stop/start ordering, observer callbacks, and Thread Sanitizer coverage.
+- Added CI and stricter debug/release codesign verification.
+
+## Included
+
+- Menu bar app shell.
+- Core Audio system output tap.
+- Playback of processed audio to the current default output.
+- Parametric EQ, 10-band graphic EQ, and 31-band graphic EQ profiles.
+- AutoEQ / EqualizerAPO and REW text import.
+- Per-output profile mappings by Core Audio device UID.
+- Profile persistence under the GlassEQ sandbox container, with migration from legacy `~/Library/Application Support/GlassEQ` data.
+- Settings helper app and local IPC for editing profiles from the menu bar app.
+- Audio route recovery after system sleep, screen wake, session unlock, and Bluetooth route teardown while the screen is locked.
+- More conservative built-in speaker buffering to avoid steady-state playback underruns and distortion.
+- Basic callback metrics and diagnostics tooling.
+
+## Supported Alpha Target
+
+- macOS 26.0 or newer.
+- Apple Silicon / arm64 only.
+
+## Known Issues
+
+- Gatekeeper rejection is expected because the app is not notarized.
+- System audio capture permission may require manual cleanup or retrying on test machines.
+- Bluetooth and AirPods routes may still expose macOS Core Audio edge cases; report device model, macOS version, and steps to reproduce.
+- AirPlay outputs are not yet supported.
+- No automatic updates.
+- No crash reporting.
+- No notarized Developer ID build yet.
+- No x86_64 build.
+
+## Build Artifact
+
+The release script writes:
+
+```sh
+.build/dist/GlassEQ-alpha-0.8-macos26-arm64.zip
+.build/dist/GlassEQ-alpha-0.8-macos26-arm64.zip.sha256
+```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GlassEQ takes a different route. It uses **Core Audio process taps**, Apple's mo
 
 ## Download & install
 
-Grab `GlassEQ-alpha-0.7-macos26-arm64.zip` from the [alpha-0.7 release](https://github.com/juhokoskela/GlassEQ/releases/tag/alpha-0.7), then:
+Grab `GlassEQ-alpha-0.8-macos26-arm64.zip` from the [alpha-0.8 release](https://github.com/juhokoskela/GlassEQ/releases/tag/alpha-0.8), then:
 
 1. Unzip it.
 2. Move `GlassEQ.app` to `/Applications`.
@@ -37,7 +37,7 @@ On first run GlassEQ asks for **system audio capture permission** — that's wha
 
 ### About this alpha
 
-GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no automatic updates or crash reporting yet. Expect the occasional rough edge, and please report any hardware-specific audio issues you run into. See [Docs/AlphaTesting.md](Docs/AlphaTesting.md), [Docs/Distribution.md](Docs/Distribution.md), and [Docs/ReleaseNotes-alpha-0.7.md](Docs/ReleaseNotes-alpha-0.7.md) before installing a build.
+GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no automatic updates or crash reporting yet. Expect the occasional rough edge, and please report any hardware-specific audio issues you run into. See [Docs/AlphaTesting.md](Docs/AlphaTesting.md), [Docs/Distribution.md](Docs/Distribution.md), and [Docs/ReleaseNotes-alpha-0.8.md](Docs/ReleaseNotes-alpha-0.8.md) before installing a build.
 
 ## How it works
 
@@ -69,12 +69,12 @@ During normal listening GlassEQ is just a menu bar app and the audio engine, con
 ### Security & privacy
 
 - Sandboxed: requests only the audio-capture permission it needs to function.
-- The settings helper is code-signature-checked (expected identity, same signing team) before it's launched and talks to the main app over a token-authenticated local pipe – no networking, no shared files.
+- The settings helper must be inside the app bundle and pass code-signature integrity plus signing-identifier checks before launch and again after launch. Developer ID builds also require the same signing team; ad hoc alpha builds rely on bundle containment, identifier checks, and the private token-authenticated pipe. There is no networking or shared profile storage.
 - No telemetry, no analytics, no cloud sync. Diagnostics run locally and print device details only to your terminal.
 
 ## Known limitations
 
-- **AirPlay outputs are not yet supported.** The DSP engine currently fails to start on AirPlay receivers. GlassEQ fails open, so audio keeps playing to the AirPlay device just without EQ and switching to any other output (built-in, USB, Bluetooth, HDMI) restores processing cleanly.
+- **AirPlay outputs are not yet supported.** The DSP engine currently fails to start on AirPlay receivers and GlassEQ stops processing that route; macOS keeps routing normal system audio to the AirPlay device. Switching to any other output (built-in, USB, Bluetooth, HDMI) restores processing cleanly.
 - **Stereo only.** GlassEQ processes mono and 2-channel outputs, multichannel / surround outputs aren't supported yet.
 - **Bluetooth** routes can still surface Core Audio edge cases, please report device model, macOS version, and steps to reproduce.
 - No automatic updates, no crash reporting, no x86_64 build.

--- a/Scripts/build-debug-app.sh
+++ b/Scripts/build-debug-app.sh
@@ -86,5 +86,7 @@ chmod +x "$SETTINGS_MACOS_DIR/$SETTINGS_APP_NAME"
 
 codesign --force --sign - --identifier com.glasseq.app.settings --entitlements "$ROOT_DIR/GlassEQSettings.entitlements" "$SETTINGS_APP_DIR" >/dev/null
 codesign --force --sign - --entitlements "$ROOT_DIR/GlassEQ.entitlements" "$APP_DIR" >/dev/null
+codesign --verify --strict --verbose=2 "$SETTINGS_APP_DIR" >/dev/null
+codesign --verify --strict --verbose=2 "$APP_DIR" >/dev/null
 
 echo "$APP_DIR"

--- a/Scripts/build-release-app.sh
+++ b/Scripts/build-release-app.sh
@@ -19,8 +19,12 @@ APP_NAME="GlassEQ"
 APP_TARGET="GlassEQApp"
 SETTINGS_APP_NAME="GlassEQSettings"
 SETTINGS_APP_TARGET="GlassEQSettings"
-VERSION="${VERSION:-0.7.0}"
-BUILD="${BUILD:-9}"
+source_plist_value() {
+    /usr/libexec/PlistBuddy -c "Print :$1" "$2"
+}
+
+VERSION="${VERSION:-$(source_plist_value CFBundleShortVersionString "$ROOT_DIR/Sources/GlassEQApp/Info.plist")}"
+BUILD="${BUILD:-$(source_plist_value CFBundleVersion "$ROOT_DIR/Sources/GlassEQApp/Info.plist")}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL:-alpha}"
 ARCH="${ARCH:-arm64}"
 RELEASE_LABEL="${RELEASE_LABEL:-}"
@@ -258,8 +262,8 @@ else
         "$APP_DIR" >/dev/null
 fi
 
-codesign --verify --strict --deep --verbose=2 "$SETTINGS_APP_DIR" >/dev/null
-codesign --verify --strict --deep --verbose=2 "$APP_DIR" >/dev/null
+codesign --verify --strict --verbose=2 "$SETTINGS_APP_DIR" >/dev/null
+codesign --verify --strict --verbose=2 "$APP_DIR" >/dev/null
 
 if [[ "$RELEASE_CHANNEL" == "production" ]]; then
     NOTARY_ZIP="$DIST_DIR/$APP_NAME-$RELEASE_LABEL-macos26-$ARCH-notary-submit.zip"
@@ -267,8 +271,8 @@ if [[ "$RELEASE_CHANNEL" == "production" ]]; then
     ditto -c -k --keepParent --norsrc --noextattr --noqtn --noacl "$APP_DIR" "$NOTARY_ZIP"
     xcrun notarytool submit "$NOTARY_ZIP" --keychain-profile "$NOTARY_PROFILE" --wait
     xcrun stapler staple "$APP_DIR"
-    codesign --verify --strict --deep --verbose=2 "$SETTINGS_APP_DIR" >/dev/null
-    codesign --verify --strict --deep --verbose=2 "$APP_DIR" >/dev/null
+    codesign --verify --strict --verbose=2 "$SETTINGS_APP_DIR" >/dev/null
+    codesign --verify --strict --verbose=2 "$APP_DIR" >/dev/null
     spctl --assess --type execute --verbose=4 "$APP_DIR"
 fi
 

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -44,7 +44,7 @@ final class GlassEQAppDelegate: NSObject, NSApplicationDelegate {
             }
             let shouldTerminate = await model.flushStoreBeforeQuit()
             if shouldTerminate {
-                model.cleanupForTermination()
+                await model.cleanupForTerminationAndWait()
             }
             sender.reply(toApplicationShouldTerminate: shouldTerminate)
         }
@@ -230,9 +230,21 @@ struct CoreAudioDefaultOutputLookup: DefaultOutputLookingUp {
 
 typealias DefaultOutputObserverHandler = @Sendable (Result<AudioOutputDevice, Error>) -> Void
 
-protocol DefaultOutputObserving: AnyObject {
+protocol DefaultOutputObserving: AnyObject, Sendable {
     func start(sendInitialValue: Bool) throws
     func stop()
+    func startAsync(sendInitialValue: Bool) async throws
+    func stopAsync() async
+}
+
+extension DefaultOutputObserving {
+    func startAsync(sendInitialValue: Bool) async throws {
+        try start(sendInitialValue: sendInitialValue)
+    }
+
+    func stopAsync() async {
+        stop()
+    }
 }
 
 extension DefaultOutputDeviceObserver: DefaultOutputObserving {}
@@ -294,9 +306,26 @@ private actor ProfileStoreWriter {
     }
 }
 
-private actor EngineWorkExecutor {
-    func run<T: Sendable>(_ operation: @Sendable () -> T) -> T {
-        operation()
+private final class EngineWorkExecutor: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tail: Task<Void, Never> = Task {}
+
+    @discardableResult
+    func enqueue<T: Sendable>(
+        priority: TaskPriority? = nil,
+        _ operation: @Sendable @escaping () -> T
+    ) -> Task<T, Never> {
+        lock.lock()
+        let previous = tail
+        let task = Task(priority: priority) {
+            _ = await previous.value
+            return operation()
+        }
+        tail = Task {
+            _ = await task.value
+        }
+        lock.unlock()
+        return task
     }
 }
 
@@ -472,14 +501,9 @@ final class GlassEQAppModel {
         }
 
         guard observer == nil else {
-            do {
-                try observer?.start(sendInitialValue: sendInitialValue)
-            } catch {
-                statusMessage = localized("Default output observer failed: \(error.localizedDescription)")
-                lifecycleState = .stopped
-                isRunning = false
+            if let observer {
+                startObserverAsync(observer, generation: observerCallbackGeneration, sendInitialValue: sendInitialValue)
             }
-            notifyModelDidChange()
             return
         }
 
@@ -492,18 +516,40 @@ final class GlassEQAppModel {
         }
         self.observer = observer
 
-        do {
-            try observer.start(sendInitialValue: sendInitialValue)
-        } catch {
-            statusMessage = localized("Default output observer failed: \(error.localizedDescription)")
-            if lifecycleState == .waking {
-                scheduleWakeReconnectRetry(status: statusMessage)
-            } else {
-                lifecycleState = .stopped
-                isRunning = false
+        startObserverAsync(observer, generation: generation, sendInitialValue: sendInitialValue)
+    }
+
+    private func startObserverAsync(
+        _ observer: any DefaultOutputObserving,
+        generation: Int,
+        sendInitialValue: Bool
+    ) {
+        Task { @MainActor [weak self, weak observer] in
+            guard let self,
+                  let observer else {
+                return
             }
+            do {
+                try await observer.startAsync(sendInitialValue: sendInitialValue)
+            } catch {
+                guard self.observer === observer,
+                      self.observerCallbackGeneration == generation else {
+                    return
+                }
+                statusMessage = localized("Default output observer failed: \(error.localizedDescription)")
+                if lifecycleState == .waking {
+                    scheduleWakeReconnectRetry(status: statusMessage)
+                } else {
+                    lifecycleState = .stopped
+                    isRunning = false
+                }
+            }
+            guard self.observer === observer,
+                  self.observerCallbackGeneration == generation else {
+                return
+            }
+            notifyModelDidChange()
         }
-        notifyModelDidChange()
     }
 
     func stop() {
@@ -516,8 +562,7 @@ final class GlassEQAppModel {
         invalidatePendingEngineStart()
         metricsTask?.cancel()
         metricsTask = nil
-        engine.stop()
-        engineMetrics = engine.snapshotMetrics()
+        scheduleEngineStop(updateMetrics: true)
         previewReturnProfile = nil
         lifecycleState = .stopped
         isRunning = false
@@ -618,15 +663,17 @@ final class GlassEQAppModel {
     }
 
     func setBypass(_ isBypassed: Bool) {
-        var profile = draftProfile
+        var profile = activeProfile
         profile.isBypassed = isBypassed
         var store = profileStore
         upsertProfile(profile, in: &store)
         do {
             try ProfilePersistence.validate(store)
             profileStore = store
-            draftProfile = profile
             activeProfile = profile
+            if draftProfile.id == profile.id {
+                draftProfile = profile
+            }
             saveStore()
             if lifecycleState == .waking {
                 reschedulePendingEngineStartWithActiveProfile()
@@ -929,7 +976,7 @@ final class GlassEQAppModel {
         let settlingDelay = outputChangeSettlingDelay(for: result)
         outputChangeTask?.cancel()
         if shouldMuteForSettlingOutputChange(result) {
-            engine.muteOutputForTransition()
+            scheduleEngineMuteForTransition()
             statusMessage = outputChangeStatusMessage(for: result)
             notifyModelDidChange()
         }
@@ -1017,7 +1064,7 @@ final class GlassEQAppModel {
                 return
             }
             invalidatePendingEngineStart()
-            engine.stop()
+            scheduleEngineStop(updateMetrics: false)
             lifecycleState = .stopped
             isRunning = false
             statusMessage = localized("Default output unavailable: \(error.localizedDescription)")
@@ -1044,10 +1091,8 @@ final class GlassEQAppModel {
         let engine = engine
         let defaultOutputLookup = defaultOutputLookup
         let engineWorkExecutor = engineWorkExecutor
-        let workTask = Task.detached(priority: .userInitiated) {
-            await engineWorkExecutor.run {
-                Self.performEngineWork(work, engine: engine, defaultOutputLookup: defaultOutputLookup)
-            }
+        let workTask = engineWorkExecutor.enqueue(priority: .userInitiated) {
+            Self.performEngineWork(work, engine: engine, defaultOutputLookup: defaultOutputLookup)
         }
 
         engineStartTask = Task { @MainActor [weak self] in
@@ -1061,6 +1106,41 @@ final class GlassEQAppModel {
                 return
             }
             self?.completeEngineWork(result, generation: generation)
+        }
+    }
+
+    private func scheduleEngineStop(updateMetrics: Bool) {
+        let stopTask = enqueueEngineStop()
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            let metrics = await stopTask.value
+            if updateMetrics {
+                engineMetrics = metrics
+                notifyModelDidChange()
+            }
+        }
+    }
+
+    private func scheduleEngineMuteForTransition() {
+        let engine = engine
+        let engineWorkExecutor = engineWorkExecutor
+        engineWorkExecutor.enqueue(priority: .userInitiated) {
+            engine.muteOutputForTransition()
+        }
+    }
+
+    private func stopEngineOffMain() async -> AudioEngineMetrics {
+        await enqueueEngineStop().value
+    }
+
+    private func enqueueEngineStop() -> Task<AudioEngineMetrics, Never> {
+        let engine = engine
+        let engineWorkExecutor = engineWorkExecutor
+        return engineWorkExecutor.enqueue(priority: .userInitiated) {
+            engine.stop()
+            return engine.snapshotMetrics()
         }
     }
 
@@ -1136,10 +1216,7 @@ final class GlassEQAppModel {
                 || lifecycleState == .terminating else {
             return
         }
-        engine.stop()
-        if lifecycleState == .stopped {
-            engineMetrics = engine.snapshotMetrics()
-        }
+        scheduleEngineStop(updateMetrics: lifecycleState == .stopped)
     }
 
     private func completeEngineWork(_ result: EngineWorkResult, generation: Int) {
@@ -1191,7 +1268,7 @@ final class GlassEQAppModel {
         }
         guard wakeReconnectAttempts < WakeReconnectPolicy.maximumAttempts else {
             invalidatePendingEngineStart()
-            engine.stop()
+            scheduleEngineStop(updateMetrics: false)
             lifecycleState = .stopped
             isRunning = false
             statusMessage = status
@@ -1259,7 +1336,7 @@ final class GlassEQAppModel {
             guard await self.flushStoreBeforeQuit() else {
                 return
             }
-            self.cleanupForTermination()
+            await self.cleanupForTerminationAndWait()
             GlassEQAppDelegate.allowNextTerminationImmediately()
             NSApplication.shared.terminate(nil)
         }
@@ -1341,8 +1418,11 @@ final class GlassEQAppModel {
 
     private func stopObserver() {
         observerCallbackGeneration += 1
-        observer?.stop()
+        let observerToStop = observer
         observer = nil
+        Task {
+            await observerToStop?.stopAsync()
+        }
     }
 
     private func invalidatePendingOutputChange() {
@@ -1391,7 +1471,7 @@ final class GlassEQAppModel {
         lifecycleObserverTokens.append(
             NotificationCenter.default.addObserver(forName: NSApplication.willTerminateNotification, object: nil, queue: .main) { [weak self] _ in
                 Task { @MainActor in
-                    self?.cleanupForTermination()
+                    await self?.cleanupForTerminationAndWait()
                 }
             }
         )
@@ -1406,7 +1486,7 @@ final class GlassEQAppModel {
         invalidatePendingOutputChange()
         invalidatePendingEngineStart()
         stopObserver()
-        engine.stop()
+        scheduleEngineStop(updateMetrics: false)
         previewReturnProfile = nil
         lifecycleState = .sleeping
         isRunning = false
@@ -1485,8 +1565,23 @@ final class GlassEQAppModel {
     }
 
     func cleanupForTermination() {
-        guard lifecycleState != .terminating else {
+        guard prepareForTermination(shutdownSettings: true) else {
             return
+        }
+        scheduleEngineStop(updateMetrics: false)
+    }
+
+    func cleanupForTerminationAndWait() async {
+        guard prepareForTermination(shutdownSettings: false) else {
+            return
+        }
+        await settingsCoordinator.shutdownAndWait()
+        _ = await stopEngineOffMain()
+    }
+
+    private func prepareForTermination(shutdownSettings: Bool) -> Bool {
+        guard lifecycleState != .terminating else {
+            return false
         }
         lifecycleState = .terminating
         wasRunningBeforeSleep = false
@@ -1495,11 +1590,13 @@ final class GlassEQAppModel {
         metricsTask?.cancel()
         metricsTask = nil
         stopObserver()
-        engine.stop()
         previewReturnProfile = nil
         isRunning = false
-        settingsCoordinator.shutdown()
+        if shutdownSettings {
+            settingsCoordinator.shutdown()
+        }
         notifyModelDidChange()
+        return true
     }
 
     private func audioEngineStatusMessage(_ error: Error) -> String {
@@ -1592,16 +1689,16 @@ private struct MenuBarView: View {
                 .labelsHidden()
                 .accessibilityLabel(Text(localized("Profile")))
                 .accessibilityValue(Text(model.selectedProfile.name))
-                .accessibilityHint(Text(localized("Chooses the active profile")))
+                .accessibilityHint(Text(localized("Chooses a profile for editing")))
             }
 
             HStack(spacing: 10) {
                 Button {
-                    model.setBypass(!model.draftProfile.isBypassed)
+                    model.setBypass(!model.activeProfile.isBypassed)
                 } label: {
                     Label(
-                        model.draftProfile.isBypassed ? localized("Enable") : localized("Disable"),
-                        systemImage: model.draftProfile.isBypassed ? "speaker.wave.2" : "speaker.slash"
+                        model.activeProfile.isBypassed ? localized("Enable") : localized("Disable"),
+                        systemImage: model.activeProfile.isBypassed ? "speaker.wave.2" : "speaker.slash"
                     )
                         .frame(minWidth: 82, minHeight: 28)
                         .contentShape(.rect)
@@ -1609,9 +1706,9 @@ private struct MenuBarView: View {
                 .controlSize(.large)
                 .buttonStyle(.glass)
                 .tint(popoverControlsAreActive ? enableButtonTint : nil)
-                .accessibilityLabel(Text(model.draftProfile.isBypassed ? localized("Enable equalizer") : localized("Disable equalizer")))
+                .accessibilityLabel(Text(model.activeProfile.isBypassed ? localized("Enable equalizer") : localized("Disable equalizer")))
                 .accessibilityValue(Text(statusBadgeTitle))
-                .accessibilityHint(Text(localized("Toggles audio bypass for the selected profile")))
+                .accessibilityHint(Text(localized("Toggles audio bypass for the active profile")))
 
                 Button {
                     dismiss()
@@ -1675,15 +1772,15 @@ private struct MenuBarView: View {
         guard model.isRunning else {
             return localized("Stopped")
         }
-        return model.draftProfile.isBypassed ? localized("Disabled") : localized("Active")
+        return model.activeProfile.isBypassed ? localized("Disabled") : localized("Active")
     }
 
     private var statusBadgeColor: Color {
-        model.isRunning && !model.draftProfile.isBypassed ? .macOSSystemGreen : .macOSSystemRed
+        model.isRunning && !model.activeProfile.isBypassed ? .macOSSystemGreen : .macOSSystemRed
     }
 
     private var enableButtonTint: Color {
-        model.draftProfile.isBypassed ? .macOSSystemGreen : .macOSSystemYellow
+        model.activeProfile.isBypassed ? .macOSSystemGreen : .macOSSystemYellow
     }
 
     private var popoverControlsAreActive: Bool {

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -85,8 +85,8 @@ private enum AppBuildInfo {
            !releaseLabel.isEmpty {
             return releaseLabel
         }
-        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.7.0"
-        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "9"
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.8.0"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "10"
         return "v\(version) (\(build))"
     }
 }

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -304,6 +304,10 @@ private actor ProfileStoreWriter {
         }
         try handle.synchronize()
     }
+
+    func resetUnsupportedStore(timestamp: Date = Date()) throws -> (store: ProfileStore, backupURL: URL) {
+        try ProfilePersistence.resetUnsupportedStore(at: url, timestamp: timestamp)
+    }
 }
 
 private final class EngineWorkExecutor: @unchecked Sendable {
@@ -370,16 +374,38 @@ final class GlassEQAppModel {
     private var engineStartGeneration = 0
     private var pendingEngineStartOutput: AudioOutputDevice?
     private let storeWriter: ProfileStoreWriter
+    private var profilePersistenceMode: ProfilePersistenceMode = .normal
     @ObservationIgnored private let engineWorkExecutor = EngineWorkExecutor()
     @ObservationIgnored lazy var settingsCoordinator = SettingsCoordinator(model: self)
 
+    private enum ProfilePersistenceMode: Equatable, Sendable {
+        case normal
+        case unsupportedSchema(version: Int, maximumSupported: Int)
+
+        var isProtected: Bool {
+            if case .unsupportedSchema = self {
+                return true
+            }
+            return false
+        }
+    }
+
+    private struct ProfileRollback: Sendable {
+        var profileStore: ProfileStore
+        var activeProfile: EQProfile
+        var selectedProfileID: UUID
+        var draftProfile: EQProfile
+        var previewReturnProfile: EQProfile?
+    }
+
     private enum EngineWork: Sendable {
         case start(output: AudioOutputDevice, profile: EQProfile)
-        case restart(profile: EQProfile)
+        case restart(profile: EQProfile, rollback: ProfileRollback?)
     }
 
     private enum EngineWorkResult: Sendable {
         case success(AudioOutputDevice)
+        case profileChangeNotApplied(any Error, AudioOutputDevice, ProfileRollback?)
         case failure(any Error, AudioOutputDevice?)
         case cancelled
     }
@@ -416,6 +442,12 @@ final class GlassEQAppModel {
             loadResult = result
             loadedStore = result.store
         }
+        let persistenceMode: ProfilePersistenceMode
+        if case let .unsupportedSchemaVersion(version, maximumSupported) = loadResult?.status {
+            persistenceMode = .unsupportedSchema(version: version, maximumSupported: maximumSupported)
+        } else {
+            persistenceMode = .normal
+        }
         let initialProfile = loadedStore.profile(forOutputUID: nil)
         self.profileStore = loadedStore
         self.activeProfile = initialProfile
@@ -429,6 +461,7 @@ final class GlassEQAppModel {
         self.outputChangeSettlingDelayOverride = outputChangeSettlingDelayOverride
         self.wakeReconnectDelayOverride = wakeReconnectDelayOverride
         self.storeWriter = ProfileStoreWriter(url: storeURL)
+        self.profilePersistenceMode = persistenceMode
         if registerAppDelegate {
             GlassEQAppDelegate.model = self
         }
@@ -482,8 +515,37 @@ final class GlassEQAppModel {
             fallbackProfileID: profileStore.fallbackProfileID,
             statusMessage: statusMessage,
             metrics: SettingsAudioMetricsDTO(engineMetrics),
-            isPreviewing: previewReturnProfile != nil
+            isPreviewing: previewReturnProfile != nil,
+            profileStoreProtection: profileStoreProtectionSnapshot()
         )
+    }
+
+    private func profileStoreProtectionSnapshot() -> SettingsProfileStoreProtectionDTO {
+        switch profilePersistenceMode {
+        case .normal:
+            return .unprotected
+        case let .unsupportedSchema(version, maximumSupported):
+            return SettingsProfileStoreProtectionDTO(
+                isProtected: true,
+                message: localized("Profiles are read-only because this store was written by a newer GlassEQ schema \(version). This build supports schema \(maximumSupported)."),
+                resetButtonTitle: localized("Reset profiles for this version")
+            )
+        }
+    }
+
+    func ensureProfileStoreWritable() throws {
+        guard !profilePersistenceMode.isProtected else {
+            throw SettingsCommandFailure(message: unsupportedProfileStoreEditMessage())
+        }
+    }
+
+    private func unsupportedProfileStoreEditMessage() -> String {
+        switch profilePersistenceMode {
+        case .normal:
+            return ""
+        case .unsupportedSchema:
+            return localized("Profile store was written by a newer GlassEQ; reset profiles or use a newer build.")
+        }
     }
 
     func start() {
@@ -589,9 +651,11 @@ final class GlassEQAppModel {
     }
 
     func apply(profile: EQProfile) throws {
+        try ensureProfileStoreWritable()
+        let rollback = profileRollback()
         var store = profileStore
         upsertProfile(profile, in: &store)
-        try ProfilePersistence.validate(store)
+        try ProfilePersistence.validateForCommit(store)
 
         profileStore = store
         activeProfile = profile
@@ -607,10 +671,10 @@ final class GlassEQAppModel {
             if engine.updateDSP(profile: profile) {
                 statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
             } else {
-                restartEngineWithActiveProfile()
+                restartEngineWithActiveProfile(rollback: rollback)
             }
         } else {
-            restartEngineWithActiveProfile()
+            restartEngineWithActiveProfile(rollback: rollback)
         }
         notifyModelDidChange()
     }
@@ -628,6 +692,8 @@ final class GlassEQAppModel {
     }
 
     func useForCurrentOutput(profile: EQProfile) throws {
+        try ensureProfileStoreWritable()
+        let rollback = profileRollback()
         guard !currentOutputUID.isEmpty else {
             return
         }
@@ -638,7 +704,7 @@ final class GlassEQAppModel {
         store.outputMappings.append(
             OutputDeviceProfileMapping(outputDeviceUID: currentOutputUID, profileID: profile.id)
         )
-        try ProfilePersistence.validate(store)
+        try ProfilePersistence.validateForCommit(store)
 
         profileStore = store
         activeProfile = profile
@@ -654,21 +720,27 @@ final class GlassEQAppModel {
             if engine.updateDSP(profile: profile) {
                 statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
             } else {
-                restartEngineWithActiveProfile()
+                restartEngineWithActiveProfile(rollback: rollback)
             }
         } else {
-            restartEngineWithActiveProfile()
+            restartEngineWithActiveProfile(rollback: rollback)
         }
         notifyModelDidChange()
     }
 
     func setBypass(_ isBypassed: Bool) {
+        do {
+            try ensureProfileStoreWritable()
+        } catch {
+            reportProfileActionFailure(error)
+            return
+        }
         var profile = activeProfile
         profile.isBypassed = isBypassed
         var store = profileStore
         upsertProfile(profile, in: &store)
         do {
-            try ProfilePersistence.validate(store)
+            try ProfilePersistence.validateForCommit(store)
             profileStore = store
             activeProfile = profile
             if draftProfile.id == profile.id {
@@ -737,6 +809,7 @@ final class GlassEQAppModel {
     }
 
     func importProfile(format: ImportFormat, name: String, text: String) async throws -> Bool {
+        try ensureProfileStoreWritable()
         statusMessage = localized("Importing \(format.title)...")
         notifyModelDidChange()
 
@@ -781,10 +854,11 @@ final class GlassEQAppModel {
     }
 
     func setFallback(profile: EQProfile) throws {
+        try ensureProfileStoreWritable()
         var store = profileStore
         upsertProfile(profile, in: &store)
         store.fallbackProfileID = profile.id
-        try ProfilePersistence.validate(store)
+        try ProfilePersistence.validateForCommit(store)
 
         profileStore = store
         selectedProfileID = profile.id
@@ -795,6 +869,13 @@ final class GlassEQAppModel {
     }
 
     func preview(profile: EQProfile) {
+        do {
+            try ensureProfileStoreWritable()
+        } catch {
+            reportProfileActionFailure(error)
+            return
+        }
+        let rollback = profileRollback()
         guard lifecycleState != .terminating,
               lifecycleState != .sleeping,
               lifecycleState != .waking else {
@@ -809,7 +890,7 @@ final class GlassEQAppModel {
         if engine.updateDSP(profile: profile) {
             statusMessage = localized("Previewing settings for \(profile.name)")
         } else {
-            restartEngineWithActiveProfile()
+            restartEngineWithActiveProfile(rollback: rollback)
         }
         notifyModelDidChange()
     }
@@ -823,6 +904,7 @@ final class GlassEQAppModel {
         guard let profile = previewReturnProfile else {
             return
         }
+        let rollback = profileRollback()
         previewReturnProfile = nil
         activeProfile = profile
         selectedProfileID = profile.id
@@ -830,7 +912,7 @@ final class GlassEQAppModel {
         if engine.updateDSP(profile: profile) {
             statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
         } else {
-            restartEngineWithActiveProfile()
+            restartEngineWithActiveProfile(rollback: rollback)
         }
         notifyModelDidChange()
     }
@@ -843,12 +925,13 @@ final class GlassEQAppModel {
 
     @discardableResult
     private func addProfile(_ profile: EQProfile, name: String, status: String? = nil) throws -> EQProfile {
+        try ensureProfileStoreWritable()
         var profile = profile
         profile.id = UUID()
         profile.name = uniqueProfileName(name)
         var store = profileStore
         store.profiles.append(profile)
-        try ProfilePersistence.validate(store)
+        try ProfilePersistence.validateForCommit(store)
 
         profileStore = store
         selectedProfileID = profile.id
@@ -877,6 +960,7 @@ final class GlassEQAppModel {
     }
 
     func duplicateProfile(id: UUID) throws {
+        try ensureProfileStoreWritable()
         guard let source = profileStore.profiles.first(where: { $0.id == id }) else {
             throw SettingsCommandFailure(message: localized("The selected profile no longer exists. Refresh settings and try again."))
         }
@@ -886,6 +970,7 @@ final class GlassEQAppModel {
     }
 
     func deleteProfile(id: UUID) throws {
+        try ensureProfileStoreWritable()
         guard let deletedIndex = profileStore.profiles.firstIndex(where: { $0.id == id }) else {
             throw SettingsCommandFailure(message: localized("The selected profile no longer exists. Refresh settings and try again."))
         }
@@ -915,7 +1000,7 @@ final class GlassEQAppModel {
             nextDraft = draftProfile
         }
 
-        try ProfilePersistence.validate(store)
+        try ProfilePersistence.validateForCommit(store)
         profileStore = store
         selectedProfileID = nextSelectionID
         draftProfile = nextDraft
@@ -950,7 +1035,17 @@ final class GlassEQAppModel {
         notifyModelDidChange()
     }
 
-    private func restartEngineWithActiveProfile() {
+    private func profileRollback() -> ProfileRollback {
+        ProfileRollback(
+            profileStore: profileStore,
+            activeProfile: activeProfile,
+            selectedProfileID: selectedProfileID,
+            draftProfile: draftProfile,
+            previewReturnProfile: previewReturnProfile
+        )
+    }
+
+    private func restartEngineWithActiveProfile(rollback: ProfileRollback? = nil) {
         guard lifecycleState != .terminating,
               lifecycleState != .sleeping,
               lifecycleState != .waking else {
@@ -958,7 +1053,7 @@ final class GlassEQAppModel {
         }
 
         statusMessage = localized("Reconnecting audio output...")
-        scheduleEngineWork(.restart(profile: activeProfile))
+        scheduleEngineWork(.restart(profile: activeProfile, rollback: rollback))
         notifyModelDidChange()
     }
 
@@ -1164,14 +1259,21 @@ final class GlassEQAppModel {
                 } else {
                     output = requestedOutput
                 }
-            case .restart(let profile):
+            case .restart(let profile, let rollback):
                 switch engine.state {
                 case .running(let runningOutput):
                     guard !Task.isCancelled else {
                         return .cancelled
                     }
                     attemptedOutput = runningOutput
-                    try engine.update(profile: profile)
+                    do {
+                        try engine.update(profile: profile)
+                    } catch {
+                        if case .running(let activeOutput) = engine.state {
+                            return .profileChangeNotApplied(error, activeOutput, rollback)
+                        }
+                        throw error
+                    }
                     guard case .running(let activeOutput) = engine.state else {
                         return .failure(
                             EngineWorkFailure(message: localized("Default output unavailable")),
@@ -1237,6 +1339,18 @@ final class GlassEQAppModel {
             wakeReconnectAttempts = 0
             wasRunningBeforeSleep = false
             statusMessage = processingStatus(outputName: output.name, profileName: activeProfile.name)
+        case .profileChangeNotApplied(_, let output, let rollback):
+            refreshCurrentOutputMetadata(from: output)
+            if let rollback {
+                restoreProfileRollback(rollback, persist: true)
+                statusMessage = localized("Profile change was not applied; audio is still running with \(rollback.activeProfile.name).")
+            } else {
+                statusMessage = localized("Profile change was not applied; audio is still running with \(activeProfile.name).")
+            }
+            lifecycleState = .running
+            isRunning = true
+            wakeReconnectAttempts = 0
+            wasRunningBeforeSleep = false
         case .failure(let error, let attemptedOutput):
             if let attemptedOutput {
                 refreshCurrentOutputMetadata(from: attemptedOutput)
@@ -1252,6 +1366,17 @@ final class GlassEQAppModel {
             return
         }
         notifyModelDidChange()
+    }
+
+    private func restoreProfileRollback(_ rollback: ProfileRollback, persist: Bool) {
+        profileStore = rollback.profileStore
+        activeProfile = rollback.activeProfile
+        selectedProfileID = rollback.selectedProfileID
+        draftProfile = rollback.draftProfile
+        previewReturnProfile = rollback.previewReturnProfile
+        if persist {
+            saveStore()
+        }
     }
 
     private func reschedulePendingEngineStartWithActiveProfile() {
@@ -1293,6 +1418,11 @@ final class GlassEQAppModel {
     }
 
     private func saveStore() {
+        guard !profilePersistenceMode.isProtected else {
+            pendingSaveTask?.cancel()
+            pendingSaveTask = nil
+            return
+        }
         let store = profileStore
         let storeWriter = storeWriter
         let saveDebounceDelay = saveDebounceDelay
@@ -1317,6 +1447,9 @@ final class GlassEQAppModel {
         pendingSaveTask?.cancel()
         await pendingSaveTask?.value
         pendingSaveTask = nil
+        guard !profilePersistenceMode.isProtected else {
+            return true
+        }
         do {
             try await storeWriter.saveAndSynchronize(profileStore)
             return true
@@ -1325,6 +1458,25 @@ final class GlassEQAppModel {
             notifyModelDidChange()
             return false
         }
+    }
+
+    func resetUnsupportedProfileStore() async throws {
+        guard profilePersistenceMode.isProtected else {
+            throw SettingsCommandFailure(message: localized("Profile store reset is only available for stores written by a newer GlassEQ."))
+        }
+        pendingSaveTask?.cancel()
+        await pendingSaveTask?.value
+        pendingSaveTask = nil
+
+        let result = try await storeWriter.resetUnsupportedStore()
+        profilePersistenceMode = .normal
+        profileStore = result.store
+        activeProfile = result.store.profile(forOutputUID: currentOutputUID.isEmpty ? nil : currentOutputUID)
+        selectedProfileID = activeProfile.id
+        draftProfile = activeProfile
+        previewReturnProfile = nil
+        statusMessage = localized("Profiles reset for this GlassEQ version; previous store backed up to \(result.backupURL.lastPathComponent).")
+        notifyModelDidChange()
     }
 
     func requestQuit() {

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -1537,10 +1537,14 @@ final class GlassEQAppModel {
             return nil
         case .repairedReferences(let summary):
             return profileStoreRepairStatus(summary)
+        case .repairedInvalidStore:
+            return localized("Profile store was invalid; backed it up and repaired valid profiles")
         case .recoveredDefaults:
             return localized("Profile store was invalid; backed it up and restored defaults")
         case .backupFailed:
             return localized("Profile store was invalid; using defaults, but backup failed")
+        case let .unsupportedSchemaVersion(version, maximumSupported):
+            return localized("Profile store was written by a newer GlassEQ version (schema \(version)); using defaults without modifying it. This build supports schema \(maximumSupported).")
         }
     }
 
@@ -1550,6 +1554,9 @@ final class GlassEQAppModel {
         }
         if summary.repairedFallbackProfileID {
             return localized("Profile store repaired: fallback reset")
+        }
+        if summary.removedInvalidProfiles > 0 {
+            return localized("Profile store repaired: removed invalid profile")
         }
         if summary.removedOutputMappings > 0 || summary.deduplicatedOutputMappings > 0 {
             return localized("Profile store repaired: removed unavailable output mapping")

--- a/Sources/GlassEQApp/Info.plist
+++ b/Sources/GlassEQApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-    <string>0.7.0</string>
+    <string>0.8.0</string>
 	<key>CFBundleVersion</key>
-    <string>9</string>
+    <string>10</string>
 	<key>GlassEQReleaseLabel</key>
-    <string>alpha-0.7</string>
+    <string>alpha-0.8</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -9,23 +9,95 @@ private struct UncheckedSendable<Value>: @unchecked Sendable {
     var value: Value
 }
 
+struct SettingsHelperLaunch {
+    var process: Process
+    var input: Pipe
+    var output: Pipe
+    var error: Pipe
+}
+
+protocol SettingsHelperLaunching {
+    func launch(
+        executableURL: URL,
+        arguments: [String],
+        terminationHandler: @escaping @Sendable (Process) -> Void
+    ) throws -> SettingsHelperLaunch
+}
+
+struct ProcessSettingsHelperLauncher: SettingsHelperLaunching {
+    func launch(
+        executableURL: URL,
+        arguments: [String],
+        terminationHandler: @escaping @Sendable (Process) -> Void
+    ) throws -> SettingsHelperLaunch {
+        let process = Process()
+        let helperInput = Pipe()
+        let helperOutput = Pipe()
+        let helperError = Pipe()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardInput = helperInput.fileHandleForReading
+        process.standardOutput = helperOutput.fileHandleForWriting
+        process.standardError = helperError.fileHandleForWriting
+        process.terminationHandler = terminationHandler
+        try process.run()
+        return SettingsHelperLaunch(
+            process: process,
+            input: helperInput,
+            output: helperOutput,
+            error: helperError
+        )
+    }
+}
+
+protocol SettingsHelperLaunchValidating {
+    func validatedExecutableURL(for helperURL: URL) throws -> URL
+    func validateRunningProcess(processIdentifier: pid_t, expectedHelperURL: URL) throws
+}
+
+struct DefaultSettingsHelperLaunchValidator: SettingsHelperLaunchValidating {
+    func validatedExecutableURL(for helperURL: URL) throws -> URL {
+        try SettingsHelperVerifier.validatedExecutableURL(for: helperURL)
+    }
+
+    func validateRunningProcess(processIdentifier: pid_t, expectedHelperURL: URL) throws {
+        try SettingsHelperVerifier.validateRunningProcess(
+            processIdentifier: processIdentifier,
+            expectedHelperURL: expectedHelperURL
+        )
+    }
+}
+
 @MainActor
 final class SettingsCoordinator: NSObject {
     private weak var model: GlassEQAppModel?
+    private let helperLauncher: any SettingsHelperLaunching
+    private let helperValidator: any SettingsHelperLaunchValidating
+    private let settingsHelperURLProvider: () throws -> URL
     private var launchToken: String?
     private var runningApplication: NSRunningApplication?
     private var helperProcess: Process?
     private var pipeWriter: FileHandle?
     private var pipeReader: FileHandle?
     private var pipeErrorReader: FileHandle?
-    private var pipeDecoder = SettingsPipeLineDecoder()
+    private var pipeReadPump: SettingsPipeReadPump?
+    private var pipeReadDelivery: SettingsPipeOrderedMainActorDelivery?
+    private var pipeWritePump: SettingsPipeWritePump?
     private var settingsConnected = false
     private var pendingFocusRequest = false
-    private var suppressModelChangeEvents = false
+    private var suppressedModelChangeDepth = 0
     private var lastSentSnapshot: SettingsSnapshot?
 
-    init(model: GlassEQAppModel) {
+    init(
+        model: GlassEQAppModel,
+        helperLauncher: any SettingsHelperLaunching = ProcessSettingsHelperLauncher(),
+        helperValidator: any SettingsHelperLaunchValidating = DefaultSettingsHelperLaunchValidator(),
+        settingsHelperURLProvider: (() throws -> URL)? = nil
+    ) {
         self.model = model
+        self.helperLauncher = helperLauncher
+        self.helperValidator = helperValidator
+        self.settingsHelperURLProvider = settingsHelperURLProvider ?? { try Self.defaultSettingsHelperURL() }
         super.init()
     }
 
@@ -41,13 +113,13 @@ final class SettingsCoordinator: NSObject {
         }
 
         do {
-            let token = prepareSession()
+            let token = try prepareSession()
             pendingFocusRequest = true
             try launchHelper(token: token)
         } catch {
             model?.statusMessage = localized("Settings failed to open: \(error.localizedDescription)")
             model?.notifyModelDidChangeFromCoordinator()
-            cleanupSession(terminateHelper: false)
+            cleanupSession(terminateHelper: true)
         }
     }
 
@@ -56,8 +128,13 @@ final class SettingsCoordinator: NSObject {
         cleanupSession(terminateHelper: true)
     }
 
+    func shutdownAndWait() async {
+        send(.shutdown)
+        await cleanupSessionAndWait(terminateHelper: true)
+    }
+
     func modelDidChange() {
-        guard !suppressModelChangeEvents,
+        guard suppressedModelChangeDepth == 0,
               let model else {
             return
         }
@@ -79,41 +156,53 @@ final class SettingsCoordinator: NSObject {
         send(.metricsChanged(metrics))
     }
 
-    private func prepareSession() -> String {
-        let token = UUID().uuidString
+    private func prepareSession() throws -> String {
+        let token = try Self.makeSessionToken()
         launchToken = token
         settingsConnected = false
         pendingFocusRequest = false
-        suppressModelChangeEvents = false
+        suppressedModelChangeDepth = 0
         lastSentSnapshot = nil
-        pipeDecoder = SettingsPipeLineDecoder()
         return token
     }
 
-    private func launchHelper(token: String) throws {
-        let helperURL = try settingsHelperURL()
-        let executableURL = try SettingsHelperVerifier.validatedExecutableURL(for: helperURL)
-
-        let process = Process()
-        let helperInput = Pipe()
-        let helperOutput = Pipe()
-        let helperError = Pipe()
-        process.executableURL = executableURL
-        process.arguments = [
-            "--glasseq-settings-token", token,
-            "--glasseq-main-pid", String(ProcessInfo.processInfo.processIdentifier)
-        ]
-        process.standardInput = helperInput.fileHandleForReading
-        process.standardOutput = helperOutput.fileHandleForWriting
-        process.standardError = helperError.fileHandleForWriting
-        process.terminationHandler = { [weak self] _ in
-            Task { @MainActor in
-                self?.cleanupSession(terminateHelper: false)
-            }
+    private static func makeSessionToken() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw SettingsCommandFailure(message: localized("Secure random token generation failed: \(status)"))
         }
-        try process.run()
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private func launchHelper(token: String) throws {
+        let helperURL = try settingsHelperURLProvider()
+        let executableURL = try helperValidator.validatedExecutableURL(for: helperURL)
+        let launch = try helperLauncher.launch(
+            executableURL: executableURL,
+            arguments: [
+                "--glasseq-main-pid", String(ProcessInfo.processInfo.processIdentifier)
+            ],
+            terminationHandler: { [weak self] _ in
+                Task { @MainActor in
+                    self?.cleanupSession(terminateHelper: false)
+                }
+            }
+        )
+        let process = launch.process
+        let helperInput = launch.input
+        let helperOutput = launch.output
+        let helperError = launch.error
         helperProcess = process
         pipeWriter = helperInput.fileHandleForWriting
+        pipeWritePump = SettingsPipeWritePump(
+            label: "com.glasseq.settings-coordinator.pipe-write",
+            fileHandle: helperInput.fileHandleForWriting
+        )
         pipeReader = helperOutput.fileHandleForReading
         pipeErrorReader = helperError.fileHandleForReading
         installPipeReader(helperOutput.fileHandleForReading)
@@ -121,10 +210,20 @@ final class SettingsCoordinator: NSObject {
             _ = handle.availableData
         }
         runningApplication = NSRunningApplication(processIdentifier: process.processIdentifier)
-        focusSettings()
+        do {
+            try helperValidator.validateRunningProcess(
+                processIdentifier: process.processIdentifier,
+                expectedHelperURL: helperURL
+            )
+            writePipeMessage(.bootstrap(sessionToken: token))
+            focusSettings()
+        } catch {
+            cleanupSession(terminateHelper: true)
+            throw error
+        }
     }
 
-    private func settingsHelperURL() throws -> URL {
+    private static func defaultSettingsHelperURL() throws -> URL {
         let bundleURL = Bundle.main.bundleURL
         let helperURL: URL
         if bundleURL.pathExtension == "app" {
@@ -142,6 +241,19 @@ final class SettingsCoordinator: NSObject {
         }
         return helperURL
     }
+
+    #if DEBUG
+    var hasActiveSessionResourcesForTesting: Bool {
+        helperProcess != nil ||
+            pipeWriter != nil ||
+            pipeReader != nil ||
+            pipeErrorReader != nil ||
+            pipeReadPump != nil ||
+            pipeWritePump != nil ||
+            launchToken != nil ||
+            runningApplication != nil
+    }
+    #endif
 
     private func perform(_ command: SettingsCommand) async throws -> SettingsCommandResponse {
         guard let model else {
@@ -161,36 +273,34 @@ final class SettingsCoordinator: NSObject {
         guard let launchToken else {
             return
         }
-        do {
-            try writePipeMessage(.event(sessionToken: launchToken, event: event))
-        } catch {
-            failPipeSession(error)
-        }
+        writePipeMessage(.event(sessionToken: launchToken, event: event))
     }
 
     private func installPipeReader(_ readHandle: FileHandle) {
-        let decoder = pipeDecoder
-        readHandle.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
-                Task { @MainActor in
-                    self?.cleanupSession(terminateHelper: false)
-                }
-                return
-            }
-            Task {
-                do {
-                    let messages = try await decoder.append(data)
-                    await MainActor.run {
+        let delivery = SettingsPipeOrderedMainActorDelivery(
+            label: "com.glasseq.settings-coordinator.pipe-read.delivery"
+        )
+        let pump = SettingsPipeReadPump(
+            label: "com.glasseq.settings-coordinator.pipe-read",
+            onMessages: { [weak self, delivery] result in
+                delivery.enqueue {
+                    switch result {
+                    case .success(let messages):
                         self?.handlePipeMessages(messages)
-                    }
-                } catch {
-                    await MainActor.run {
+                    case .failure(let error):
                         self?.failPipeSession(error)
                     }
                 }
+            },
+            onEndOfFile: { [weak self, delivery] in
+                delivery.enqueue {
+                    self?.cleanupSession(terminateHelper: false)
+                }
             }
-        }
+        )
+        pipeReadDelivery = delivery
+        pipeReadPump = pump
+        pump.install(on: readHandle)
     }
 
     private func handlePipeMessages(_ messages: [SettingsPipeMessage]) {
@@ -210,6 +320,8 @@ final class SettingsCoordinator: NSObject {
         try message.validateSessionToken(launchToken)
 
         switch message {
+        case .bootstrap:
+            break
         case let .request(_, id, .connect, _):
             handleConnect(requestID: id)
         case let .request(_, id, .command, command):
@@ -246,15 +358,15 @@ final class SettingsCoordinator: NSObject {
                 return
             }
             do {
-                suppressModelChangeEvents = true
+                suppressedModelChangeDepth += 1
                 let response = try await perform(command)
-                suppressModelChangeEvents = false
+                suppressedModelChangeDepth = max(suppressedModelChangeDepth - 1, 0)
                 if let snapshot = response.snapshot {
                     lastSentSnapshot = snapshot
                 }
                 sendResponse(response, requestID: requestID)
             } catch {
-                suppressModelChangeEvents = false
+                suppressedModelChangeDepth = max(suppressedModelChangeDepth - 1, 0)
                 sendError(error.localizedDescription, requestID: requestID)
             }
         }
@@ -344,32 +456,37 @@ final class SettingsCoordinator: NSObject {
         guard let launchToken else {
             return
         }
-        do {
-            try writePipeMessage(.response(sessionToken: launchToken, id: requestID, response: response, error: nil))
-        } catch {
-            failPipeSession(error)
-        }
+        writePipeMessage(.response(sessionToken: launchToken, id: requestID, response: response, error: nil))
     }
 
     private func sendError(_ message: String, requestID: String) {
         guard let launchToken else {
             return
         }
-        do {
-            try writePipeMessage(.response(sessionToken: launchToken, id: requestID, response: nil, error: message))
-        } catch {
-            failPipeSession(error)
-        }
+        writePipeMessage(.response(sessionToken: launchToken, id: requestID, response: nil, error: message))
     }
 
-    private func writePipeMessage(_ message: SettingsPipeMessage) throws {
-        guard let pipeWriter else {
-            throw SettingsCommandFailure(message: localized("Settings IPC pipe is not connected."))
+    private func writePipeMessage(_ message: SettingsPipeMessage) {
+        guard let pipeWritePump else {
+            failPipeSession(SettingsCommandFailure(message: localized("Settings IPC pipe is not connected.")))
+            return
         }
-        do {
-            try pipeWriter.write(contentsOf: SettingsPipeCodec.encodeLine(message))
-        } catch {
-            throw SettingsCommandFailure(message: localized("Settings IPC write failed: \(error.localizedDescription)"))
+        let expectedToken = message.sessionToken
+        let expectedPump = pipeWritePump
+        pipeWritePump.enqueue(message) { [weak self] result in
+            guard case .failure(let error) = result else {
+                return
+            }
+            Task { @MainActor in
+                guard let self,
+                      self.launchToken == expectedToken,
+                      self.pipeWritePump === expectedPump else {
+                    return
+                }
+                self.failPipeSession(SettingsCommandFailure(
+                    message: localized("Settings IPC write failed: \(error.localizedDescription)")
+                ))
+            }
         }
     }
 
@@ -383,34 +500,56 @@ final class SettingsCoordinator: NSObject {
         model?.notifyModelDidChangeFromCoordinator()
     }
 
-    private func cleanupSession(terminateHelper: Bool) {
+    @discardableResult
+    private func cleanupSession(terminateHelper: Bool) -> Task<Void, Never>? {
         model?.stopMetricsPolling()
         let processToTerminate = terminateHelper ? helperProcess : nil
-        pipeReader?.readabilityHandler = nil
+        let writePumpToDrain = pipeWritePump
+        let writerToCloseDirectly = writePumpToDrain == nil ? pipeWriter : nil
+        pipeReadDelivery?.invalidate()
+        pipeReadDelivery = nil
+        pipeReadPump?.invalidate(handle: pipeReader)
+        pipeReadPump = nil
+        pipeWritePump = nil
         pipeErrorReader?.readabilityHandler = nil
         try? pipeReader?.close()
         try? pipeErrorReader?.close()
-        try? pipeWriter?.close()
+        if let writerToCloseDirectly {
+            try? writerToCloseDirectly.close()
+        }
         pipeReader = nil
         pipeErrorReader = nil
         pipeWriter = nil
         launchToken = nil
         pendingFocusRequest = false
-        suppressModelChangeEvents = false
+        suppressedModelChangeDepth = 0
         lastSentSnapshot = nil
         runningApplication = nil
         helperProcess = nil
         settingsConnected = false
-        if let processToTerminate {
-            SettingsHelperTerminator.terminate(process: processToTerminate)
+        if writePumpToDrain != nil || processToTerminate != nil {
+            return Task {
+                if let writePumpToDrain {
+                    _ = await writePumpToDrain.drainAndClose()
+                }
+                if let processToTerminate {
+                    await SettingsHelperTerminator.terminate(process: processToTerminate).value
+                }
+            }
         }
+        return nil
+    }
+
+    private func cleanupSessionAndWait(terminateHelper: Bool) async {
+        let terminationTask = cleanupSession(terminateHelper: terminateHelper)
+        await terminationTask?.value
     }
 }
 
 private enum SettingsHelperTerminator {
-    static func terminate(process: Process) {
+    static func terminate(process: Process) -> Task<Void, Never> {
         let terminator = ProcessTerminator(process: process)
-        Task.detached(priority: .utility) {
+        return Task.detached(priority: .utility) {
             await terminator.run()
         }
     }
@@ -453,6 +592,7 @@ struct SettingsCodeSignatureInfo: Equatable, Sendable {
 
 protocol SettingsCodeSigningValidating {
     func signatureInfo(for url: URL) throws -> SettingsCodeSignatureInfo
+    func signatureInfo(forProcessIdentifier processIdentifier: pid_t) throws -> SettingsCodeSignatureInfo
 }
 
 enum SettingsHelperVerifier {
@@ -486,16 +626,11 @@ enum SettingsHelperVerifier {
             throw SettingsCommandFailure(message: localized("GlassEQSettings.app has an unexpected bundle identifier."))
         }
 
-        let executableName = helperBundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String ?? "GlassEQSettings"
-        let executableURL = standardizedHelperURL
-            .appendingPathComponent("Contents", isDirectory: true)
-            .appendingPathComponent("MacOS", isDirectory: true)
-            .appendingPathComponent(executableName, isDirectory: false)
-            .standardizedFileURL
-        guard executableURL.path.hasPrefix(standardizedHelperURL.path + "/"),
-              fileManager.fileExists(atPath: executableURL.path) else {
-            throw SettingsCommandFailure(message: localized("GlassEQSettings executable was not found in the app bundle."))
-        }
+        let executableURL = try helperExecutableURL(
+            for: standardizedHelperURL,
+            helperBundle: helperBundle,
+            fileManager: fileManager
+        )
 
         let helperSignature = try codeSigningValidator.signatureInfo(for: standardizedHelperURL)
         if let signingIdentifier = helperSignature.signingIdentifier,
@@ -520,6 +655,97 @@ enum SettingsHelperVerifier {
 
         return executableURL
     }
+
+    static func validateRunningProcess(
+        processIdentifier: pid_t,
+        expectedHelperURL: URL,
+        hostBundleURL: URL = Bundle.main.bundleURL,
+        fileManager: FileManager = .default,
+        runningBundleURL: (pid_t) -> URL? = { NSRunningApplication(processIdentifier: $0)?.bundleURL },
+        processExecutableURL: (pid_t) -> URL? = runningExecutableURL(processIdentifier:),
+        codeSigningValidator: any SettingsCodeSigningValidating = SecuritySettingsCodeSigningValidator()
+    ) throws {
+        let standardizedExpectedHelperURL = expectedHelperURL.standardizedFileURL
+        let standardizedHostURL = hostBundleURL.standardizedFileURL
+        let resolvedBundleURL = runningBundleURL(processIdentifier)?.standardizedFileURL
+        let bundleURL = resolvedBundleURL ?? standardizedExpectedHelperURL
+
+        if let resolvedBundleURL,
+           resolvedBundleURL.path != standardizedExpectedHelperURL.path {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings.app resolved to an unexpected location after launch."))
+        }
+
+        guard fileManager.fileExists(atPath: bundleURL.path),
+              let helperBundle = Bundle(url: bundleURL),
+              helperBundle.bundleIdentifier == helperBundleIdentifier else {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings.app could not be resolved after launch."))
+        }
+        let expectedExecutableURL = try helperExecutableURL(
+            for: bundleURL,
+            helperBundle: helperBundle,
+            fileManager: fileManager
+        )
+        guard let actualExecutableURL = processExecutableURL(processIdentifier)?.standardizedFileURL,
+              actualExecutableURL.path == expectedExecutableURL.path else {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings executable could not be resolved after launch."))
+        }
+
+        let helperSignature = try codeSigningValidator.signatureInfo(for: bundleURL)
+        if let signingIdentifier = helperSignature.signingIdentifier,
+           signingIdentifier != helperBundleIdentifier {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings.app has an unexpected code-signing identifier."))
+        }
+
+        let processSignature = try? codeSigningValidator.signatureInfo(forProcessIdentifier: processIdentifier)
+        if let processSignature {
+            if let signingIdentifier = processSignature.signingIdentifier,
+               signingIdentifier != helperBundleIdentifier {
+                throw SettingsCommandFailure(message: localized("GlassEQSettings.app has an unexpected code-signing identifier."))
+            }
+        }
+
+        let hostSignature = try? codeSigningValidator.signatureInfo(for: standardizedHostURL)
+        guard let hostTeamIdentifier = hostSignature?.teamIdentifier,
+              !hostTeamIdentifier.isEmpty else {
+            return
+        }
+        guard helperSignature.teamIdentifier == hostTeamIdentifier else {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings.app was not signed by the same team as GlassEQ."))
+        }
+        if let processSignature,
+           processSignature.teamIdentifier != hostTeamIdentifier {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings.app was not signed by the same team as GlassEQ."))
+        }
+    }
+
+    private static func helperExecutableURL(
+        for standardizedHelperURL: URL,
+        helperBundle: Bundle,
+        fileManager: FileManager
+    ) throws -> URL {
+        let executableName = helperBundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String ?? "GlassEQSettings"
+        let executableURL = standardizedHelperURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent(executableName, isDirectory: false)
+            .standardizedFileURL
+        guard executableURL.path.hasPrefix(standardizedHelperURL.path + "/"),
+              fileManager.fileExists(atPath: executableURL.path) else {
+            throw SettingsCommandFailure(message: localized("GlassEQSettings executable was not found in the app bundle."))
+        }
+        return executableURL
+    }
+
+    private static func runningExecutableURL(processIdentifier: pid_t) -> URL? {
+        var pathBuffer = [CChar](repeating: 0, count: 4_096)
+        let length = proc_pidpath(processIdentifier, &pathBuffer, UInt32(pathBuffer.count))
+        guard length > 0 else {
+            return nil
+        }
+        let bytes = pathBuffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        let path = String(decoding: bytes, as: UTF8.self)
+        return URL(fileURLWithPath: path).standardizedFileURL
+    }
 }
 
 struct SecuritySettingsCodeSigningValidator: SettingsCodeSigningValidating {
@@ -536,17 +762,42 @@ struct SecuritySettingsCodeSigningValidator: SettingsCodeSigningValidating {
             throw SettingsCommandFailure(message: localized("Code signing validation failed for \(url.lastPathComponent): \(status)"))
         }
 
+        return try signatureInfo(from: staticCode, label: url.lastPathComponent)
+    }
+
+    func signatureInfo(forProcessIdentifier processIdentifier: pid_t) throws -> SettingsCodeSignatureInfo {
+        var code: SecCode?
+        let attributes = [kSecGuestAttributePid as String: processIdentifier] as CFDictionary
+        var status = SecCodeCopyGuestWithAttributes(nil, attributes, SecCSFlags(), &code)
+        guard status == errSecSuccess, let code else {
+            throw SettingsCommandFailure(message: localized("Code signing validation failed for process \(processIdentifier): \(status)"))
+        }
+
+        status = SecCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSStrictValidate), nil)
+        guard status == errSecSuccess else {
+            throw SettingsCommandFailure(message: localized("Code signing validation failed for process \(processIdentifier): \(status)"))
+        }
+
+        var staticCode: SecStaticCode?
+        status = SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode)
+        guard status == errSecSuccess, let staticCode else {
+            throw SettingsCommandFailure(message: localized("Code signing information was unavailable for process \(processIdentifier): \(status)"))
+        }
+
+        return try signatureInfo(from: staticCode, label: "process \(processIdentifier)")
+    }
+
+    private func signatureInfo(from code: SecStaticCode, label: String) throws -> SettingsCodeSignatureInfo {
         var info: CFDictionary?
-        status = SecCodeCopySigningInformation(
-            staticCode,
+        let status = SecCodeCopySigningInformation(
+            code,
             SecCSFlags(rawValue: kSecCSSigningInformation),
             &info
         )
         guard status == errSecSuccess,
               let dictionary = info as? [String: Any] else {
-            throw SettingsCommandFailure(message: localized("Code signing information was unavailable for \(url.lastPathComponent)."))
+            throw SettingsCommandFailure(message: localized("Code signing information was unavailable for \(label)."))
         }
-
         return SettingsCodeSignatureInfo(
             signingIdentifier: dictionary[kSecCodeInfoIdentifier as String] as? String,
             teamIdentifier: dictionary[kSecCodeInfoTeamIdentifier as String] as? String

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -442,6 +442,10 @@ final class SettingsCoordinator: NSObject {
             }
             didPatch = true
         }
+        if previous.profileStoreProtection != snapshot.profileStoreProtection {
+            patch.profileStoreProtection = snapshot.profileStoreProtection
+            didPatch = true
+        }
 
         guard didPatch else {
             lastSentSnapshot = snapshot
@@ -875,16 +879,21 @@ extension GlassEQAppModel {
         case .stopMetricsPolling:
             stopMetricsPolling()
             return SettingsCommandResponse()
+
+        case .resetUnsupportedProfileStore:
+            try await resetUnsupportedProfileStore()
+            return SettingsCommandResponse(snapshot: settingsSnapshot())
         }
     }
 
     private func validateIncomingProfile(_ profile: EQProfile) throws {
+        try ensureProfileStoreWritable()
         var store = profileStore
         if let index = store.profiles.firstIndex(where: { $0.id == profile.id }) {
             store.profiles[index] = profile
         } else {
             store.profiles.append(profile)
         }
-        try ProfilePersistence.validate(store)
+        try ProfilePersistence.validateForCommit(store)
     }
 }

--- a/Sources/GlassEQAudio/DefaultOutputDeviceObserver.swift
+++ b/Sources/GlassEQAudio/DefaultOutputDeviceObserver.swift
@@ -1,9 +1,37 @@
 import CoreAudio
 import Foundation
 
+final class DispatchRefreshCoalescer: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let delay: DispatchTimeInterval
+    private var generation = 0
+
+    init(queue: DispatchQueue, delay: DispatchTimeInterval) {
+        self.queue = queue
+        self.delay = delay
+    }
+
+    func cancelPending() {
+        generation += 1
+    }
+
+    func schedule(_ operation: @escaping @Sendable () -> Void) {
+        generation += 1
+        let scheduledGeneration = generation
+        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self,
+                  self.generation == scheduledGeneration else {
+                return
+            }
+            operation()
+        }
+    }
+}
+
 public final class DefaultOutputDeviceObserver: @unchecked Sendable {
-    private let queue = DispatchQueue(label: "com.glasseq.default-output-observer")
+    private let queue: DispatchQueue
     private let queueSpecific = DispatchSpecificKey<Void>()
+    private let refreshCoalescer: DispatchRefreshCoalescer
     private var systemListeners: [ListenerToken] = []
     private var outputListeners: [ListenerToken] = []
     private var observedOutputID = AudioObjectID(kAudioObjectUnknown)
@@ -17,6 +45,9 @@ public final class DefaultOutputDeviceObserver: @unchecked Sendable {
     }
 
     public init(onChange: @escaping @Sendable (Result<AudioOutputDevice, Error>) -> Void) {
+        let queue = DispatchQueue(label: "com.glasseq.default-output-observer")
+        self.queue = queue
+        self.refreshCoalescer = DispatchRefreshCoalescer(queue: queue, delay: .milliseconds(50))
         self.onChange = onChange
         queue.setSpecific(key: queueSpecific, value: ())
     }
@@ -31,9 +62,35 @@ public final class DefaultOutputDeviceObserver: @unchecked Sendable {
         }
     }
 
+    public func startAsync(sendInitialValue: Bool = true) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                do {
+                    try self.startOnQueue(sendInitialValue: sendInitialValue)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
     public func stop() {
         performOnQueue {
             stopOnQueue()
+        }
+    }
+
+    public func stopAsync() async {
+        await withCheckedContinuation { continuation in
+            queue.async { [weak self] in
+                self?.stopOnQueue()
+                continuation.resume()
+            }
         }
     }
 
@@ -65,6 +122,7 @@ public final class DefaultOutputDeviceObserver: @unchecked Sendable {
         removeOutputListeners()
         removeListeners(&systemListeners)
         isStarted = false
+        refreshCoalescer.cancelPending()
     }
 
     private func refreshObservedOutput(sendChange: Bool) {
@@ -83,6 +141,19 @@ public final class DefaultOutputDeviceObserver: @unchecked Sendable {
             if sendChange {
                 onChange(.failure(error))
             }
+        }
+    }
+
+    private func scheduleRefreshObservedOutput(sendChange: Bool) {
+        guard isStarted else {
+            return
+        }
+        refreshCoalescer.schedule { [weak self] in
+            guard let self,
+                  self.isStarted else {
+                return
+            }
+            self.refreshObservedOutput(sendChange: sendChange)
         }
     }
 
@@ -127,7 +198,7 @@ public final class DefaultOutputDeviceObserver: @unchecked Sendable {
             mElement: kAudioObjectPropertyElementMain
         )
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            self?.refreshObservedOutput(sendChange: true)
+            self?.scheduleRefreshObservedOutput(sendChange: true)
         }
         try checkOSStatus(
             AudioObjectAddPropertyListenerBlock(
@@ -170,17 +241,17 @@ public final class DefaultOutputDeviceObserver: @unchecked Sendable {
             guard selector != kAudioDevicePropertyDeviceIsAlive else {
                 do {
                     guard try CoreAudioDeviceQuery.isDeviceAlive(id: outputID) else {
-                        self.refreshObservedOutput(sendChange: true)
+                        self.scheduleRefreshObservedOutput(sendChange: true)
                         return
                     }
                 } catch {
-                    self.refreshObservedOutput(sendChange: true)
+                    self.scheduleRefreshObservedOutput(sendChange: true)
                     return
                 }
-                self.refreshObservedOutput(sendChange: true)
+                self.scheduleRefreshObservedOutput(sendChange: true)
                 return
             }
-            self.refreshObservedOutput(sendChange: true)
+            self.scheduleRefreshObservedOutput(sendChange: true)
         }
         try checkOSStatus(
             AudioObjectAddPropertyListenerBlock(

--- a/Sources/GlassEQAudio/PersistedAudioDeviceRestorationStore.swift
+++ b/Sources/GlassEQAudio/PersistedAudioDeviceRestorationStore.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+struct PersistedAudioDeviceRestorationRecord: Codable, Equatable, Sendable {
+    var uid: String
+    var originalSampleRate: Double?
+    var originalBufferFrameSize: UInt32?
+
+    var isEmpty: Bool {
+        originalSampleRate == nil && originalBufferFrameSize == nil
+    }
+}
+
+enum PersistedAudioDeviceRestorationStore {
+    static func defaultURL(
+        applicationSupportDirectory: URL = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+    ) -> URL {
+        applicationSupportDirectory
+            .appendingPathComponent("GlassEQ", isDirectory: true)
+            .appendingPathComponent("DeviceRestorations.json", isDirectory: false)
+    }
+
+    static func load(from url: URL) -> [String: PersistedAudioDeviceRestorationRecord] {
+        guard let data = try? Data(contentsOf: url),
+              let records = try? JSONDecoder().decode([PersistedAudioDeviceRestorationRecord].self, from: data) else {
+            return [:]
+        }
+        var recordsByUID: [String: PersistedAudioDeviceRestorationRecord] = [:]
+        for record in records {
+            guard !record.uid.isEmpty else {
+                continue
+            }
+            if var existing = recordsByUID[record.uid] {
+                if existing.originalSampleRate == nil {
+                    existing.originalSampleRate = record.originalSampleRate
+                }
+                if existing.originalBufferFrameSize == nil {
+                    existing.originalBufferFrameSize = record.originalBufferFrameSize
+                }
+                recordsByUID[record.uid] = existing
+            } else {
+                recordsByUID[record.uid] = record
+            }
+        }
+        return recordsByUID
+    }
+
+    static func save(_ recordsByUID: [String: PersistedAudioDeviceRestorationRecord], to url: URL) throws {
+        let records = recordsByUID.values
+            .filter { !$0.isEmpty }
+            .sorted { $0.uid < $1.uid }
+        guard !records.isEmpty else {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(records)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+    }
+
+    static func recordSampleRate(uid: String, originalSampleRate: Double, at url: URL) throws {
+        var records = load(from: url)
+        var record = records[uid] ?? PersistedAudioDeviceRestorationRecord(uid: uid)
+        if record.originalSampleRate == nil {
+            record.originalSampleRate = originalSampleRate
+        }
+        records[uid] = record
+        try save(records, to: url)
+    }
+
+    static func recordBufferFrameSize(uid: String, originalFrameSize: UInt32, at url: URL) throws {
+        var records = load(from: url)
+        var record = records[uid] ?? PersistedAudioDeviceRestorationRecord(uid: uid)
+        if record.originalBufferFrameSize == nil {
+            record.originalBufferFrameSize = originalFrameSize
+        }
+        records[uid] = record
+        try save(records, to: url)
+    }
+
+    static func clearSampleRate(uid: String, at url: URL) throws {
+        try update(uid: uid, at: url) { $0.originalSampleRate = nil }
+    }
+
+    static func clearBufferFrameSize(uid: String, at url: URL) throws {
+        try update(uid: uid, at: url) { $0.originalBufferFrameSize = nil }
+    }
+
+    private static func update(
+        uid: String,
+        at url: URL,
+        mutation: (inout PersistedAudioDeviceRestorationRecord) -> Void
+    ) throws {
+        var records = load(from: url)
+        guard var record = records[uid] else {
+            return
+        }
+        mutation(&record)
+        records[uid] = record.isEmpty ? nil : record
+        try save(records, to: url)
+    }
+}

--- a/Sources/GlassEQAudio/RealtimeAudioRingBuffer.swift
+++ b/Sources/GlassEQAudio/RealtimeAudioRingBuffer.swift
@@ -66,10 +66,12 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
         let framesToWrite = min(requestedFrames, capacityFrames)
         let firstSourceFrame = requestedFrames - framesToWrite
 
-        let read = readFrame.load(ordering: .acquiring)
         let write = writeFrame.load(ordering: .relaxed)
         let retainedFrames = max(0, capacityFrames - framesToWrite)
-        let droppedFrames = max(0, occupancyFrames(read: read, write: write) - retainedFrames)
+        var droppedFrames = max(
+            0,
+            occupancyFrames(read: readFrame.load(ordering: .acquiring), write: write) - retainedFrames
+        )
         if droppedFrames > 0 {
             guard enterOverwriteGate() else {
                 return RingBufferWriteResult(
@@ -81,7 +83,11 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
             defer {
                 leaveOverwriteGate()
             }
-            readFrame.store(advance(read, by: droppedFrames), ordering: .releasing)
+            let gatedRead = readFrame.load(ordering: .acquiring)
+            droppedFrames = max(0, occupancyFrames(read: gatedRead, write: write) - retainedFrames)
+            if droppedFrames > 0 {
+                readFrame.store(advance(gatedRead, by: droppedFrames), ordering: .releasing)
+            }
         }
 
         if sourceChannelCount == channelCount,
@@ -124,10 +130,6 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
             return 0
         }
 
-        let read = readFrame.load(ordering: .relaxed)
-        let write = writeFrame.load(ordering: .acquiring)
-        let framesToRead = min(requestedFrames, occupancyFrames(read: read, write: write))
-
         guard enterOverwriteGate() else {
             zeroFill(samples, startFrame: 0, frameCount: requestedFrames, channelCount: destinationChannelCount)
             return 0
@@ -135,6 +137,10 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
         defer {
             leaveOverwriteGate()
         }
+
+        let read = readFrame.load(ordering: .acquiring)
+        let write = writeFrame.load(ordering: .acquiring)
+        let framesToRead = min(requestedFrames, occupancyFrames(read: read, write: write))
 
         if destinationChannelCount == channelCount,
            let source = storage.baseAddress,
@@ -225,6 +231,8 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
         overwriteGate.store(false, ordering: .releasing)
     }
 
+    // Write path copies linear source into wrapped storage; read path below copies
+    // wrapped storage back out. The pointer overloads keep those directions distinct.
     private func copyMatchingChannels(
         source: UnsafePointer<Float>,
         destination: UnsafeMutablePointer<Float>,

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -64,6 +64,14 @@ struct TopologyRebuildMuteGuardUnavailable: Error, LocalizedError {
     }
 }
 
+private struct AudioEngineInternalError: Error, LocalizedError {
+    var message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
 public final class SystemTapAudioEngine: @unchecked Sendable {
     private static let preferredBufferFrameSize: UInt32 = 256
     private static let preferredBluetoothBufferFrameSize: UInt32 = 512
@@ -91,7 +99,19 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         var activeProfile: EQProfile?
         var bufferFrameSizeRestorations: [String: BufferFrameSizeRestoration] = [:]
         var sampleRateRestorations: [String: SampleRateRestoration] = [:]
+        var outputRebuildGeneration = 0
     }
+
+    private struct OutputRebuildPreparation {
+        var generation: Int
+        var output: AudioOutputDevice
+        var profile: EQProfile
+        var runtime: AudioRuntime
+        var tapSampleRate: Double
+        var originalBufferFrameSize: UInt32
+    }
+
+    private struct StaleOutputRebuild: Error {}
 
     struct BufferFrameSizeRestoration: Equatable, Sendable {
         var uid: String
@@ -775,6 +795,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
     }
 
     private let control = Mutex(ControlState())
+    private let restorationStoreURL: URL
 
     public var state: AudioEngineState {
         control.withLock { $0.state }
@@ -784,31 +805,57 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         control.withLock { $0.status }
     }
 
-    public init() {}
+    public init(restorationStoreURL: URL? = nil) {
+        let restorationStoreURL = restorationStoreURL ?? PersistedAudioDeviceRestorationStore.defaultURL()
+        self.restorationStoreURL = restorationStoreURL
+        Self.restorePersistedDeviceSettings(at: restorationStoreURL)
+    }
 
     deinit {
         stop()
     }
 
     public func start(output: AudioOutputDevice, profile: EQProfile) throws {
-        try control.withLock { state in
-            let previousState = state.state
-            let previousStatus = state.status
-            state.status = .starting
-            do {
+        var previousState = AudioEngineState.stopped
+        var previousStatus = AudioEngineStatus.stopped
+        var activePreparation: OutputRebuildPreparation?
+
+        do {
+            let preparation = try control.withLock { state in
+                previousState = state.state
+                previousStatus = state.status
+                state.status = .starting
                 // The capture half (one global muted tap @ the tap rate) is created once and
                 // kept alive across output switches, so dry audio never leaks to a newly
                 // selected device. Only the output half is (re)built for `output`.
                 try ensureCaptureHalfLocked(&state, profile: profile)
-                try rebuildOutputHalfLocked(&state, output: output, profile: profile)
+                return try prepareOutputRebuildLocked(&state, output: output, profile: profile)
+            }
+            activePreparation = preparation
+            let matchedOutput = try forceSampleRate(preparation.tapSampleRate, on: preparation.output)
+            try control.withLock { state in
+                try finishOutputRebuildLocked(&state, preparation: preparation, matchedOutput: matchedOutput)
                 let active = state.activeOutput ?? output
                 state.state = .running(output: active)
                 state.status = .running(output: active)
-            } catch {
+            }
+        } catch is StaleOutputRebuild {
+            return
+        } catch {
+            var shouldRethrow = true
+            control.withLock { state in
+                if let activePreparation,
+                   state.outputRebuildGeneration != activePreparation.generation {
+                    shouldRethrow = false
+                    return
+                }
                 if error is TopologyRebuildMuteGuardUnavailable {
                     state.state = previousState
                     state.status = previousStatus
-                    throw error
+                    if case .running = previousState {
+                        shouldRethrow = false
+                    }
+                    return
                 }
                 let failure = audioEngineFailure(from: error)
                 // Any failure tears the tap down too, so the system is never left muted
@@ -820,6 +867,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 } else {
                     state.status = .failed(failure)
                 }
+            }
+            if shouldRethrow {
                 throw error
             }
         }
@@ -837,6 +886,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         }
         let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
         try start(output: freshOutput, profile: profile)
+        let didApplyProfile = control.withLock { state in
+            state.activeProfile == profile
+        }
+        guard didApplyProfile else {
+            throw TopologyRebuildMuteGuardUnavailable(
+                underlyingError: AudioEngineInternalError(message: "Profile rebuild was not applied.")
+            )
+        }
     }
 
     @discardableResult
@@ -1023,26 +1080,55 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
     // MARK: - Output half (swappable; device forced to the tap rate so no resampling)
 
-    private func rebuildOutputHalfLocked(
+    private func prepareOutputRebuildLocked(
         _ state: inout ControlState,
         output: AudioOutputDevice,
         profile: EQProfile
-    ) throws {
+    ) throws -> OutputRebuildPreparation {
         guard let runtime = state.runtime else {
             throw CoreAudioError(operation: "rebuildOutputHalf(missing runtime)", status: kAudioHardwareNotRunningError)
         }
-
-        stopOutputHalfLocked(&state)
-
         // Match the device to the tap's fixed rate so the EQ'd stream needs no resampling.
         let originalBufferFrameSize = output.bufferFrameSize
-        let matchedOutput = try forceSampleRate(state.tapSampleRate, on: output, state: &state)
+        _ = try Self.supportedRuntimeChannelCount(for: output)
+        stopOutputHalfLocked(&state)
+        if state.tapSampleRate > 0, abs(output.nominalSampleRate - state.tapSampleRate) >= 1 {
+            try recordSampleRateRestorationIfNeeded(for: output, state: &state)
+        }
+        return OutputRebuildPreparation(
+            generation: state.outputRebuildGeneration,
+            output: output,
+            profile: profile,
+            runtime: runtime,
+            tapSampleRate: state.tapSampleRate,
+            originalBufferFrameSize: originalBufferFrameSize
+        )
+    }
+
+    private func finishOutputRebuildLocked(
+        _ state: inout ControlState,
+        preparation: OutputRebuildPreparation,
+        matchedOutput: AudioOutputDevice
+    ) throws {
+        guard state.outputRebuildGeneration == preparation.generation,
+              state.runtime === preparation.runtime,
+              state.captureRunning else {
+            throw StaleOutputRebuild()
+        }
+        let runtime = preparation.runtime
+        let output = preparation.output
         _ = try Self.supportedRuntimeChannelCount(for: matchedOutput)
         if state.bufferFrameSizeRestorations[output.uid] == nil {
-            state.bufferFrameSizeRestorations[output.uid] = BufferFrameSizeRestoration(
+            let restoration = BufferFrameSizeRestoration(
                 uid: output.uid,
-                originalFrameSize: originalBufferFrameSize
+                originalFrameSize: preparation.originalBufferFrameSize
             )
+            try PersistedAudioDeviceRestorationStore.recordBufferFrameSize(
+                uid: restoration.uid,
+                originalFrameSize: restoration.originalFrameSize,
+                at: restorationStoreURL
+            )
+            state.bufferFrameSizeRestorations[output.uid] = restoration
         }
 
         // Keep our replay muted while we claim and reconfigure the device. The ORDER matters:
@@ -1075,10 +1161,11 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         runtime.reprimePlayback()
 
         state.activeOutput = tunedOutput
-        state.activeProfile = profile
+        state.activeProfile = preparation.profile
     }
 
     private func stopOutputHalfLocked(_ state: inout ControlState) {
+        state.outputRebuildGeneration += 1
         if let output = state.activeOutput, let outputIOProcID = state.outputIOProcID {
             _ = AudioDeviceStop(output.id, outputIOProcID)
             _ = AudioDeviceDestroyIOProcID(output.id, outputIOProcID)
@@ -1090,17 +1177,10 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
     private func forceSampleRate(
         _ sampleRate: Double,
-        on output: AudioOutputDevice,
-        state: inout ControlState
+        on output: AudioOutputDevice
     ) throws -> AudioOutputDevice {
         guard sampleRate > 0, abs(output.nominalSampleRate - sampleRate) >= 1 else {
             return output
-        }
-        if state.sampleRateRestorations[output.uid] == nil {
-            state.sampleRateRestorations[output.uid] = SampleRateRestoration(
-                uid: output.uid,
-                originalSampleRate: output.nominalSampleRate
-            )
         }
         try CoreAudioDeviceQuery.setNominalSampleRate(sampleRate, objectID: output.id)
         for _ in 0..<3 {
@@ -1117,10 +1197,49 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         )
     }
 
+    private func recordSampleRateRestorationIfNeeded(
+        for output: AudioOutputDevice,
+        state: inout ControlState
+    ) throws {
+        guard state.sampleRateRestorations[output.uid] == nil else {
+            return
+        }
+        let restoration = SampleRateRestoration(
+            uid: output.uid,
+            originalSampleRate: output.nominalSampleRate
+        )
+        try PersistedAudioDeviceRestorationStore.recordSampleRate(
+            uid: restoration.uid,
+            originalSampleRate: restoration.originalSampleRate,
+            at: restorationStoreURL
+        )
+        state.sampleRateRestorations[output.uid] = restoration
+    }
+
+    static func setSampleRateAfterRecordingRestoration(
+        _ sampleRate: Double,
+        on output: AudioOutputDevice,
+        needsRestoration: Bool,
+        recordRestoration: (SampleRateRestoration) throws -> Void,
+        installRestoration: (SampleRateRestoration) -> Void,
+        setSampleRate: (Double, AudioObjectID) throws -> Void
+    ) throws {
+        if needsRestoration {
+            let restoration = SampleRateRestoration(
+                uid: output.uid,
+                originalSampleRate: output.nominalSampleRate
+            )
+            try recordRestoration(restoration)
+            installRestoration(restoration)
+        }
+        try setSampleRate(sampleRate, output.id)
+    }
+
     private func restoreDeviceSettingsIfNeeded(_ state: inout ControlState) {
         var restoredSampleRateUIDs: [String] = []
         for (uid, restoration) in state.sampleRateRestorations {
             if Self.restoreSampleRateRestoration(restoration) {
+                try? PersistedAudioDeviceRestorationStore.clearSampleRate(uid: uid, at: restorationStoreURL)
                 restoredSampleRateUIDs.append(uid)
             }
         }
@@ -1131,6 +1250,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         var restoredBufferFrameSizeUIDs: [String] = []
         for (uid, restoration) in state.bufferFrameSizeRestorations {
             if Self.restoreBufferFrameSizeRestoration(restoration) {
+                try? PersistedAudioDeviceRestorationStore.clearBufferFrameSize(uid: uid, at: restorationStoreURL)
                 restoredBufferFrameSizeUIDs.append(uid)
             }
         }
@@ -1183,6 +1303,41 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         }
     }
 
+    static func restorePersistedDeviceSettings(
+        at url: URL,
+        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
+        setSampleRate: (Double, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:),
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
+    ) {
+        var records = PersistedAudioDeviceRestorationStore.load(from: url)
+        guard !records.isEmpty else {
+            return
+        }
+
+        for (uid, record) in records {
+            var updated = record
+            if let originalSampleRate = record.originalSampleRate,
+               restoreSampleRateRestoration(
+                   SampleRateRestoration(uid: uid, originalSampleRate: originalSampleRate),
+                   outputForUID: outputForUID,
+                   setSampleRate: setSampleRate
+               ) {
+                updated.originalSampleRate = nil
+            }
+            if let originalBufferFrameSize = record.originalBufferFrameSize,
+               restoreBufferFrameSizeRestoration(
+                   BufferFrameSizeRestoration(uid: uid, originalFrameSize: originalBufferFrameSize),
+                   outputForUID: outputForUID,
+                   setBufferFrameSize: setBufferFrameSize
+               ) {
+                updated.originalBufferFrameSize = nil
+            }
+            records[uid] = updated.isEmpty ? nil : updated
+        }
+
+        try? PersistedAudioDeviceRestorationStore.save(records, to: url)
+    }
+
     private static func dspProfile(from profile: EQProfile) -> EQProfile {
         var profile = profile
         profile.isBypassed = false
@@ -1222,6 +1377,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             throw AudioDeviceAvailabilityError.unsupportedOutputChannelCount(output.id, output.outputChannelCount)
         }
         return output.outputChannelCount
+    }
+
+    static func performAfterRuntimeChannelValidation<T>(
+        for output: AudioOutputDevice,
+        _ operation: () throws -> T
+    ) throws -> T {
+        _ = try supportedRuntimeChannelCount(for: output)
+        return try operation()
     }
 
     static func monoDownmix(
@@ -1451,6 +1614,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             AudioObjectGetPropertyData(tapID, &address, 0, nil, &size, &asbd),
             operation: "AudioObjectGetPropertyData(tap format)"
         )
+        try CoreAudioDeviceQuery.validatePropertySize(
+            actual: size,
+            expected: UInt32(MemoryLayout<AudioStreamBasicDescription>.size),
+            operation: "AudioObjectGetPropertyData(tap format)",
+            objectID: tapID
+        )
         return asbd
     }
 
@@ -1564,6 +1733,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             operation: "AudioObjectGetPropertyData(translate pid)"
         )
 
+        guard processID != kAudioObjectUnknown else {
+            throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
+                AudioObjectID(kAudioObjectSystemObject),
+                "current audio process object is unknown"
+            )
+        }
         return processID
     }
 }

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -755,58 +755,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             sourceChannelCount: Int,
             to buffers: UnsafeMutableAudioBufferListPointer
         ) {
-            let sourceChannelCount = max(sourceChannelCount, 1)
-            if buffers.count == 1,
-               let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
-               Int(buffers[0].mNumberChannels) == 1,
-               sourceChannelCount > 1,
-               frameCount > 0,
-               sourceFrameOffset >= 0,
-               destinationFrameOffset >= 0 {
-                let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
-                for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSamples {
-                    data[destinationFrameOffset + frameIndex] = SystemTapAudioEngine.monoDownmix(
-                        samples,
-                        frame: sourceFrameOffset + frameIndex,
-                        sourceChannelCount: sourceChannelCount
-                    )
-                }
-                return
-            }
-
-            if buffers.count == 1,
-               let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
-               Int(buffers[0].mNumberChannels) == sourceChannelCount,
-               frameCount > 0,
-               sourceFrameOffset >= 0,
-               destinationFrameOffset >= 0 {
-                let copySamples = frameCount * sourceChannelCount
-                let sourceSampleStart = sourceFrameOffset * sourceChannelCount
-                let destinationSampleStart = destinationFrameOffset * sourceChannelCount
-                let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
-                if sourceSampleStart + copySamples <= samples.count,
-                   destinationSampleStart + copySamples <= destinationSamples,
-                   let source = samples.baseAddress {
-                    data.advanced(by: destinationSampleStart)
-                        .update(from: source.advanced(by: sourceSampleStart), count: copySamples)
-                    return
-                }
-            }
-
-            for bufferIndex in buffers.indices {
-                guard let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self) else {
-                    continue
-                }
-                let sourceChannel = min(bufferIndex, sourceChannelCount - 1)
-                let destinationSampleCount = Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride
-                for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSampleCount {
-                    let sourceIndex = (sourceFrameOffset + frameIndex) * sourceChannelCount + sourceChannel
-                    guard sourceIndex < samples.count else {
-                        continue
-                    }
-                    data[destinationFrameOffset + frameIndex] = samples[sourceIndex]
-                }
-            }
+            SystemTapAudioEngine.copyInterleavedSamples(
+                samples,
+                sourceFrameOffset: sourceFrameOffset,
+                destinationFrameOffset: destinationFrameOffset,
+                frameCount: frameCount,
+                sourceChannelCount: sourceChannelCount,
+                to: buffers
+            )
         }
 
         private func enter(_ gate: borrowing Atomic<Bool>) -> Bool {
@@ -1291,6 +1247,93 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             return samples[sampleBase]
         }
         return (samples[sampleBase] + samples[sampleBase + 1]) * 0.5
+    }
+
+    static func copyInterleavedSamples(
+        _ samples: UnsafeBufferPointer<Float>,
+        sourceFrameOffset: Int,
+        destinationFrameOffset: Int,
+        frameCount: Int,
+        sourceChannelCount: Int,
+        to buffers: UnsafeMutableAudioBufferListPointer
+    ) {
+        let sourceChannelCount = max(sourceChannelCount, 1)
+        if buffers.count == 1,
+           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+           Int(buffers[0].mNumberChannels) == 1,
+           sourceChannelCount > 1,
+           frameCount > 0,
+           sourceFrameOffset >= 0,
+           destinationFrameOffset >= 0 {
+            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+            for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSamples {
+                data[destinationFrameOffset + frameIndex] = monoDownmix(
+                    samples,
+                    frame: sourceFrameOffset + frameIndex,
+                    sourceChannelCount: sourceChannelCount
+                )
+            }
+            return
+        }
+
+        if buffers.count == 1,
+           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+           sourceChannelCount == 1,
+           Int(buffers[0].mNumberChannels) > 1,
+           frameCount > 0,
+           sourceFrameOffset >= 0,
+           destinationFrameOffset >= 0 {
+            let destinationChannelCount = Int(buffers[0].mNumberChannels)
+            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+            for frameIndex in 0..<frameCount {
+                let sourceIndex = sourceFrameOffset + frameIndex
+                guard sourceIndex < samples.count else {
+                    continue
+                }
+                let destinationBase = (destinationFrameOffset + frameIndex) * destinationChannelCount
+                guard destinationBase < destinationSamples else {
+                    continue
+                }
+                for channel in 0..<destinationChannelCount where destinationBase + channel < destinationSamples {
+                    data[destinationBase + channel] = samples[sourceIndex]
+                }
+            }
+            return
+        }
+
+        if buffers.count == 1,
+           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+           Int(buffers[0].mNumberChannels) == sourceChannelCount,
+           frameCount > 0,
+           sourceFrameOffset >= 0,
+           destinationFrameOffset >= 0 {
+            let copySamples = frameCount * sourceChannelCount
+            let sourceSampleStart = sourceFrameOffset * sourceChannelCount
+            let destinationSampleStart = destinationFrameOffset * sourceChannelCount
+            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+            if sourceSampleStart + copySamples <= samples.count,
+               destinationSampleStart + copySamples <= destinationSamples,
+               let source = samples.baseAddress {
+                data.advanced(by: destinationSampleStart)
+                    .update(from: source.advanced(by: sourceSampleStart), count: copySamples)
+                return
+            }
+        }
+
+        for bufferIndex in buffers.indices {
+            guard let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self) else {
+                continue
+            }
+            let sourceChannel = min(bufferIndex, sourceChannelCount - 1)
+            let destinationSampleCount = Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride
+            for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSampleCount {
+                let sourceIndex = (sourceFrameOffset + frameIndex) * sourceChannelCount + sourceChannel
+                guard sourceIndex < samples.count else {
+                    continue
+                }
+                data[destinationFrameOffset + frameIndex] = samples[sourceIndex]
+            }
+        }
     }
 
     static func performTopologyRebuild<T>(

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -146,6 +146,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
     private final class PreparedDSPConfigBox: @unchecked Sendable {
         let config: EQRenderConfiguration
+        var retiredStorage: EQProcessorRetiredRenderStorage?
         var nextRetiredPointer: UInt = 0
 
         init(config: EQRenderConfiguration) {
@@ -527,7 +528,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
             let pointer = UnsafeRawPointer(bitPattern: rawPointer)!
             let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
-            processor.applyPreparedConfiguration(box.config)
+            box.retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(box.config)
             pushRetiredDSPConfigBox(rawPointer)
         }
 

--- a/Sources/GlassEQCore/Biquad.swift
+++ b/Sources/GlassEQCore/Biquad.swift
@@ -269,6 +269,14 @@ public enum EQProfileAnalysis {
             ]
         }
         let peak = peaks.max() ?? 0
-        return peak > -0.5 ? -peak - 0.5 : profile.preampDB
+        if peak > -0.5 {
+            return -peak - 0.5
+        }
+        switch profile.channelMode {
+        case .linked:
+            return profile.preampDB
+        case .stereo:
+            return min(profile.leftPreampDB, profile.rightPreampDB)
+        }
     }
 }

--- a/Sources/GlassEQCore/EQModels.swift
+++ b/Sources/GlassEQCore/EQModels.swift
@@ -180,42 +180,81 @@ public struct ProfileStoreRepairSummary: Equatable, Sendable {
     public var repairedFallbackProfileID: Bool
     public var removedOutputMappings: Int
     public var deduplicatedOutputMappings: Int
+    public var removedInvalidProfiles: Int
 
     public var didRepair: Bool {
         restoredDefaultProfiles ||
             repairedFallbackProfileID ||
             removedOutputMappings > 0 ||
-            deduplicatedOutputMappings > 0
+            deduplicatedOutputMappings > 0 ||
+            removedInvalidProfiles > 0
     }
 
     public init(
         restoredDefaultProfiles: Bool = false,
         repairedFallbackProfileID: Bool = false,
         removedOutputMappings: Int = 0,
-        deduplicatedOutputMappings: Int = 0
+        deduplicatedOutputMappings: Int = 0,
+        removedInvalidProfiles: Int = 0
     ) {
         self.restoredDefaultProfiles = restoredDefaultProfiles
         self.repairedFallbackProfileID = repairedFallbackProfileID
         self.removedOutputMappings = removedOutputMappings
         self.deduplicatedOutputMappings = deduplicatedOutputMappings
+        self.removedInvalidProfiles = removedInvalidProfiles
+    }
+
+    mutating func merge(_ other: ProfileStoreRepairSummary) {
+        restoredDefaultProfiles = restoredDefaultProfiles || other.restoredDefaultProfiles
+        repairedFallbackProfileID = repairedFallbackProfileID || other.repairedFallbackProfileID
+        removedOutputMappings += other.removedOutputMappings
+        deduplicatedOutputMappings += other.deduplicatedOutputMappings
+        removedInvalidProfiles += other.removedInvalidProfiles
     }
 }
 
 public struct ProfileStore: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
     public static let defaultProfiles: [EQProfile] = [.flatGraphic31, .flatGraphic10, .flatParametric]
 
+    public var schemaVersion: Int
     public var profiles: [EQProfile]
     public var outputMappings: [OutputDeviceProfileMapping]
     public var fallbackProfileID: UUID
 
     public init(
+        schemaVersion: Int = ProfileStore.currentSchemaVersion,
         profiles: [EQProfile] = ProfileStore.defaultProfiles,
         outputMappings: [OutputDeviceProfileMapping] = [],
         fallbackProfileID: UUID? = nil
     ) {
+        self.schemaVersion = schemaVersion
         self.profiles = profiles
         self.outputMappings = outputMappings
         self.fallbackProfileID = fallbackProfileID ?? profiles.first?.id ?? EQProfile.flatParametric.id
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case profiles
+        case outputMappings
+        case fallbackProfileID
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? Self.currentSchemaVersion
+        profiles = try container.decode([EQProfile].self, forKey: .profiles)
+        outputMappings = try container.decode([OutputDeviceProfileMapping].self, forKey: .outputMappings)
+        fallbackProfileID = try container.decode(UUID.self, forKey: .fallbackProfileID)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(profiles, forKey: .profiles)
+        try container.encode(outputMappings, forKey: .outputMappings)
+        try container.encode(fallbackProfileID, forKey: .fallbackProfileID)
     }
 
     @discardableResult

--- a/Sources/GlassEQCore/EQProcessor.swift
+++ b/Sources/GlassEQCore/EQProcessor.swift
@@ -100,6 +100,28 @@ public struct EQRenderConfiguration: Equatable, Sendable {
     }
 }
 
+public struct EQProcessorRetiredRenderStorage: Sendable {
+    private let configuration: EQConfiguration
+    private let coefficients: [RenderBiquadCoefficients]
+    private let channelStarts: [Int]
+    private let channelFilterCounts: [Int]
+    private let preampLinearGains: [Float]
+
+    fileprivate init(
+        configuration: EQConfiguration,
+        coefficients: [RenderBiquadCoefficients],
+        channelStarts: [Int],
+        channelFilterCounts: [Int],
+        preampLinearGains: [Float]
+    ) {
+        self.configuration = configuration
+        self.coefficients = coefficients
+        self.channelStarts = channelStarts
+        self.channelFilterCounts = channelFilterCounts
+        self.preampLinearGains = preampLinearGains
+    }
+}
+
 public struct EQProcessor: Sendable {
     public private(set) var configuration: EQConfiguration
     private var coefficients: [RenderBiquadCoefficients]
@@ -143,6 +165,43 @@ public struct EQProcessor: Sendable {
         } else {
             resetChangedFilterStates(previousCoefficients: previousCoefficients, nextCoefficients: renderConfiguration.coefficients)
         }
+    }
+
+    public mutating func applyRealtimeCompatiblePreparedConfiguration(
+        _ renderConfiguration: EQRenderConfiguration
+    ) -> EQProcessorRetiredRenderStorage? {
+        guard renderConfiguration.configuration.sampleRate == configuration.sampleRate,
+              renderConfiguration.configuration.channelCount == configuration.channelCount,
+              renderConfiguration.channelFilterCounts == channelFilterCounts,
+              renderConfiguration.coefficients.count == coefficients.count,
+              renderConfiguration.channelStarts.count == channelStarts.count,
+              renderConfiguration.preampLinearGains.count == preampLinearGains.count,
+              states.count == coefficients.count else {
+            return nil
+        }
+
+        let retiredStorage = EQProcessorRetiredRenderStorage(
+            configuration: configuration,
+            coefficients: coefficients,
+            channelStarts: channelStarts,
+            channelFilterCounts: channelFilterCounts,
+            preampLinearGains: preampLinearGains
+        )
+        let previousCoefficients = coefficients
+
+        configuration = renderConfiguration.configuration
+        coefficients = renderConfiguration.coefficients
+        channelStarts = renderConfiguration.channelStarts
+        channelFilterCounts = renderConfiguration.channelFilterCounts
+        preampLinearGains = renderConfiguration.preampLinearGains
+
+        for index in coefficients.indices {
+            if previousCoefficients[index] != coefficients[index] {
+                states[index] = BiquadState()
+            }
+        }
+
+        return retiredStorage
     }
 
     private mutating func resetChangedFilterStates(

--- a/Sources/GlassEQCore/ProfileImporters.swift
+++ b/Sources/GlassEQCore/ProfileImporters.swift
@@ -35,7 +35,7 @@ public struct ProfileImportLimits: Equatable, Sendable {
         maxLineCount: 10_000,
         maxFiltersPerChannel: 128,
         maxTotalFilters: 256,
-        frequencyRange: 1...96_000,
+        frequencyRange: 1...24_000,
         gainRange: -120...120,
         preampRange: -120...120,
         qRange: 0.01...100
@@ -194,26 +194,29 @@ public enum EQProfileTextImporter {
         }
 
         let hasStereoFilters = !leftFilters.isEmpty || !rightFilters.isEmpty
-        guard !filters.isEmpty || hasStereoFilters || preampDB != 0 || leftPreampDB != nil || rightPreampDB != nil else {
+        let hasStereoData = hasStereoFilters || leftPreampDB != nil || rightPreampDB != nil
+        guard !filters.isEmpty || hasStereoData || preampDB != 0 else {
             throw ProfileImportError.noSupportedFilters
         }
 
-        if hasStereoFilters {
+        if hasStereoData {
             let fallbackFilters = filters
+            let resolvedLeftFilters = leftFilters.isEmpty ? fallbackFilters : leftFilters
+            let resolvedRightFilters = rightFilters.isEmpty ? fallbackFilters : rightFilters
             return EQProfile(
                 name: profileName,
-                mode: .parametric,
+                mode: inferredMode(leftFilters: resolvedLeftFilters, rightFilters: resolvedRightFilters),
                 channelMode: .stereo,
                 preampDB: preampDB,
                 filters: fallbackFilters,
                 leftPreampDB: leftPreampDB ?? preampDB,
-                leftFilters: leftFilters.isEmpty ? fallbackFilters : leftFilters,
+                leftFilters: resolvedLeftFilters,
                 rightPreampDB: rightPreampDB ?? preampDB,
-                rightFilters: rightFilters.isEmpty ? fallbackFilters : rightFilters
+                rightFilters: resolvedRightFilters
             )
         }
 
-        return EQProfile(name: profileName, mode: .parametric, preampDB: preampDB, filters: filters)
+        return EQProfile(name: profileName, mode: inferredMode(filters: filters), preampDB: preampDB, filters: filters)
     }
 
     public static func importREW(
@@ -233,7 +236,7 @@ public enum EQProfileTextImporter {
             }
 
             let tokens = line
-                .replacingOccurrences(of: ",", with: " ")
+                .replacingOccurrences(of: ":", with: " ")
                 .split(whereSeparator: \.isWhitespace)
                 .map(String.init)
 
@@ -246,9 +249,7 @@ public enum EQProfileTextImporter {
                 continue
             }
 
-            let kind = tokens.contains { $0.caseInsensitiveCompare("PK") == .orderedSame || $0.caseInsensitiveCompare("Modal") == .orderedSame }
-                ? FilterKind.peak
-                : FilterKind.peak
+            let kind = parseREWKind(in: tokens)
 
             guard let frequency = try requiredValue(afterAnyOf: ["Fc", "F"], in: tokens, field: "frequency", line: lineNumber) ??
                 firstNumberFollowingFrequencyUnit(in: tokens, line: lineNumber) else {
@@ -259,9 +260,7 @@ public enum EQProfileTextImporter {
             let gain = try value(beforeUnit: "dB", in: tokens, field: "gain", line: lineNumber) ?? 0
             try validate(gain, in: limits.gainRange, field: "gain", line: lineNumber)
 
-            let q = try optionalValue(after: "Q", in: tokens, field: "Q", line: lineNumber) ??
-                lastNumericToken(in: tokens, field: "Q", line: lineNumber) ??
-                0.707_106_781_18
+            let q = try optionalValue(after: "Q", in: tokens, field: "Q", line: lineNumber) ?? 0.707_106_781_18
             try validate(q, in: limits.qRange, field: "Q", line: lineNumber)
 
             try append(
@@ -278,7 +277,7 @@ public enum EQProfileTextImporter {
             throw ProfileImportError.noSupportedFilters
         }
 
-        return EQProfile(name: profileName, mode: .parametric, filters: filters)
+        return EQProfile(name: profileName, mode: inferredMode(filters: filters), filters: filters)
     }
 
     private static func parseEqualizerAPOKind(_ token: String) -> FilterKind? {
@@ -296,6 +295,18 @@ public enum EQProfileTextImporter {
         default:
             return nil
         }
+    }
+
+    private static func parseREWKind(in tokens: [String]) -> FilterKind {
+        if tokens.contains(where: { $0.caseInsensitiveCompare("Modal") == .orderedSame }) {
+            return .peak
+        }
+        for token in tokens {
+            if let kind = parseEqualizerAPOKind(token) {
+                return kind
+            }
+        }
+        return .peak
     }
 
     private static func optionalValue(after label: String, in tokens: [String], field: String, line: Int) throws -> Double? {
@@ -353,22 +364,7 @@ public enum EQProfileTextImporter {
 
     private static func firstNumericToken<S: Sequence>(in tokens: S, field: String, line: Int) throws -> Double? where S.Element == String {
         for token in tokens {
-            if let value = Double(token) {
-                guard value.isFinite else {
-                    throw ProfileImportError.invalidNumber(line: line, field: field, value: token)
-                }
-                return value
-            }
-        }
-        return nil
-    }
-
-    private static func lastNumericToken(in tokens: [String], field: String, line: Int) throws -> Double? {
-        for token in tokens.reversed() {
-            if let value = Double(token) {
-                guard value.isFinite else {
-                    throw ProfileImportError.invalidNumber(line: line, field: field, value: token)
-                }
+            if let value = try parseNumberIfPresent(token, field: field, line: line) {
                 return value
             }
         }
@@ -376,10 +372,38 @@ public enum EQProfileTextImporter {
     }
 
     private static func parseNumber(_ token: String, field: String, line: Int) throws -> Double {
-        guard let value = Double(token), value.isFinite else {
+        guard let value = try parseNumberIfPresent(token, field: field, line: line) else {
             throw ProfileImportError.invalidNumber(line: line, field: field, value: token)
         }
         return value
+    }
+
+    private static func parseNumberIfPresent(_ token: String, field: String, line: Int) throws -> Double? {
+        guard !isHexFloatToken(token) else {
+            throw ProfileImportError.invalidNumber(line: line, field: field, value: token)
+        }
+        guard let value = Double(normalizedDecimalToken(token)) else {
+            return nil
+        }
+        guard value.isFinite else {
+            throw ProfileImportError.invalidNumber(line: line, field: field, value: token)
+        }
+        return value
+    }
+
+    private static func normalizedDecimalToken(_ token: String) -> String {
+        guard token.contains(","),
+              !token.contains("."),
+              token.filter({ $0 == "," }).count == 1 else {
+            return token
+        }
+        return token.replacingOccurrences(of: ",", with: ".")
+    }
+
+    private static func isHexFloatToken(_ token: String) -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let unsigned = trimmed.hasPrefix("+") || trimmed.hasPrefix("-") ? String(trimmed.dropFirst()) : trimmed
+        return unsigned.lowercased().hasPrefix("0x")
     }
 
     private static func validate(_ value: Double, in range: ClosedRange<Double>, field: String, line: Int) throws {
@@ -446,6 +470,43 @@ public enum EQProfileTextImporter {
         rightFilters: [EQFilter]
     ) -> Int {
         filters.count + leftFilters.count + rightFilters.count
+    }
+
+    private static func inferredMode(filters: [EQFilter]) -> EQMode {
+        graphicMode(for: filters) ?? .parametric
+    }
+
+    private static func inferredMode(leftFilters: [EQFilter], rightFilters: [EQFilter]) -> EQMode {
+        guard let leftMode = graphicMode(for: leftFilters),
+              let rightMode = graphicMode(for: rightFilters),
+              leftMode == rightMode else {
+            return .parametric
+        }
+        return leftMode
+    }
+
+    private static func graphicMode(for filters: [EQFilter]) -> EQMode? {
+        let activeFilters = filters.filter(\.isEnabled)
+        guard activeFilters.allSatisfy({ $0.kind == .peak }) else {
+            return nil
+        }
+        if matchesGraphicBands(activeFilters, bands: GraphicEQBands.tenBand) {
+            return .graphic10
+        }
+        if matchesGraphicBands(activeFilters, bands: GraphicEQBands.thirtyOneBand) {
+            return .graphic31
+        }
+        return nil
+    }
+
+    private static func matchesGraphicBands(_ filters: [EQFilter], bands: [Double]) -> Bool {
+        guard filters.count == bands.count else {
+            return false
+        }
+        return zip(filters, bands).allSatisfy { filter, band in
+            abs(filter.frequency - band) <= 0.1 &&
+                abs(filter.q - GraphicEQBands.graphicQ) <= 0.01
+        }
     }
 }
 

--- a/Sources/GlassEQCore/ProfilePersistence.swift
+++ b/Sources/GlassEQCore/ProfilePersistence.swift
@@ -14,20 +14,26 @@ public enum ProfileStoreLoadStatus: Equatable, Sendable {
     case loaded
     case missingStore
     case repairedReferences(ProfileStoreRepairSummary)
+    case repairedInvalidStore(backupURL: URL, ProfileStoreRepairSummary)
     case recoveredDefaults(backupURL: URL)
     case backupFailed
+    case unsupportedSchemaVersion(version: Int, maximumSupported: Int)
 }
 
 public enum ProfileStoreValidationError: Error, Equatable, Sendable, LocalizedError {
     case inputTooLarge(byteCount: Int, maximum: Int)
+    case unsupportedSchemaVersion(version: Int, maximumSupported: Int)
     case invalidProfileCount(count: Int, allowed: ClosedRange<Int>)
     case invalidOutputMappingCount(count: Int, allowed: ClosedRange<Int>)
+    case duplicateProfileID(profileID: UUID)
     case missingFallbackProfile(profileID: UUID)
     case emptyProfileName(profileID: UUID)
     case profileNameTooLong(profileID: UUID, byteCount: Int, maximum: Int)
     case outputUIDTooLong(mappingIndex: Int, byteCount: Int, maximum: Int)
     case valueOutOfRange(profileID: UUID, field: String, value: Double, range: ClosedRange<Double>)
+    case tooManyFilters(profileID: UUID, channel: String, count: Int, maximum: Int)
     case tooManyActiveFilters(profileID: UUID, channel: String, count: Int, maximum: Int)
+    case tooManyStereoFilters(profileID: UUID, count: Int, maximum: Int)
     case tooManyStereoActiveFilters(profileID: UUID, count: Int, maximum: Int)
     case invalidGraphicBandCount(profileID: UUID, channel: String, count: Int, expected: Int)
 
@@ -35,10 +41,14 @@ public enum ProfileStoreValidationError: Error, Equatable, Sendable, LocalizedEr
         switch self {
         case let .inputTooLarge(byteCount, maximum):
             return "Profile store is \(byteCount) bytes, which exceeds the \(maximum)-byte limit."
+        case let .unsupportedSchemaVersion(version, maximumSupported):
+            return "Profile store schema \(version) is newer than this build supports (\(maximumSupported))."
         case let .invalidProfileCount(count, allowed):
             return "Profile store has \(count) profiles; expected \(allowed.lowerBound)...\(allowed.upperBound)."
         case let .invalidOutputMappingCount(count, allowed):
             return "Profile store has \(count) output mappings; expected \(allowed.lowerBound)...\(allowed.upperBound)."
+        case let .duplicateProfileID(profileID):
+            return "Profile store contains duplicate profile ID \(profileID)."
         case let .missingFallbackProfile(profileID):
             return "Profile store fallback profile \(profileID) does not exist."
         case .emptyProfileName:
@@ -49,8 +59,12 @@ public enum ProfileStoreValidationError: Error, Equatable, Sendable, LocalizedEr
             return "Output mapping \(mappingIndex) has \(byteCount) UTF-8 bytes, which exceeds the \(maximum)-byte limit."
         case let .valueOutOfRange(_, field, value, range):
             return "Profile store contains \(field) \(format(value)), outside the allowed range \(format(range.lowerBound))...\(format(range.upperBound))."
+        case let .tooManyFilters(_, channel, count, maximum):
+            return "Profile store contains \(count) \(channel) filters, which exceeds the \(maximum)-filter channel limit."
         case let .tooManyActiveFilters(_, channel, count, maximum):
             return "Profile store contains \(count) active \(channel) filters, which exceeds the \(maximum)-filter channel limit."
+        case let .tooManyStereoFilters(_, count, maximum):
+            return "Profile store contains \(count) stereo filters, which exceeds the \(maximum)-filter stereo limit."
         case let .tooManyStereoActiveFilters(_, count, maximum):
             return "Profile store contains \(count) active stereo filters, which exceeds the \(maximum)-filter stereo limit."
         case let .invalidGraphicBandCount(_, channel, count, expected):
@@ -69,20 +83,28 @@ public enum ProfilePersistence {
     public static let outputMappingCountRange = 0...256
     public static let maxProfileNameUTF8Bytes = 120
     public static let maxOutputUIDUTF8Bytes = 512
-    public static let maxActiveFiltersPerChannel = 128
-    public static let maxStereoActiveFilters = 256
-    public static let frequencyRange: ClosedRange<Double> = 1...96_000
+    public static let maxFiltersPerChannel = 128
+    public static let maxStereoFilters = 256
+    public static let maxActiveFiltersPerChannel = maxFiltersPerChannel
+    public static let maxStereoActiveFilters = maxStereoFilters
+    public static let frequencyRange: ClosedRange<Double> = 1...24_000
     public static let gainRange: ClosedRange<Double> = -120...120
     public static let preampRange: ClosedRange<Double> = -120...120
     public static let qRange: ClosedRange<Double> = 0.01...100
 
-    public static let encoder: JSONEncoder = {
+    public static var encoder: JSONEncoder {
+        makeEncoder()
+    }
+
+    public static var decoder: JSONDecoder {
+        JSONDecoder()
+    }
+
+    private static func makeEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return encoder
-    }()
-
-    public static let decoder = JSONDecoder()
+    }
 
     public static func encode(_ store: ProfileStore) throws -> Data {
         try encoder.encode(store)
@@ -100,6 +122,19 @@ public enum ProfilePersistence {
     }
 
     public static func validate(_ store: ProfileStore) throws {
+        guard store.schemaVersion <= ProfileStore.currentSchemaVersion else {
+            throw ProfileStoreValidationError.unsupportedSchemaVersion(
+                version: store.schemaVersion,
+                maximumSupported: ProfileStore.currentSchemaVersion
+            )
+        }
+        guard store.schemaVersion > 0 else {
+            throw ProfileStoreValidationError.unsupportedSchemaVersion(
+                version: store.schemaVersion,
+                maximumSupported: ProfileStore.currentSchemaVersion
+            )
+        }
+
         guard profileCountRange.contains(store.profiles.count) else {
             throw ProfileStoreValidationError.invalidProfileCount(
                 count: store.profiles.count,
@@ -114,7 +149,12 @@ public enum ProfilePersistence {
             )
         }
 
-        let profileIDs = Set(store.profiles.map(\.id))
+        var profileIDs = Set<UUID>()
+        for profile in store.profiles {
+            guard profileIDs.insert(profile.id).inserted else {
+                throw ProfileStoreValidationError.duplicateProfileID(profileID: profile.id)
+            }
+        }
         guard profileIDs.contains(store.fallbackProfileID) else {
             throw ProfileStoreValidationError.missingFallbackProfile(profileID: store.fallbackProfileID)
         }
@@ -135,10 +175,12 @@ public enum ProfilePersistence {
         }
     }
 
+    public static func validateForCommit(_ store: ProfileStore) throws {
+        _ = try encodeForCommit(store)
+    }
+
     public static func save(_ store: ProfileStore, to url: URL) throws {
-        try validate(store)
-        let data = try encode(store)
-        try validateStoreSize(byteCount: data.count)
+        let data = try encodeForCommit(store)
         let directory = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try data.write(to: url, options: .atomic)
@@ -153,12 +195,36 @@ public enum ProfilePersistence {
             return recoverInvalidStore(at: url, timestamp: timestamp)
         }
 
+        let data: Data
         do {
-            let data = try Data(contentsOf: url)
+            data = try Data(contentsOf: url)
             try validateStoreSize(byteCount: data.count)
+        } catch {
+            return recoverInvalidStore(at: url, timestamp: timestamp)
+        }
+
+        do {
             var store = try decodeRaw(data)
+            if store.schemaVersion > ProfileStore.currentSchemaVersion {
+                return ProfileStoreLoadResult(
+                    store: defaultStore(),
+                    status: .unsupportedSchemaVersion(
+                        version: store.schemaVersion,
+                        maximumSupported: ProfileStore.currentSchemaVersion
+                    )
+                )
+            }
             let repairSummary = store.repairReferences()
-            try validate(store)
+            do {
+                try validate(store)
+            } catch {
+                return repairInvalidDecodedStore(
+                    store,
+                    initialRepairSummary: repairSummary,
+                    at: url,
+                    timestamp: timestamp
+                )
+            }
 
             if repairSummary.didRepair {
                 try save(store, to: url)
@@ -167,6 +233,25 @@ public enum ProfilePersistence {
 
             return ProfileStoreLoadResult(store: store, status: .loaded)
         } catch {
+            if let repairable = try? decodeRepairableStore(data) {
+                if repairable.store.schemaVersion > ProfileStore.currentSchemaVersion {
+                    return ProfileStoreLoadResult(
+                        store: defaultStore(),
+                        status: .unsupportedSchemaVersion(
+                            version: repairable.store.schemaVersion,
+                            maximumSupported: ProfileStore.currentSchemaVersion
+                        )
+                    )
+                }
+                return repairInvalidDecodedStore(
+                    repairable.store,
+                    initialRepairSummary: ProfileStoreRepairSummary(
+                        removedInvalidProfiles: repairable.removedInvalidProfiles
+                    ),
+                    at: url,
+                    timestamp: timestamp
+                )
+            }
             return recoverInvalidStore(at: url, timestamp: timestamp)
         }
     }
@@ -181,6 +266,23 @@ public enum ProfilePersistence {
         }
 
         return storeURL.deletingLastPathComponent().appendingPathComponent(backupName)
+    }
+
+    public static func resetUnsupportedStore(
+        at url: URL,
+        timestamp: Date = Date()
+    ) throws -> (store: ProfileStore, backupURL: URL) {
+        let store = defaultStore()
+        let backupURL = uniqueInvalidStoreBackupURL(for: url, timestamp: timestamp)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.moveItem(at: url, to: backupURL)
+        do {
+            try save(store, to: url)
+        } catch {
+            try? FileManager.default.moveItem(at: backupURL, to: url)
+            throw error
+        }
+        return (store, backupURL)
     }
 
     public static func defaultStoreURL(
@@ -198,6 +300,72 @@ public enum ProfilePersistence {
         guard byteCount <= maxStoreBytes else {
             throw ProfileStoreValidationError.inputTooLarge(byteCount: byteCount, maximum: maxStoreBytes)
         }
+    }
+
+    private static func encodeForCommit(_ store: ProfileStore) throws -> Data {
+        try validate(store)
+        let data = try encode(store)
+        try validateStoreSize(byteCount: data.count)
+        return data
+    }
+
+    private struct ProfileStoreEnvelope: Decodable {
+        var schemaVersion: Int
+        var outputMappings: [OutputDeviceProfileMapping]
+        var fallbackProfileID: UUID
+
+        private enum CodingKeys: String, CodingKey {
+            case schemaVersion
+            case outputMappings
+            case fallbackProfileID
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+                ?? ProfileStore.currentSchemaVersion
+            outputMappings = try container.decode([OutputDeviceProfileMapping].self, forKey: .outputMappings)
+            fallbackProfileID = try container.decode(UUID.self, forKey: .fallbackProfileID)
+        }
+    }
+
+    private static func decodeRepairableStore(_ data: Data) throws -> (
+        store: ProfileStore,
+        removedInvalidProfiles: Int
+    ) {
+        let envelope = try decoder.decode(ProfileStoreEnvelope.self, from: data)
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let object = json as? [String: Any],
+              let rawProfiles = object["profiles"] as? [Any] else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Profile store profiles array is missing.")
+            )
+        }
+
+        var profiles: [EQProfile] = []
+        var removedInvalidProfiles = 0
+        for rawProfile in rawProfiles {
+            guard JSONSerialization.isValidJSONObject(rawProfile) else {
+                removedInvalidProfiles += 1
+                continue
+            }
+            do {
+                let profileData = try JSONSerialization.data(withJSONObject: rawProfile)
+                profiles.append(try decoder.decode(EQProfile.self, from: profileData))
+            } catch {
+                removedInvalidProfiles += 1
+            }
+        }
+
+        return (
+            ProfileStore(
+                schemaVersion: envelope.schemaVersion,
+                profiles: profiles,
+                outputMappings: envelope.outputMappings,
+                fallbackProfileID: envelope.fallbackProfileID
+            ),
+            removedInvalidProfiles
+        )
     }
 
     private static func validate(_ profile: EQProfile) throws {
@@ -219,12 +387,12 @@ public enum ProfilePersistence {
         try validate(profile.leftPreampDB, in: preampRange, field: "left preamp", profileID: profile.id)
         try validate(profile.rightPreampDB, in: preampRange, field: "right preamp", profileID: profile.id)
 
-        let linkedActiveCount = try validateFilters(profile.filters, channel: "linked", profileID: profile.id)
-        let leftActiveCount = try validateFilters(profile.leftFilters, channel: "left", profileID: profile.id)
-        let rightActiveCount = try validateFilters(profile.rightFilters, channel: "right", profileID: profile.id)
+        let linkedCounts = try validateFilters(profile.filters, channel: "linked", profileID: profile.id)
+        let leftCounts = try validateFilters(profile.leftFilters, channel: "left", profileID: profile.id)
+        let rightCounts = try validateFilters(profile.rightFilters, channel: "right", profileID: profile.id)
 
         if profile.channelMode == .stereo {
-            let stereoActiveCount = leftActiveCount + rightActiveCount
+            let stereoActiveCount = leftCounts.active + rightCounts.active
             guard stereoActiveCount <= maxStereoActiveFilters else {
                 throw ProfileStoreValidationError.tooManyStereoActiveFilters(
                     profileID: profile.id,
@@ -232,16 +400,48 @@ public enum ProfilePersistence {
                     maximum: maxStereoActiveFilters
                 )
             }
+
+            let stereoFilterCount = leftCounts.total + rightCounts.total
+            guard stereoFilterCount <= maxStereoFilters else {
+                throw ProfileStoreValidationError.tooManyStereoFilters(
+                    profileID: profile.id,
+                    count: stereoFilterCount,
+                    maximum: maxStereoFilters
+                )
+            }
         }
 
         if let expectedBandCount = graphicBandCount(for: profile.mode) {
-            try validateGraphicBandCount(linkedActiveCount, channel: "linked", expected: expectedBandCount, profileID: profile.id)
-            try validateGraphicBandCount(leftActiveCount, channel: "left", expected: expectedBandCount, profileID: profile.id)
-            try validateGraphicBandCount(rightActiveCount, channel: "right", expected: expectedBandCount, profileID: profile.id)
+            switch profile.channelMode {
+            case .linked:
+                try validateGraphicBandCount(
+                    linkedCounts.active,
+                    channel: "linked",
+                    expected: expectedBandCount,
+                    profileID: profile.id
+                )
+            case .stereo:
+                try validateGraphicBandCount(
+                    leftCounts.active,
+                    channel: "left",
+                    expected: expectedBandCount,
+                    profileID: profile.id
+                )
+                try validateGraphicBandCount(
+                    rightCounts.active,
+                    channel: "right",
+                    expected: expectedBandCount,
+                    profileID: profile.id
+                )
+            }
         }
     }
 
-    private static func validateFilters(_ filters: [EQFilter], channel: String, profileID: UUID) throws -> Int {
+    private static func validateFilters(
+        _ filters: [EQFilter],
+        channel: String,
+        profileID: UUID
+    ) throws -> (active: Int, total: Int) {
         var activeCount = 0
 
         for filter in filters {
@@ -263,7 +463,16 @@ public enum ProfilePersistence {
             )
         }
 
-        return activeCount
+        guard filters.count <= maxFiltersPerChannel else {
+            throw ProfileStoreValidationError.tooManyFilters(
+                profileID: profileID,
+                channel: channel,
+                count: filters.count,
+                maximum: maxFiltersPerChannel
+            )
+        }
+
+        return (activeCount, filters.count)
     }
 
     private static func validate(_ value: Double, in range: ClosedRange<Double>, field: String, profileID: UUID) throws {
@@ -304,9 +513,78 @@ public enum ProfilePersistence {
         }
     }
 
+    private static func repairInvalidDecodedStore(
+        _ decodedStore: ProfileStore,
+        initialRepairSummary: ProfileStoreRepairSummary,
+        at url: URL,
+        timestamp: Date
+    ) -> ProfileStoreLoadResult {
+        var store = decodedStore
+        var summary = initialRepairSummary
+        let backupURL = uniqueInvalidStoreBackupURL(for: url, timestamp: timestamp)
+
+        do {
+            try FileManager.default.copyItem(at: url, to: backupURL)
+        } catch {
+            return ProfileStoreLoadResult(store: defaultStore(), status: .backupFailed)
+        }
+
+        let profileCountBeforeRepair = store.profiles.count
+        var seenProfileIDs = Set<UUID>()
+        store.profiles = store.profiles.filter { profile in
+            guard seenProfileIDs.insert(profile.id).inserted else {
+                return false
+            }
+            return (try? validate(profile)) != nil
+        }
+        summary.removedInvalidProfiles += profileCountBeforeRepair - store.profiles.count
+
+        if store.profiles.isEmpty {
+            let defaultStore = defaultStore()
+            do {
+                try save(defaultStore, to: url)
+                return ProfileStoreLoadResult(store: defaultStore, status: .recoveredDefaults(backupURL: backupURL))
+            } catch {
+                return ProfileStoreLoadResult(store: defaultStore, status: .backupFailed)
+            }
+        }
+
+        if store.profiles.count > profileCountRange.upperBound {
+            summary.removedInvalidProfiles += store.profiles.count - profileCountRange.upperBound
+            store.profiles = Array(store.profiles.prefix(profileCountRange.upperBound))
+        }
+
+        let mappingCountBeforeLengthRepair = store.outputMappings.count
+        store.outputMappings.removeAll { mapping in
+            mapping.outputDeviceUID.utf8.count > maxOutputUIDUTF8Bytes
+        }
+        summary.removedOutputMappings += mappingCountBeforeLengthRepair - store.outputMappings.count
+
+        if store.outputMappings.count > outputMappingCountRange.upperBound {
+            summary.removedOutputMappings += store.outputMappings.count - outputMappingCountRange.upperBound
+            store.outputMappings = Array(store.outputMappings.prefix(outputMappingCountRange.upperBound))
+        }
+
+        summary.merge(store.repairReferences())
+
+        do {
+            try validate(store)
+            try save(store, to: url)
+            return ProfileStoreLoadResult(store: store, status: .repairedInvalidStore(backupURL: backupURL, summary))
+        } catch {
+            let defaultStore = defaultStore()
+            do {
+                try save(defaultStore, to: url)
+                return ProfileStoreLoadResult(store: defaultStore, status: .recoveredDefaults(backupURL: backupURL))
+            } catch {
+                return ProfileStoreLoadResult(store: defaultStore, status: .backupFailed)
+            }
+        }
+    }
+
     private static func recoverInvalidStore(at url: URL, timestamp: Date) -> ProfileStoreLoadResult {
         let store = defaultStore()
-        let backupURL = invalidStoreBackupURL(for: url, timestamp: timestamp)
+        let backupURL = uniqueInvalidStoreBackupURL(for: url, timestamp: timestamp)
 
         do {
             try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -317,6 +595,27 @@ public enum ProfilePersistence {
 
         try? save(store, to: url)
         return ProfileStoreLoadResult(store: store, status: .recoveredDefaults(backupURL: backupURL))
+    }
+
+    private static func uniqueInvalidStoreBackupURL(for storeURL: URL, timestamp: Date) -> URL {
+        let first = invalidStoreBackupURL(for: storeURL, timestamp: timestamp)
+        guard FileManager.default.fileExists(atPath: first.path) else {
+            return first
+        }
+
+        let directory = first.deletingLastPathComponent()
+        let baseName = first.deletingPathExtension().lastPathComponent
+        let pathExtension = first.pathExtension
+        for index in 2...999 {
+            let candidateName = pathExtension.isEmpty
+                ? "\(baseName)-\(index)"
+                : "\(baseName)-\(index).\(pathExtension)"
+            let candidate = directory.appendingPathComponent(candidateName)
+            if !FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return directory.appendingPathComponent(UUID().uuidString + "-" + first.lastPathComponent)
     }
 
     private static func defaultStore() -> ProfileStore {

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -120,7 +120,7 @@ private func runDiagnostics(options: DiagnosticsOptions) -> Int32 {
         }
 
         if options.intentionalCrashAfterStart {
-            print("Intentional crash requested after engine start. This crash-test path verifies crash reporter and cleanup behavior.")
+            print("Intentional crash requested after engine start. Pending device setting restoration is persisted and retried on the next launch.")
             fflush(stdout)
             abort()
         }

--- a/Sources/GlassEQSettings/GlassEQSettingsApp.swift
+++ b/Sources/GlassEQSettings/GlassEQSettingsApp.swift
@@ -58,7 +58,7 @@ final class SettingsAppDelegate: NSObject, NSApplicationDelegate {
 
 @MainActor
 protocol SettingsPipeClientConnection: SettingsCommanding {
-    var token: String { get }
+    var token: String? { get }
 
     func connect() async throws -> SettingsSnapshotDTO
     func disconnect()
@@ -88,6 +88,7 @@ final class SettingsLaunchCoordinator {
     private var client: (any SettingsPipeClientConnection)?
     private var pendingLaunchInfo: SettingsLaunchInfo?
     private var connectedToken: String?
+    private var connectedMainProcessIdentifier: pid_t?
     private var didFinishLaunching = false
     private var connectionTask: Task<Void, Never>?
     private let clientFactory: any SettingsPipeClientMaking
@@ -112,6 +113,8 @@ final class SettingsLaunchCoordinator {
         connectionTask = nil
         client?.disconnect()
         client = nil
+        connectedToken = nil
+        connectedMainProcessIdentifier = nil
     }
 
     func waitForConnectionTask() async {
@@ -132,7 +135,7 @@ final class SettingsLaunchCoordinator {
             model.commandErrorMessage = "Settings was not launched by GlassEQ."
             return
         }
-        guard pendingLaunchInfo.token != connectedToken else {
+        guard pendingLaunchInfo.mainProcessIdentifier != connectedMainProcessIdentifier else {
             return
         }
 
@@ -149,7 +152,7 @@ final class SettingsLaunchCoordinator {
 
     private func connect(launchInfo: SettingsLaunchInfo, model: GlassEQSettingsViewModel) async {
         do {
-            guard launchInfo.token != connectedToken else {
+            guard launchInfo.mainProcessIdentifier != connectedMainProcessIdentifier else {
                 return
             }
             let client = try clientFactory.makeClient(launchInfo: launchInfo, model: model)
@@ -160,6 +163,7 @@ final class SettingsLaunchCoordinator {
             }
             self.client = client
             connectedToken = client.token
+            connectedMainProcessIdentifier = launchInfo.mainProcessIdentifier
             model.attach(client: client, snapshot: snapshot)
         } catch {
             guard !Task.isCancelled else {
@@ -172,26 +176,44 @@ final class SettingsLaunchCoordinator {
 
 @MainActor
 final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @unchecked Sendable {
-    let token: String
+    private(set) var token: String?
     private let mainProcessIdentifier: pid_t
     private weak var model: GlassEQSettingsViewModel?
     private let input = FileHandle.standardInput
-    private let output = FileHandle.standardOutput
+    private let bootstrapTimeout: Duration
+    private let requestTimeout: Duration
+    private let pipeWritePump = SettingsPipeWritePump(
+        label: "com.glasseq.settings.pipe-write",
+        fileHandle: FileHandle.standardOutput
+    )
+    private let pipeReadDelivery = SettingsPipeOrderedMainActorDelivery(
+        label: "com.glasseq.settings.pipe-read.delivery"
+    )
     private var mainTerminationObserver: NSObjectProtocol?
     private var continuations: [String: CheckedContinuation<SettingsCommandResponse, any Error>] = [:]
-    private let pipeDecoder = SettingsPipeLineDecoder()
+    private var pipeReadPump: SettingsPipeReadPump?
     private var disconnected = false
+    private var bootstrapContinuation: CheckedContinuation<String, any Error>?
+    private var bootstrapTimeoutTask: Task<Void, Never>?
+    private var requestTimeoutTasks: [String: Task<Void, Never>] = [:]
 
-    fileprivate init(launchInfo: SettingsLaunchInfo, model: GlassEQSettingsViewModel) throws {
-        self.token = launchInfo.token
+    fileprivate init(
+        launchInfo: SettingsLaunchInfo,
+        model: GlassEQSettingsViewModel,
+        bootstrapTimeout: Duration = .seconds(5),
+        requestTimeout: Duration = .seconds(30)
+    ) throws {
         self.mainProcessIdentifier = launchInfo.mainProcessIdentifier
         self.model = model
+        self.bootstrapTimeout = bootstrapTimeout
+        self.requestTimeout = requestTimeout
         super.init()
         try SettingsHostValidator.validate(launchInfo: launchInfo)
         installObservers()
     }
 
     func connect() async throws -> SettingsSnapshotDTO {
+        token = try await waitForBootstrapToken()
         let response = try await send(kind: .connect)
         guard let snapshot = response.snapshot else {
             throw SettingsCommandFailure(message: "GlassEQ returned an empty settings snapshot.")
@@ -208,40 +230,52 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
             return
         }
         disconnected = true
-        try? writePipeMessage(.request(sessionToken: token, id: UUID().uuidString, kind: .disconnect, command: nil))
+        if let token {
+            writePipeMessage(.request(sessionToken: token, id: UUID().uuidString, kind: .disconnect, command: nil))
+        }
         let error = SettingsCommandFailure(message: "Settings disconnected from GlassEQ.")
+        bootstrapContinuation?.resume(throwing: error)
+        bootstrapContinuation = nil
+        bootstrapTimeoutTask?.cancel()
+        bootstrapTimeoutTask = nil
+        requestTimeoutTasks.values.forEach { $0.cancel() }
+        requestTimeoutTasks.removeAll()
         continuations.values.forEach { $0.resume(throwing: error) }
         continuations.removeAll()
-        input.readabilityHandler = nil
+        pipeReadDelivery.invalidate()
+        pipeReadPump?.invalidate(handle: input)
+        pipeReadPump = nil
+        Task {
+            _ = await pipeWritePump.drainAndClose()
+        }
         mainTerminationObserver.map(NSWorkspace.shared.notificationCenter.removeObserver)
         mainTerminationObserver = nil
     }
 
     private func installObservers() {
-        let decoder = pipeDecoder
-        input.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
-                Task { @MainActor in
-                    NSApplication.shared.terminate(nil)
-                }
-                return
-            }
-            Task {
-                do {
-                    let messages = try await decoder.append(data)
-                    await MainActor.run {
+        let delivery = pipeReadDelivery
+        let pump = SettingsPipeReadPump(
+            label: "com.glasseq.settings.pipe-read",
+            onMessages: { [weak self, delivery] result in
+                delivery.enqueue {
+                    switch result {
+                    case .success(let messages):
                         self?.handlePipeMessages(messages)
-                    }
-                } catch {
-                    await MainActor.run {
+                    case .failure(let error):
                         self?.failPending(error)
                         self?.model?.commandErrorMessage = error.localizedDescription
                         NSApplication.shared.terminate(nil)
                     }
                 }
+            },
+            onEndOfFile: { [delivery] in
+                delivery.enqueue {
+                    NSApplication.shared.terminate(nil)
+                }
             }
-        }
+        )
+        pipeReadPump = pump
+        pump.install(on: input)
         mainTerminationObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didTerminateApplicationNotification,
             object: nil,
@@ -259,14 +293,44 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
     }
 
     private func send(kind: SettingsPipeRequestKind, command: SettingsCommand? = nil) async throws -> SettingsCommandResponse {
+        guard let token else {
+            throw SettingsCommandFailure(message: "Settings IPC session was not initialized.")
+        }
         let requestID = UUID().uuidString
+        let timeout = requestTimeout
         return try await withCheckedThrowingContinuation { continuation in
             continuations[requestID] = continuation
-            do {
-                try writePipeMessage(.request(sessionToken: token, id: requestID, kind: kind, command: command))
-            } catch {
-                continuations.removeValue(forKey: requestID)
-                continuation.resume(throwing: error)
+            requestTimeoutTasks[requestID] = Task { [weak self] in
+                guard let self else {
+                    return
+                }
+                try? await Task.sleep(for: timeout)
+                await MainActor.run {
+                    guard let continuation = self.continuations.removeValue(forKey: requestID) else {
+                        return
+                    }
+                    self.requestTimeoutTasks[requestID] = nil
+                    continuation.resume(throwing: SettingsCommandFailure(message: "Settings IPC request timed out."))
+                }
+            }
+            let message = SettingsPipeMessage.request(sessionToken: token, id: requestID, kind: kind, command: command)
+            pipeWritePump.enqueue(message) { [weak self] result in
+                guard case .failure(let error) = result else {
+                    return
+                }
+                Task { @MainActor in
+                    guard let self else {
+                        continuation.resume(throwing: SettingsCommandFailure(message: "Settings disconnected from GlassEQ."))
+                        return
+                    }
+                    guard self.continuations.removeValue(forKey: requestID) != nil else {
+                        return
+                    }
+                    self.requestTimeoutTasks.removeValue(forKey: requestID)?.cancel()
+                    continuation.resume(throwing: SettingsCommandFailure(
+                        message: "Settings IPC write failed: \(error.localizedDescription)"
+                    ))
+                }
             }
         }
     }
@@ -284,6 +348,13 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
     }
 
     private func handlePipeMessage(_ message: SettingsPipeMessage) throws {
+        if case .bootstrap(let sessionToken) = message {
+            acceptBootstrapToken(sessionToken)
+            return
+        }
+        guard let token else {
+            throw SettingsPipeError.sessionTokenMismatch
+        }
         try message.validateSessionToken(token)
 
         switch message {
@@ -291,6 +362,7 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
             guard let continuation = continuations.removeValue(forKey: id) else {
                 return
             }
+            requestTimeoutTasks.removeValue(forKey: id)?.cancel()
             if let error {
                 continuation.resume(throwing: SettingsCommandFailure(message: error))
                 return
@@ -302,7 +374,7 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
             continuation.resume(returning: response)
         case let .event(_, event):
             handleEvent(event)
-        case .request:
+        case .bootstrap, .request:
             break
         }
     }
@@ -328,29 +400,66 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
         }
     }
 
-    private func writePipeMessage(_ message: SettingsPipeMessage) throws {
-        try output.write(contentsOf: SettingsPipeCodec.encodeLine(message))
+    private func writePipeMessage(_ message: SettingsPipeMessage) {
+        pipeWritePump.enqueue(message)
     }
 
     private func failPending(_ error: any Error) {
+        bootstrapContinuation?.resume(throwing: error)
+        bootstrapContinuation = nil
+        bootstrapTimeoutTask?.cancel()
+        bootstrapTimeoutTask = nil
+        requestTimeoutTasks.values.forEach { $0.cancel() }
+        requestTimeoutTasks.removeAll()
         continuations.values.forEach { $0.resume(throwing: error) }
         continuations.removeAll()
+    }
+
+    private func waitForBootstrapToken() async throws -> String {
+        if let token {
+            return token
+        }
+        let timeout = bootstrapTimeout
+        return try await withCheckedThrowingContinuation { continuation in
+            bootstrapContinuation = continuation
+            bootstrapTimeoutTask?.cancel()
+            bootstrapTimeoutTask = Task { [weak self] in
+                guard let self else {
+                    return
+                }
+                try? await Task.sleep(for: timeout)
+                await MainActor.run {
+                    guard let continuation = self.bootstrapContinuation else {
+                        return
+                    }
+                    self.bootstrapContinuation = nil
+                    continuation.resume(throwing: SettingsCommandFailure(message: "Settings IPC bootstrap timed out."))
+                }
+            }
+        }
+    }
+
+    private func acceptBootstrapToken(_ sessionToken: String) {
+        guard token == nil else {
+            return
+        }
+        token = sessionToken
+        bootstrapContinuation?.resume(returning: sessionToken)
+        bootstrapContinuation = nil
+        bootstrapTimeoutTask?.cancel()
+        bootstrapTimeoutTask = nil
     }
 }
 
 struct SettingsLaunchInfo {
-    var token: String
     var mainProcessIdentifier: pid_t
 
     init?(commandLineArguments arguments: [String]) {
-        guard let tokenIndex = arguments.firstIndex(of: "--glasseq-settings-token"),
-              let pidIndex = arguments.firstIndex(of: "--glasseq-main-pid"),
-              arguments.indices.contains(tokenIndex + 1),
+        guard let pidIndex = arguments.firstIndex(of: "--glasseq-main-pid"),
               arguments.indices.contains(pidIndex + 1),
               let mainPID = Int32(arguments[pidIndex + 1]) else {
             return nil
         }
-        self.token = arguments[tokenIndex + 1]
         self.mainProcessIdentifier = mainPID
     }
 }

--- a/Sources/GlassEQSettings/Info.plist
+++ b/Sources/GlassEQSettings/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.0</string>
+    <string>0.8.0</string>
     <key>CFBundleVersion</key>
-    <string>9</string>
+    <string>10</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -136,6 +136,26 @@ public enum SettingsOptionalUUIDPatchDTO: Codable, Equatable, Sendable {
     case clear
 }
 
+public struct SettingsProfileStoreProtectionDTO: Codable, Equatable, Sendable {
+    public var isProtected: Bool
+    public var message: String
+    public var resetButtonTitle: String
+
+    public init(
+        isProtected: Bool = false,
+        message: String = "",
+        resetButtonTitle: String = ""
+    ) {
+        self.isProtected = isProtected
+        self.message = message
+        self.resetButtonTitle = resetButtonTitle
+    }
+
+    public static var unprotected: SettingsProfileStoreProtectionDTO {
+        SettingsProfileStoreProtectionDTO()
+    }
+}
+
 public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
     public var statusMessage: String?
     public var isPreviewing: Bool?
@@ -146,6 +166,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
     public var fallbackProfileID: UUID?
     public var currentOutput: SettingsOutputDTO?
     public var currentOutputMappedProfileID: SettingsOptionalUUIDPatchDTO?
+    public var profileStoreProtection: SettingsProfileStoreProtectionDTO?
 
     public init(
         statusMessage: String? = nil,
@@ -156,7 +177,8 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
         activeProfileName: String? = nil,
         fallbackProfileID: UUID? = nil,
         currentOutput: SettingsOutputDTO? = nil,
-        currentOutputMappedProfileID: SettingsOptionalUUIDPatchDTO? = nil
+        currentOutputMappedProfileID: SettingsOptionalUUIDPatchDTO? = nil,
+        profileStoreProtection: SettingsProfileStoreProtectionDTO? = nil
     ) {
         self.statusMessage = statusMessage
         self.isPreviewing = isPreviewing
@@ -167,6 +189,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
         self.fallbackProfileID = fallbackProfileID
         self.currentOutput = currentOutput
         self.currentOutputMappedProfileID = currentOutputMappedProfileID
+        self.profileStoreProtection = profileStoreProtection
     }
 }
 
@@ -186,6 +209,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
     public var statusMessage: String
     public var metrics: SettingsAudioMetricsDTO
     public var isPreviewing: Bool
+    public var profileStoreProtection: SettingsProfileStoreProtectionDTO
 
     public init(
         profiles: [EQProfile],
@@ -202,7 +226,8 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         fallbackProfileID: UUID,
         statusMessage: String,
         metrics: SettingsAudioMetricsDTO,
-        isPreviewing: Bool
+        isPreviewing: Bool,
+        profileStoreProtection: SettingsProfileStoreProtectionDTO = .unprotected
     ) {
         self.profiles = profiles
         self.selectedProfileID = selectedProfileID
@@ -219,6 +244,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         self.statusMessage = statusMessage
         self.metrics = metrics
         self.isPreviewing = isPreviewing
+        self.profileStoreProtection = profileStoreProtection
     }
 
     public static var disconnected: SettingsSnapshotDTO {
@@ -238,7 +264,8 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
             fallbackProfileID: profile.id,
             statusMessage: "Connecting to GlassEQ...",
             metrics: SettingsAudioMetricsDTO(),
-            isPreviewing: false
+            isPreviewing: false,
+            profileStoreProtection: .unprotected
         )
     }
 }
@@ -258,6 +285,7 @@ public enum SettingsCommand: Codable, Equatable, Sendable {
     case openPrivacySettings
     case startMetricsPolling
     case stopMetricsPolling
+    case resetUnsupportedProfileStore
 }
 
 public struct SettingsCommandResponse: Codable, Equatable, Sendable {

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -1,5 +1,30 @@
+import Darwin
 import Foundation
 import GlassEQCore
+
+private struct UncheckedSendable<Value>: @unchecked Sendable {
+    let value: Value
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer {
+            unlock()
+        }
+        return try body()
+    }
+}
+
+public enum SettingsPipeProcessSignalPolicy {
+    private static let ignoreSIGPIPEOnce: Void = {
+        _ = Darwin.signal(SIGPIPE, SIG_IGN)
+    }()
+
+    public static func ignoreBrokenPipeSignal() {
+        _ = ignoreSIGPIPEOnce
+    }
+}
 
 public enum SettingsImportFormat: String, CaseIterable, Codable, Identifiable, Sendable {
     case autoEQ = "AutoEQ / EqualizerAPO"
@@ -271,13 +296,15 @@ public enum SettingsPipeRequestKind: String, Codable, Equatable, Sendable {
 }
 
 public enum SettingsPipeMessage: Codable, Equatable, Sendable {
+    case bootstrap(sessionToken: String)
     case request(sessionToken: String, id: String, kind: SettingsPipeRequestKind, command: SettingsCommand?)
     case response(sessionToken: String, id: String, response: SettingsCommandResponse?, error: String?)
     case event(sessionToken: String, event: SettingsEvent)
 
     public var sessionToken: String {
         switch self {
-        case .request(let sessionToken, _, _, _),
+        case .bootstrap(let sessionToken),
+             .request(let sessionToken, _, _, _),
              .response(let sessionToken, _, _, _),
              .event(let sessionToken, _):
             sessionToken
@@ -285,9 +312,22 @@ public enum SettingsPipeMessage: Codable, Equatable, Sendable {
     }
 
     public func validateSessionToken(_ expected: String) throws {
-        guard sessionToken == expected else {
+        guard Self.constantTimeEquals(sessionToken, expected) else {
             throw SettingsPipeError.sessionTokenMismatch
         }
+    }
+
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        let count = max(lhsBytes.count, rhsBytes.count)
+        var difference = lhsBytes.count ^ rhsBytes.count
+        for index in 0..<count {
+            let lhsByte = index < lhsBytes.count ? Int(lhsBytes[index]) : 0
+            let rhsByte = index < rhsBytes.count ? Int(rhsBytes[index]) : 0
+            difference |= lhsByte ^ rhsByte
+        }
+        return difference == 0
     }
 }
 
@@ -312,7 +352,7 @@ public enum SettingsPipeCodec {
         _ message: SettingsPipeMessage,
         maximumLineBytes: Int = Self.maximumLineBytes
     ) throws -> Data {
-        var data = try SettingsPipeJSONCodec.encoder.encode(message)
+        var data = try SettingsPipeJSONCodec.makeEncoder().encode(message)
         guard data.count + 1 <= maximumLineBytes else {
             throw SettingsPipeError.frameTooLarge(byteCount: data.count + 1, maximum: maximumLineBytes)
         }
@@ -321,7 +361,7 @@ public enum SettingsPipeCodec {
     }
 
     public static func decodeLine(_ data: Data) throws -> SettingsPipeMessage {
-        try SettingsPipeJSONCodec.decoder.decode(SettingsPipeMessage.self, from: data)
+        try SettingsPipeJSONCodec.makeDecoder().decode(SettingsPipeMessage.self, from: data)
     }
 }
 
@@ -387,6 +427,239 @@ public actor SettingsPipeLineDecoder {
 }
 
 enum SettingsPipeJSONCodec {
-    static let encoder = JSONEncoder()
-    static let decoder = JSONDecoder()
+    static func makeEncoder() -> JSONEncoder {
+        JSONEncoder()
+    }
+
+    static func makeDecoder() -> JSONDecoder {
+        JSONDecoder()
+    }
+}
+
+public final class SettingsPipeReadPump: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let onMessages: @Sendable (Result<[SettingsPipeMessage], any Error>) -> Void
+    private let onEndOfFile: @Sendable () -> Void
+    private var buffer: SettingsPipeLineBuffer
+
+    public init(
+        label: String,
+        maximumLineBytes: Int = SettingsPipeCodec.maximumLineBytes,
+        onMessages: @escaping @Sendable (Result<[SettingsPipeMessage], any Error>) -> Void,
+        onEndOfFile: @escaping @Sendable () -> Void
+    ) {
+        self.queue = DispatchQueue(label: label)
+        self.buffer = SettingsPipeLineBuffer(maximumLineBytes: maximumLineBytes)
+        self.onMessages = onMessages
+        self.onEndOfFile = onEndOfFile
+    }
+
+    public func install(on handle: FileHandle) {
+        handle.readabilityHandler = { [weak self] handle in
+            guard let self else {
+                return
+            }
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                queue.async { [self] in
+                    self.onEndOfFile()
+                }
+                return
+            }
+            queue.async { [self] in
+                do {
+                    let lines = try self.buffer.append(data)
+                    let messages = try lines.map(SettingsPipeCodec.decodeLine)
+                    self.onMessages(.success(messages))
+                } catch {
+                    self.onMessages(.failure(error))
+                }
+            }
+        }
+    }
+
+    public func invalidate(handle: FileHandle?) {
+        handle?.readabilityHandler = nil
+        queue.async { [weak self] in
+            self?.buffer.removeAll(keepingCapacity: false)
+        }
+    }
+}
+
+public final class SettingsPipeOrderedMainActorDelivery: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let lock = NSLock()
+    private var generation = 0
+    private var isActive = true
+
+    public init(label: String) {
+        self.queue = DispatchQueue(label: label)
+    }
+
+    public func enqueue(_ operation: @escaping @MainActor () -> Void) {
+        let scheduledGeneration: Int? = lock.withLock {
+            guard isActive else {
+                return nil
+            }
+            return generation
+        }
+        guard let scheduledGeneration else {
+            return
+        }
+
+        queue.async { [weak self] in
+            guard let self,
+                  self.isCurrent(scheduledGeneration) else {
+                return
+            }
+            let semaphore = DispatchSemaphore(value: 0)
+            let operation = UncheckedSendable(value: operation)
+            Task { @MainActor in
+                defer {
+                    semaphore.signal()
+                }
+                guard self.isCurrent(scheduledGeneration) else {
+                    return
+                }
+                operation.value()
+            }
+            semaphore.wait()
+        }
+    }
+
+    public func invalidate() {
+        lock.withLock {
+            isActive = false
+            generation += 1
+        }
+    }
+
+    private func isCurrent(_ scheduledGeneration: Int) -> Bool {
+        lock.withLock {
+            isActive && generation == scheduledGeneration
+        }
+    }
+}
+
+public struct SettingsPipeWriteSink: Sendable {
+    private let writeBody: @Sendable (Data) throws -> Void
+    private let closeBody: @Sendable () throws -> Void
+
+    public init(
+        _ writeBody: @escaping @Sendable (Data) throws -> Void,
+        close closeBody: @escaping @Sendable () throws -> Void = {}
+    ) {
+        self.writeBody = writeBody
+        self.closeBody = closeBody
+    }
+
+    public init(fileHandle: FileHandle) {
+        SettingsPipeProcessSignalPolicy.ignoreBrokenPipeSignal()
+        let handle = UncheckedSendable(value: fileHandle)
+        self.writeBody = { data in
+            try handle.value.write(contentsOf: data)
+        }
+        self.closeBody = {
+            try handle.value.close()
+        }
+    }
+
+    func write(_ data: Data) throws {
+        try writeBody(data)
+    }
+
+    func close() throws {
+        try closeBody()
+    }
+}
+
+public enum SettingsPipeWritePumpError: Error, Equatable, LocalizedError, Sendable {
+    case closed
+
+    public var errorDescription: String? {
+        switch self {
+        case .closed:
+            return "Settings IPC pipe is closed."
+        }
+    }
+}
+
+public final class SettingsPipeWritePump: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let sink: SettingsPipeWriteSink
+    private let lock = NSLock()
+    private var isClosing = false
+
+    public init(label: String, sink: SettingsPipeWriteSink) {
+        self.queue = DispatchQueue(label: label)
+        self.sink = sink
+    }
+
+    public convenience init(label: String, fileHandle: FileHandle) {
+        self.init(label: label, sink: SettingsPipeWriteSink(fileHandle: fileHandle))
+    }
+
+    public func enqueue(
+        _ message: SettingsPipeMessage,
+        completion: @escaping @Sendable (Result<Void, any Error>) -> Void = { _ in }
+    ) {
+        guard markEnqueueAccepted() else {
+            queue.async {
+                completion(.failure(SettingsPipeWritePumpError.closed))
+            }
+            return
+        }
+
+        queue.async { [sink] in
+            do {
+                let data = try SettingsPipeCodec.encodeLine(message)
+                try sink.write(data)
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func drainAndClose(
+        completion: @escaping @Sendable (Result<Void, any Error>) -> Void = { _ in }
+    ) {
+        let shouldClose = lock.withLock {
+            guard !isClosing else {
+                return false
+            }
+            isClosing = true
+            return true
+        }
+
+        guard shouldClose else {
+            queue.async {
+                completion(.success(()))
+            }
+            return
+        }
+
+        queue.async { [sink] in
+            do {
+                try sink.close()
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func drainAndClose() async -> Result<Void, any Error> {
+        await withCheckedContinuation { continuation in
+            drainAndClose { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    private func markEnqueueAccepted() -> Bool {
+        lock.withLock {
+            !isClosing
+        }
+    }
 }

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -525,7 +525,10 @@ private struct GraphLegendItem: View {
     }
 }
 
-private struct EQAnalysisSignature: Equatable, Sendable {
+struct EQAnalysisSignature: Equatable, Sendable {
+    static let defaultSampleRate = 48_000.0
+
+    var sampleRate: Double
     var mode: EQMode
     var channelMode: EQChannelMode
     var preampDB: Double
@@ -535,7 +538,8 @@ private struct EQAnalysisSignature: Equatable, Sendable {
     var rightPreampDB: Double
     var rightFilters: [EQFilter]
 
-    init(profile: EQProfile) {
+    init(profile: EQProfile, sampleRate: Double) {
+        self.sampleRate = Self.effectiveSampleRate(sampleRate)
         self.mode = profile.mode
         self.channelMode = profile.channelMode
         self.preampDB = profile.preampDB
@@ -545,9 +549,16 @@ private struct EQAnalysisSignature: Equatable, Sendable {
         self.rightPreampDB = profile.rightPreampDB
         self.rightFilters = profile.rightFilters
     }
+
+    static func effectiveSampleRate(_ sampleRate: Double) -> Double {
+        guard sampleRate.isFinite, sampleRate > 0 else {
+            return defaultSampleRate
+        }
+        return sampleRate
+    }
 }
 
-private struct EQAnalysisSnapshot: Equatable, Sendable {
+struct EQAnalysisSnapshot: Equatable, Sendable {
     var signature: EQAnalysisSignature
     var channelMode: EQChannelMode
     var recommendedPreampDB: Double
@@ -555,20 +566,33 @@ private struct EQAnalysisSnapshot: Equatable, Sendable {
     var leftPoints: [FrequencyResponsePoint]
     var rightPoints: [FrequencyResponsePoint]
 
-    init(profile: EQProfile) {
-        self.signature = EQAnalysisSignature(profile: profile)
+    init(profile: EQProfile, sampleRate: Double) {
+        let sampleRate = EQAnalysisSignature.effectiveSampleRate(sampleRate)
+        self.signature = EQAnalysisSignature(profile: profile, sampleRate: sampleRate)
         self.channelMode = profile.channelMode
-        self.recommendedPreampDB = EQProfileAnalysis.recommendedPreampDB(profile: profile)
+        self.recommendedPreampDB = EQProfileAnalysis.recommendedPreampDB(profile: profile, sampleRate: sampleRate)
 
         switch profile.channelMode {
         case .linked:
-            self.linkedPoints = FrequencyResponse.points(for: profile.filters, preampDB: profile.preampDB)
+            self.linkedPoints = FrequencyResponse.points(
+                for: profile.filters,
+                preampDB: profile.preampDB,
+                sampleRate: sampleRate
+            )
             self.leftPoints = []
             self.rightPoints = []
         case .stereo:
             self.linkedPoints = []
-            self.leftPoints = FrequencyResponse.points(for: profile.leftFilters, preampDB: profile.leftPreampDB)
-            self.rightPoints = FrequencyResponse.points(for: profile.rightFilters, preampDB: profile.rightPreampDB)
+            self.leftPoints = FrequencyResponse.points(
+                for: profile.leftFilters,
+                preampDB: profile.leftPreampDB,
+                sampleRate: sampleRate
+            )
+            self.rightPoints = FrequencyResponse.points(
+                for: profile.rightFilters,
+                preampDB: profile.rightPreampDB,
+                sampleRate: sampleRate
+            )
         }
     }
 
@@ -777,7 +801,8 @@ private struct ProfileDetail: View {
                         switch tab {
                         case .editor:
                             EditorTab(
-                                draftProfile: $draftProfile
+                                draftProfile: $draftProfile,
+                                sampleRate: snapshot.currentOutputSampleRate
                             )
                         case .importer:
                             ImportTab(profile: draftProfile, onImport: onImport)
@@ -948,13 +973,20 @@ private extension EQChannelMode {
 
 private struct EditorTab: View {
     @Binding var draftProfile: EQProfile
+    var sampleRate: Double
     @State private var editChannel = EQEditChannel.left
     @State private var analysis: EQAnalysisSnapshot
     @State private var analysisTask: Task<Void, Never>?
 
-    init(draftProfile: Binding<EQProfile>) {
+    init(draftProfile: Binding<EQProfile>, sampleRate: Double) {
         self._draftProfile = draftProfile
-        self._analysis = State(initialValue: EQAnalysisSnapshot(profile: draftProfile.wrappedValue))
+        self.sampleRate = sampleRate
+        self._analysis = State(
+            initialValue: EQAnalysisSnapshot(
+                profile: draftProfile.wrappedValue,
+                sampleRate: sampleRate
+            )
+        )
     }
 
     var body: some View {
@@ -1070,12 +1102,13 @@ private struct EditorTab: View {
     }
 
     private var analysisSignature: EQAnalysisSignature {
-        EQAnalysisSignature(profile: draftProfile)
+        EQAnalysisSignature(profile: draftProfile, sampleRate: sampleRate)
     }
 
     private func refreshAnalysisIfNeeded(debounced: Bool) {
         let profile = draftProfile
-        let signature = EQAnalysisSignature(profile: profile)
+        let sampleRate = sampleRate
+        let signature = EQAnalysisSignature(profile: profile, sampleRate: sampleRate)
         guard analysis.signature != signature else {
             return
         }
@@ -1093,11 +1126,11 @@ private struct EditorTab: View {
             }
 
             let nextAnalysis = await Task.detached(priority: .userInitiated) {
-                EQAnalysisSnapshot(profile: profile)
+                EQAnalysisSnapshot(profile: profile, sampleRate: sampleRate)
             }.value
 
             guard !Task.isCancelled,
-                  EQAnalysisSignature(profile: draftProfile) == nextAnalysis.signature else {
+                  EQAnalysisSignature(profile: draftProfile, sampleRate: sampleRate) == nextAnalysis.signature else {
                 return
             }
             analysis = nextAnalysis

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -136,7 +136,8 @@ public struct SettingsView: View {
                 onCreateParametric: createParametricProfile,
                 onDuplicate: duplicateSelectedProfile,
                 onDelete: deleteSelectedProfile,
-                canDeleteSelectedProfile: canDeleteSelectedProfile
+                canDeleteSelectedProfile: canDeleteSelectedProfile,
+                isReadOnly: isProfileStoreProtected
             )
                 .frame(width: 260)
 
@@ -154,7 +155,8 @@ public struct SettingsView: View {
                                 onStopPreview: stopPreview,
                                 onResetDiagnostics: resetDiagnostics,
                                 onRetryAudioEngine: retryAudioEngine,
-                                onOpenPrivacySettings: openPrivacySettings
+                                onOpenPrivacySettings: openPrivacySettings,
+                                onResetUnsupportedProfileStore: resetUnsupportedProfileStore
                             )
                 .frame(minWidth: 640, maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -202,7 +204,11 @@ public struct SettingsView: View {
     }
 
     private var canDeleteSelectedProfile: Bool {
-        snapshot.profiles.count > 1 && snapshot.selectedProfileID != snapshot.activeProfileID
+        !isProfileStoreProtected && snapshot.profiles.count > 1 && snapshot.selectedProfileID != snapshot.activeProfileID
+    }
+
+    private var isProfileStoreProtected: Bool {
+        snapshot.profileStoreProtection.isProtected
     }
 
     private func selectProfile(_ id: UUID) {
@@ -253,6 +259,10 @@ public struct SettingsView: View {
 
     private func openPrivacySettings() {
         perform(.openPrivacySettings)
+    }
+
+    private func resetUnsupportedProfileStore() {
+        perform(.resetUnsupportedProfileStore)
     }
 
     private func createGraphic31Profile() {
@@ -629,6 +639,7 @@ private struct ProfileSidebar: View {
     var onDuplicate: () -> Void
     var onDelete: () -> Void
     var canDeleteSelectedProfile: Bool
+    var isReadOnly: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -688,6 +699,7 @@ private struct ProfileSidebar: View {
                             .contentShape(.rect)
                     }
                     .help(localized("New 31-band profile"))
+                    .disabled(isReadOnly)
                     .accessibilityLabel(Text(localized("New 31-band profile")))
                     .accessibilityHint(Text(localized("Creates a 31-band graphic equalizer profile")))
 
@@ -699,6 +711,7 @@ private struct ProfileSidebar: View {
                             .contentShape(.rect)
                     }
                     .help(localized("New 10-band profile"))
+                    .disabled(isReadOnly)
                     .accessibilityLabel(Text(localized("New 10-band profile")))
                     .accessibilityHint(Text(localized("Creates a 10-band graphic equalizer profile")))
 
@@ -710,6 +723,7 @@ private struct ProfileSidebar: View {
                             .contentShape(.rect)
                     }
                     .help(localized("New parametric profile"))
+                    .disabled(isReadOnly)
                     .accessibilityLabel(Text(localized("New parametric profile")))
                     .accessibilityHint(Text(localized("Creates a parametric equalizer profile")))
 
@@ -723,6 +737,7 @@ private struct ProfileSidebar: View {
                             .contentShape(.rect)
                     }
                     .help(localized("Duplicate profile"))
+                    .disabled(isReadOnly)
                     .accessibilityLabel(Text(localized("Duplicate profile")))
                     .accessibilityHint(Text(localized("Copies the selected profile")))
 
@@ -784,6 +799,7 @@ private struct ProfileDetail: View {
     var onResetDiagnostics: () -> Void
     var onRetryAudioEngine: () -> Void
     var onOpenPrivacySettings: () -> Void
+    var onResetUnsupportedProfileStore: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -791,8 +807,19 @@ private struct ProfileDetail: View {
                 ProfileHeader(
                     snapshot: snapshot,
                     draftProfile: $draftProfile,
-                    tab: $tab
+                    tab: $tab,
+                    isReadOnly: isProfileStoreProtected
                 )
+            }
+
+            if isProfileStoreProtected {
+                constrainedContent {
+                    ProfileStoreProtectionBanner(
+                        protection: snapshot.profileStoreProtection,
+                        onReset: onResetUnsupportedProfileStore
+                    )
+                }
+                .fixedSize(horizontal: false, vertical: true)
             }
 
             ScrollView {
@@ -804,11 +831,17 @@ private struct ProfileDetail: View {
                                 draftProfile: $draftProfile,
                                 sampleRate: snapshot.currentOutputSampleRate
                             )
+                            .disabled(isProfileStoreProtected)
                         case .importer:
-                            ImportTab(profile: draftProfile, onImport: onImport)
+                            ImportTab(
+                                profile: draftProfile,
+                                isReadOnly: isProfileStoreProtected,
+                                onImport: onImport
+                            )
                         case .output:
                             OutputTab(
                                 snapshot: snapshot,
+                                isProfileStoreProtected: isProfileStoreProtected,
                                 onUseForCurrentOutput: onUseForCurrentOutput,
                                 onSetFallback: onSetFallback,
                                 onResetDiagnostics: onResetDiagnostics,
@@ -834,6 +867,7 @@ private struct ProfileDetail: View {
                         hasUnsavedDraft: hasUnsavedDraft,
                         currentOutputUID: snapshot.currentOutputUID,
                         isPreviewing: snapshot.isPreviewing,
+                        isReadOnly: isProfileStoreProtected,
                         onApply: onApply,
                         onRevert: onRevert,
                         onPreview: onPreview,
@@ -859,12 +893,17 @@ private struct ProfileDetail: View {
             .frame(maxWidth: 860, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .topLeading)
     }
+
+    private var isProfileStoreProtected: Bool {
+        snapshot.profileStoreProtection.isProtected
+    }
 }
 
 private struct ProfileHeader: View {
     var snapshot: SettingsSnapshot
     @Binding var draftProfile: EQProfile
     @Binding var tab: EditorSection
+    var isReadOnly: Bool
     @State private var isRenaming = false
 
     var body: some View {
@@ -875,6 +914,7 @@ private struct ProfileHeader: View {
                         TextField(localized("Profile name"), text: $draftProfile.name)
                             .textFieldStyle(.roundedBorder)
                             .frame(maxWidth: 280)
+                            .disabled(isReadOnly)
                             .accessibilityLabel(Text(localized("Profile name")))
                         Button(localized("Done")) {
                             isRenaming = false
@@ -894,6 +934,7 @@ private struct ProfileHeader: View {
                                 .contentShape(.rect)
                         }
                         .buttonStyle(.borderless)
+                        .disabled(isReadOnly)
                         .help(localized("Rename profile"))
                         .accessibilityLabel(Text(localized("Rename profile")))
                         .accessibilityHint(Text(localized("Edits the selected profile name")))
@@ -922,6 +963,34 @@ private struct ProfileHeader: View {
             .accessibilityHint(Text(localized("Switches between editor, import, and output details")))
         }
         .cardPanel(padding: 16)
+    }
+}
+
+private struct ProfileStoreProtectionBanner: View {
+    var protection: SettingsProfileStoreProtectionDTO
+    var onReset: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "lock.fill")
+                .foregroundStyle(Color.orange)
+                .accessibilityHidden(true)
+            Text(protection.message)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            Button(role: .destructive) {
+                onReset()
+            } label: {
+                Label(protection.resetButtonTitle, systemImage: "arrow.counterclockwise")
+                    .frame(minHeight: 28)
+                    .contentShape(.rect)
+            }
+            .controlSize(.large)
+            .accessibilityLabel(Text(protection.resetButtonTitle))
+        }
+        .cardPanel(padding: 14)
     }
 }
 
@@ -1243,6 +1312,7 @@ private struct ApplyBar: View {
     var hasUnsavedDraft: Bool
     var currentOutputUID: String
     var isPreviewing: Bool
+    var isReadOnly: Bool
     var onApply: () -> Void
     var onRevert: () -> Void
     var onPreview: () -> Void
@@ -1267,19 +1337,20 @@ private struct ApplyBar: View {
                 onApply()
             }
             .keyboardShortcut(.return, modifiers: .command)
-            .disabled(!hasUnsavedDraft)
+            .disabled(isReadOnly || !hasUnsavedDraft)
             .buttonStyle(ToolbarButtonStyle(prominent: true))
 
             Button(isPreviewing ? localized("Stop Preview") : localized("Preview")) {
                 isPreviewing ? onStopPreview() : onPreview()
             }
+            .disabled(isReadOnly && !isPreviewing)
             .buttonStyle(ToolbarButtonStyle())
             .accessibilityValue(Text(isPreviewing ? localized("Previewing") : localized("Not previewing")))
 
             Button(localized("Assign to current output")) {
                 onUseForCurrentOutput()
             }
-            .disabled(currentOutputUID.isEmpty)
+            .disabled(isReadOnly || currentOutputUID.isEmpty)
             .buttonStyle(ToolbarButtonStyle())
             .accessibilityHint(Text(currentOutputUID.isEmpty ? localized("No current output is available") : localized("Maps the selected profile to the current output device")))
         }
@@ -1710,6 +1781,7 @@ private struct SliderRow: View {
 
 private struct ImportTab: View {
     var profile: EQProfile
+    var isReadOnly: Bool
     var onImport: (ImportFormat, String, String) async -> Bool
     @State private var importFormat: ImportFormat
     @State private var importName: String
@@ -1717,8 +1789,9 @@ private struct ImportTab: View {
     @State private var isEditorVisible = false
     @State private var isImporting = false
 
-    init(profile: EQProfile, onImport: @escaping (ImportFormat, String, String) async -> Bool) {
+    init(profile: EQProfile, isReadOnly: Bool, onImport: @escaping (ImportFormat, String, String) async -> Bool) {
         self.profile = profile
+        self.isReadOnly = isReadOnly
         self.onImport = onImport
         _importFormat = State(initialValue: .autoEQ)
         _importName = State(initialValue: localized("Imported Profile"))
@@ -1809,7 +1882,7 @@ private struct ImportTab: View {
                         .frame(minHeight: 28)
                         .contentShape(.rect)
                 }
-                .disabled(!isEditorVisible || importText.isEmpty || isImporting)
+                .disabled(isReadOnly || !isEditorVisible || importText.isEmpty || isImporting)
                 .controlSize(.large)
             }
             .cardPanel(padding: 12)
@@ -1819,6 +1892,7 @@ private struct ImportTab: View {
 
 private struct OutputTab: View {
     var snapshot: SettingsSnapshot
+    var isProfileStoreProtected: Bool
     var onUseForCurrentOutput: () -> Void
     var onSetFallback: () -> Void
     var onResetDiagnostics: () -> Void
@@ -1850,12 +1924,13 @@ private struct OutputTab: View {
                         Button(localized("Use for this output")) {
                             onUseForCurrentOutput()
                         }
-                        .disabled(snapshot.currentOutputUID.isEmpty)
+                        .disabled(isProfileStoreProtected || snapshot.currentOutputUID.isEmpty)
                         .controlSize(.large)
 
                         Button(localized("Set as fallback profile")) {
                             onSetFallback()
                         }
+                        .disabled(isProfileStoreProtected)
                         .controlSize(.large)
                     }
                 }

--- a/Sources/GlassEQSettingsUI/SettingsViewModel.swift
+++ b/Sources/GlassEQSettingsUI/SettingsViewModel.swift
@@ -63,6 +63,9 @@ public final class GlassEQSettingsViewModel {
             snapshot.currentOutputChannelCount = currentOutput.channelCount
             snapshot.currentOutputBufferFrameSize = currentOutput.bufferFrameSize
         }
+        if let profileStoreProtection = patch.profileStoreProtection {
+            snapshot.profileStoreProtection = profileStoreProtection
+        }
         switch patch.currentOutputMappedProfileID {
         case .set(let profileID):
             snapshot.currentOutputMappedProfileID = profileID

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -124,6 +124,31 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func startDoesNotBlockOnAsyncObserverStart() async throws {
+        let observers = BlockingAsyncDefaultOutputObserverFactory()
+        let model = makeModel(observers: observers, outputDelay: .zero)
+
+        let start = Date()
+        model.start()
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 0.05)
+        let observer = try #require(observers.observers.first)
+        await waitUntil {
+            observer.startCalls == [true]
+        }
+        #expect(model.lifecycleState == .stopped)
+
+        model.stop()
+        observer.resumeStart()
+        await waitUntil {
+            observer.stopCallCount == 1
+        }
+
+        #expect(observer.stopCallCount == 1)
+    }
+
+    @Test
     func availabilityFailureDuringRouteSwitchStartsSettledDefaultOutput() async {
         let airPods = makeOutput(
             uid: "airpods-output",
@@ -201,6 +226,7 @@ struct GlassEQAppModelLifecycleTests {
 
         #expect(model.currentOutputUID == scarlett.uid)
         #expect(model.lifecycleState == .running)
+        #expect(engine.events == ["start:\(speakers.uid)", "mute", "start:\(scarlett.uid)"])
     }
 
     @Test
@@ -252,6 +278,37 @@ struct GlassEQAppModelLifecycleTests {
 
         #expect(model.currentOutputSampleRate == changedOutput.nominalSampleRate)
         #expect(model.currentOutputBufferFrameSize == changedOutput.bufferFrameSize)
+    }
+
+    @Test
+    func stopThenImmediateRestartEnqueuesStopBeforeNewStart() async {
+        let output = makeOutput(uid: "restart-output", name: "Restart Output")
+        let engine = FakeAudioEngine()
+        let lookup = FakeDefaultOutputLookup(.success(output))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        model.stop()
+        model.start()
+        observers.observers.last?.emit(.success(output))
+
+        await waitUntil {
+            engine.stopCallCount == 1 && engine.startCalls.count == 2
+        }
+
+        #expect(engine.events == ["start:\(output.uid)", "stop", "start:\(output.uid)"])
+        #expect(model.lifecycleState == .running)
     }
 
     @Test
@@ -320,6 +377,7 @@ struct GlassEQAppModelLifecycleTests {
         }
 
         #expect(engine.stopCallCount == 2)
+        #expect(engine.state == .stopped)
         #expect(!model.isRunning)
         #expect(model.lifecycleState == .stopped)
     }
@@ -860,6 +918,62 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func bypassAfterSelectingDifferentDraftOnlyTogglesActiveProfile() async {
+        let active = makeProfile(name: "Active")
+        let draft = makeProfile(name: "Draft")
+        let output = makeOutput(uid: "bypass-output", name: "Bypass Output")
+        let store = ProfileStore(profiles: [active, draft], fallbackProfileID: active.id)
+        let engine = FakeAudioEngine()
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(store: store, engine: engine, observers: observers, outputDelay: .zero)
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+        model.selectProfile(draft.id)
+
+        model.setBypass(true)
+
+        #expect(model.activeProfile.id == active.id)
+        #expect(model.activeProfile.isBypassed)
+        #expect(model.selectedProfileID == draft.id)
+        #expect(model.draftProfile.id == draft.id)
+        #expect(!model.draftProfile.isBypassed)
+        #expect(model.profileStore.profiles.first { $0.id == active.id }?.isBypassed == true)
+        #expect(model.profileStore.profiles.first { $0.id == draft.id }?.isBypassed == false)
+        #expect(engine.updateDSPCalls.isEmpty)
+        #expect(engine.setBypassedCalls == [true])
+    }
+
+    @Test
+    func bypassMirrorsDraftWhenSelectedProfileIsActiveProfile() async {
+        let active = makeProfile(name: "Active")
+        let output = makeOutput(uid: "active-bypass-output", name: "Active Bypass Output")
+        let store = ProfileStore(profiles: [active], fallbackProfileID: active.id)
+        let engine = FakeAudioEngine()
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(store: store, engine: engine, observers: observers, outputDelay: .zero)
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        model.setBypass(true)
+
+        #expect(model.activeProfile.id == active.id)
+        #expect(model.activeProfile.isBypassed)
+        #expect(model.draftProfile.id == active.id)
+        #expect(model.draftProfile.isBypassed)
+        #expect(model.profileStore.profiles.first { $0.id == active.id }?.isBypassed == true)
+        #expect(engine.updateDSPCalls.isEmpty)
+        #expect(engine.setBypassedCalls == [true])
+    }
+
+    @Test
     func settingsDuplicateUsesExplicitProfileID() async throws {
         let first = makeProfile(name: "First")
         let second = makeProfile(name: "Second")
@@ -1168,7 +1282,7 @@ private func makeModel(
         .appendingPathComponent("GlassEQAppTests-\(UUID().uuidString).json"),
     engine: FakeAudioEngine = FakeAudioEngine(),
     lookup: FakeDefaultOutputLookup = FakeDefaultOutputLookup(.success(makeOutput())),
-    observers: FakeDefaultOutputObserverFactory = FakeDefaultOutputObserverFactory(),
+    observers: any DefaultOutputObservingMaking = FakeDefaultOutputObserverFactory(),
     workspaceOpener: any WorkspaceOpening = FakeWorkspaceOpener(results: []),
     saveDelay: Duration = .zero,
     outputDelay: Duration? = nil,
@@ -1353,16 +1467,36 @@ private final class SleepingSettingsHelperLauncher: SettingsHelperLaunching {
 }
 
 private final class FakeDefaultOutputLookup: DefaultOutputLookingUp, @unchecked Sendable {
-    private(set) var defaultOutputCalls = 0
-    var result: Result<AudioOutputDevice, Error>
+    private let lock = NSLock()
+    private var _defaultOutputCalls = 0
+    private var _result: Result<AudioOutputDevice, Error>
+
+    private(set) var defaultOutputCalls: Int {
+        get { withLock { _defaultOutputCalls } }
+        set { withLock { _defaultOutputCalls = newValue } }
+    }
+
+    var result: Result<AudioOutputDevice, Error> {
+        get { withLock { _result } }
+        set { withLock { _result = newValue } }
+    }
 
     init(_ result: Result<AudioOutputDevice, Error>) {
-        self.result = result
+        self._result = result
     }
 
     func defaultOutputDevice() throws -> AudioOutputDevice {
-        defaultOutputCalls += 1
+        let result = withLock {
+            _defaultOutputCalls += 1
+            return _result
+        }
         return try result.get()
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
 }
 
@@ -1376,25 +1510,130 @@ private final class FakeDefaultOutputObserverFactory: DefaultOutputObservingMaki
     }
 }
 
-private final class FakeDefaultOutputObserver: DefaultOutputObserving {
+private final class FakeDefaultOutputObserver: DefaultOutputObserving, @unchecked Sendable {
     private let onChange: DefaultOutputObserverHandler
-    private(set) var startCalls: [Bool] = []
-    private(set) var stopCallCount = 0
+    private let lock = NSLock()
+    private var _startCalls: [Bool] = []
+    private var _stopCallCount = 0
+
+    var startCalls: [Bool] {
+        withLock {
+            _startCalls
+        }
+    }
+
+    var stopCallCount: Int {
+        withLock {
+            _stopCallCount
+        }
+    }
 
     init(onChange: @escaping DefaultOutputObserverHandler) {
         self.onChange = onChange
     }
 
     func start(sendInitialValue: Bool) throws {
-        startCalls.append(sendInitialValue)
+        withLock {
+            _startCalls.append(sendInitialValue)
+        }
     }
 
     func stop() {
-        stopCallCount += 1
+        withLock {
+            _stopCallCount += 1
+        }
     }
 
     func emit(_ result: Result<AudioOutputDevice, Error>) {
         onChange(result)
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return body()
+    }
+}
+
+private final class BlockingAsyncDefaultOutputObserverFactory: DefaultOutputObservingMaking {
+    private(set) var observers: [BlockingAsyncDefaultOutputObserver] = []
+
+    func makeObserver(onChange: @escaping DefaultOutputObserverHandler) -> any DefaultOutputObserving {
+        let observer = BlockingAsyncDefaultOutputObserver(onChange: onChange)
+        observers.append(observer)
+        return observer
+    }
+}
+
+private final class BlockingAsyncDefaultOutputObserver: DefaultOutputObserving, @unchecked Sendable {
+    private let onChange: DefaultOutputObserverHandler
+    private let lock = NSLock()
+    private var _startCalls: [Bool] = []
+    private var _stopCallCount = 0
+    private var startContinuation: CheckedContinuation<Void, Never>?
+
+    init(onChange: @escaping DefaultOutputObserverHandler) {
+        self.onChange = onChange
+    }
+
+    var startCalls: [Bool] {
+        withLock {
+            _startCalls
+        }
+    }
+
+    var stopCallCount: Int {
+        withLock {
+            _stopCallCount
+        }
+    }
+
+    func start(sendInitialValue: Bool) throws {
+        withLock {
+            _startCalls.append(sendInitialValue)
+        }
+    }
+
+    func startAsync(sendInitialValue: Bool) async throws {
+        try start(sendInitialValue: sendInitialValue)
+        await withCheckedContinuation { continuation in
+            withLock {
+                startContinuation = continuation
+            }
+        }
+    }
+
+    func stop() {
+        withLock {
+            _stopCallCount += 1
+        }
+    }
+
+    func stopAsync() async {
+        stop()
+    }
+
+    func emit(_ result: Result<AudioOutputDevice, Error>) {
+        onChange(result)
+    }
+
+    func resumeStart() {
+        let continuation = withLock {
+            let continuation = startContinuation
+            startContinuation = nil
+            return continuation
+        }
+        continuation?.resume()
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return body()
     }
 }
 
@@ -1404,67 +1643,183 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         var profile: EQProfile
     }
 
-    var state: AudioEngineState = .stopped
-    var startError: Error?
-    var updateError: Error?
-    var updateDSPResult = true
-    var startDelaySeconds: TimeInterval = 0
-    var startDelaySecondsByUID: [String: TimeInterval] = [:]
-    private(set) var startCalls: [StartCall] = []
-    private(set) var updateCalls: [EQProfile] = []
-    private(set) var updateDSPCalls: [EQProfile] = []
-    private(set) var stopCallCount = 0
-    private(set) var muteOutputCallCount = 0
-    private(set) var setBypassedCalls: [Bool] = []
-    var metrics = AudioEngineMetrics()
+    private let lock = NSLock()
+    private var _state: AudioEngineState = .stopped
+    private var _startError: Error?
+    private var _updateError: Error?
+    private var _updateErrorPreservesRunningState = false
+    private var _updateDSPResult = true
+    private var _startDelaySeconds: TimeInterval = 0
+    private var _startDelaySecondsByUID: [String: TimeInterval] = [:]
+    private var _startCalls: [StartCall] = []
+    private var _updateCalls: [EQProfile] = []
+    private var _updateDSPCalls: [EQProfile] = []
+    private var _stopCallCount = 0
+    private var _muteOutputCallCount = 0
+    private var _setBypassedCalls: [Bool] = []
+    private var _metrics = AudioEngineMetrics()
+    private var _events: [String] = []
+
+    var state: AudioEngineState {
+        get { withLock { _state } }
+        set { withLock { _state = newValue } }
+    }
+
+    var startError: Error? {
+        get { withLock { _startError } }
+        set { withLock { _startError = newValue } }
+    }
+
+    var updateError: Error? {
+        get { withLock { _updateError } }
+        set { withLock { _updateError = newValue } }
+    }
+
+    var updateErrorPreservesRunningState: Bool {
+        get { withLock { _updateErrorPreservesRunningState } }
+        set { withLock { _updateErrorPreservesRunningState = newValue } }
+    }
+
+    var updateDSPResult: Bool {
+        get { withLock { _updateDSPResult } }
+        set { withLock { _updateDSPResult = newValue } }
+    }
+
+    var startDelaySeconds: TimeInterval {
+        get { withLock { _startDelaySeconds } }
+        set { withLock { _startDelaySeconds = newValue } }
+    }
+
+    var startDelaySecondsByUID: [String: TimeInterval] {
+        get { withLock { _startDelaySecondsByUID } }
+        set { withLock { _startDelaySecondsByUID = newValue } }
+    }
+
+    private(set) var startCalls: [StartCall] {
+        get { withLock { _startCalls } }
+        set { withLock { _startCalls = newValue } }
+    }
+
+    private(set) var updateCalls: [EQProfile] {
+        get { withLock { _updateCalls } }
+        set { withLock { _updateCalls = newValue } }
+    }
+
+    private(set) var updateDSPCalls: [EQProfile] {
+        get { withLock { _updateDSPCalls } }
+        set { withLock { _updateDSPCalls = newValue } }
+    }
+
+    private(set) var stopCallCount: Int {
+        get { withLock { _stopCallCount } }
+        set { withLock { _stopCallCount = newValue } }
+    }
+
+    private(set) var muteOutputCallCount: Int {
+        get { withLock { _muteOutputCallCount } }
+        set { withLock { _muteOutputCallCount = newValue } }
+    }
+
+    private(set) var setBypassedCalls: [Bool] {
+        get { withLock { _setBypassedCalls } }
+        set { withLock { _setBypassedCalls = newValue } }
+    }
+
+    var metrics: AudioEngineMetrics {
+        get { withLock { _metrics } }
+        set { withLock { _metrics = newValue } }
+    }
+
+    var events: [String] {
+        withLock { _events }
+    }
 
     func start(output: AudioOutputDevice, profile: EQProfile) throws {
-        startCalls.append(StartCall(output: output, profile: profile))
-        let delay = startDelaySecondsByUID[output.uid] ?? startDelaySeconds
+        let delay = withLock {
+            _events.append("start:\(output.uid)")
+            _startCalls.append(StartCall(output: output, profile: profile))
+            return _startDelaySecondsByUID[output.uid] ?? _startDelaySeconds
+        }
         if delay > 0 {
             Thread.sleep(forTimeInterval: delay)
         }
-        if let startError {
-            state = .failed("Start failed")
+        if let startError = withLock({ _startError }) {
+            withLock {
+                _state = .failed("Start failed")
+            }
             throw startError
         }
-        state = .running(output: output)
+        withLock {
+            _state = .running(output: output)
+        }
     }
 
     func update(profile: EQProfile) throws {
-        updateCalls.append(profile)
-        if let updateError {
-            state = .failed("Update failed")
+        let update = withLock {
+            _events.append("update:\(profile.id)")
+            _updateCalls.append(profile)
+            return (error: _updateError, preservesRunningState: _updateErrorPreservesRunningState)
+        }
+        if let updateError = update.error {
+            if !update.preservesRunningState {
+                withLock {
+                    _state = .failed("Update failed")
+                }
+            }
             throw updateError
         }
-        if case .running(let output) = state {
-            state = .running(output: output)
+        withLock {
+            if case .running(let output) = _state {
+                _state = .running(output: output)
+            }
         }
     }
 
     func updateDSP(profile: EQProfile) -> Bool {
-        updateDSPCalls.append(profile)
-        return updateDSPResult
+        withLock {
+            _events.append("updateDSP:\(profile.id)")
+            _updateDSPCalls.append(profile)
+            return _updateDSPResult
+        }
     }
 
     func setBypassed(_ isBypassed: Bool) {
-        setBypassedCalls.append(isBypassed)
+        withLock {
+            _events.append("bypass:\(isBypassed)")
+            _setBypassedCalls.append(isBypassed)
+        }
     }
 
     func muteOutputForTransition() {
-        muteOutputCallCount += 1
+        withLock {
+            _events.append("mute")
+            _muteOutputCallCount += 1
+        }
     }
 
     func stop() {
-        stopCallCount += 1
-        state = .stopped
+        withLock {
+            _events.append("stop")
+            _stopCallCount += 1
+            _state = .stopped
+        }
     }
 
     func snapshotMetrics() -> AudioEngineMetrics {
-        metrics
+        withLock {
+            _metrics
+        }
     }
 
     func resetDiagnostics() {
-        metrics = AudioEngineMetrics()
+        withLock {
+            _metrics = AudioEngineMetrics()
+        }
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
 }

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -977,6 +977,36 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsLaunchValidationFailureTerminatesPartiallyStartedHelper() async throws {
+        let model = makeModel()
+        let launcher = SleepingSettingsHelperLauncher()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: launcher,
+            helperValidator: FailingSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        coordinator.openSettings()
+
+        let process = try #require(launcher.launchedProcesses.first)
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+        for _ in 0..<250 {
+            if !process.isRunning {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(!process.isRunning)
+        #expect(model.statusMessage.contains("Settings failed to open"))
+    }
+
+    @Test
     func settingsHelperValidationChecksContainmentBundleIDAndSigningPolicy() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("GlassEQHelperValidation-\(UUID().uuidString)", isDirectory: true)
@@ -1053,6 +1083,81 @@ struct GlassEQAppModelLifecycleTests {
             hostBundleURL: hostURL,
             codeSigningValidator: adHoc
         )
+    }
+
+    @Test
+    func settingsHelperRunningValidationFallsBackWhenLaunchServicesHasNoBundleURL() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQHelperRunningValidation-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let hostURL = root.appendingPathComponent("GlassEQ.app", isDirectory: true)
+        let helperURL = hostURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Helpers", isDirectory: true)
+            .appendingPathComponent("GlassEQSettings.app", isDirectory: true)
+        try makeFakeAppBundle(
+            at: helperURL,
+            bundleIdentifier: SettingsHelperVerifier.helperBundleIdentifier,
+            executableName: "GlassEQSettings"
+        )
+        let validator = FakeCodeSigningValidator(signatures: [
+            hostURL.standardizedFileURL.path: SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.hostBundleIdentifier, teamIdentifier: "TEAMID"),
+            helperURL.standardizedFileURL.path: SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.helperBundleIdentifier, teamIdentifier: "TEAMID"),
+            "pid:123": SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.helperBundleIdentifier, teamIdentifier: "TEAMID")
+        ])
+
+        try SettingsHelperVerifier.validateRunningProcess(
+            processIdentifier: 123,
+            expectedHelperURL: helperURL,
+            hostBundleURL: hostURL,
+            runningBundleURL: { _ in nil },
+            processExecutableURL: { _ in helperExecutableURL(for: helperURL) },
+            codeSigningValidator: validator
+        )
+    }
+
+    @Test
+    func settingsHelperRunningValidationRejectsUnexpectedResolvedBundleURL() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQHelperRunningValidation-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let hostURL = root.appendingPathComponent("GlassEQ.app", isDirectory: true)
+        let helperURL = hostURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Helpers", isDirectory: true)
+            .appendingPathComponent("GlassEQSettings.app", isDirectory: true)
+        let otherURL = root.appendingPathComponent("OtherSettings.app", isDirectory: true)
+        try makeFakeAppBundle(
+            at: helperURL,
+            bundleIdentifier: SettingsHelperVerifier.helperBundleIdentifier,
+            executableName: "GlassEQSettings"
+        )
+        try makeFakeAppBundle(
+            at: otherURL,
+            bundleIdentifier: SettingsHelperVerifier.helperBundleIdentifier,
+            executableName: "GlassEQSettings"
+        )
+        let validator = FakeCodeSigningValidator(signatures: [
+            hostURL.standardizedFileURL.path: SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.hostBundleIdentifier, teamIdentifier: "TEAMID"),
+            helperURL.standardizedFileURL.path: SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.helperBundleIdentifier, teamIdentifier: "TEAMID"),
+            otherURL.standardizedFileURL.path: SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.helperBundleIdentifier, teamIdentifier: "TEAMID"),
+            "pid:123": SettingsCodeSignatureInfo(signingIdentifier: SettingsHelperVerifier.helperBundleIdentifier, teamIdentifier: "TEAMID")
+        ])
+
+        #expect(throws: SettingsCommandFailure.self) {
+            try SettingsHelperVerifier.validateRunningProcess(
+                processIdentifier: 123,
+                expectedHelperURL: helperURL,
+                hostBundleURL: hostURL,
+                runningBundleURL: { _ in otherURL },
+                processExecutableURL: { _ in helperExecutableURL(for: otherURL) },
+                codeSigningValidator: validator
+            )
+        }
     }
 }
 
@@ -1145,6 +1250,14 @@ private func makeFakeAppBundle(
     FileManager.default.createFile(atPath: executableURL.path, contents: Data("#!/bin/sh\n".utf8))
 }
 
+private func helperExecutableURL(for helperURL: URL) -> URL {
+    helperURL
+        .appendingPathComponent("Contents", isDirectory: true)
+        .appendingPathComponent("MacOS", isDirectory: true)
+        .appendingPathComponent("GlassEQSettings", isDirectory: false)
+        .standardizedFileURL
+}
+
 private func settleAsyncWork() async {
     try? await Task.sleep(for: .milliseconds(20))
 }
@@ -1190,6 +1303,52 @@ private struct FakeCodeSigningValidator: SettingsCodeSigningValidating {
             throw SettingsCommandFailure(message: "Missing fake signature")
         }
         return signature
+    }
+
+    func signatureInfo(forProcessIdentifier processIdentifier: pid_t) throws -> SettingsCodeSignatureInfo {
+        guard let signature = signatures["pid:\(processIdentifier)"] ?? signatures.values.first else {
+            throw SettingsCommandFailure(message: "Missing fake process signature")
+        }
+        return signature
+    }
+}
+
+private struct FailingSettingsHelperLaunchValidator: SettingsHelperLaunchValidating {
+    func validatedExecutableURL(for helperURL: URL) throws -> URL {
+        URL(fileURLWithPath: "/bin/sleep")
+    }
+
+    func validateRunningProcess(processIdentifier: pid_t, expectedHelperURL: URL) throws {
+        throw SettingsCommandFailure(message: "Intentional post-launch validation failure")
+    }
+}
+
+private final class SleepingSettingsHelperLauncher: SettingsHelperLaunching {
+    private(set) var launchedProcesses: [Process] = []
+
+    func launch(
+        executableURL: URL,
+        arguments: [String],
+        terminationHandler: @escaping @Sendable (Process) -> Void
+    ) throws -> SettingsHelperLaunch {
+        let process = Process()
+        let helperInput = Pipe()
+        let helperOutput = Pipe()
+        let helperError = Pipe()
+        process.executableURL = executableURL
+        process.arguments = ["60"]
+        process.standardInput = helperInput.fileHandleForReading
+        process.standardOutput = helperOutput.fileHandleForWriting
+        process.standardError = helperError.fileHandleForWriting
+        process.terminationHandler = terminationHandler
+        try process.run()
+        launchedProcesses.append(process)
+        return SettingsHelperLaunch(
+            process: process,
+            input: helperInput,
+            output: helperOutput,
+            error: helperError
+        )
     }
 }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -316,7 +316,7 @@ struct GlassEQAppModelLifecycleTests {
         let firstOutput = makeOutput(uid: "first-output", name: "First Output", id: 200)
         let secondOutput = makeOutput(uid: "second-output", name: "Second Output", id: 300)
         let engine = FakeAudioEngine()
-        engine.startDelaySecondsByUID[firstOutput.uid] = 0.08
+        engine.blockStart(for: firstOutput.uid)
         let lookup = FakeDefaultOutputLookup(.success(firstOutput))
         let observers = FakeDefaultOutputObserverFactory()
         let model = makeModel(
@@ -332,9 +332,11 @@ struct GlassEQAppModelLifecycleTests {
         await waitUntil {
             engine.startCalls.count == 1
         }
+        #expect(engine.waitUntilStartIsBlocked(for: firstOutput.uid, timeout: .now() + 1))
 
         lookup.result = .success(secondOutput)
         observer.emit(.success(secondOutput))
+        engine.unblockStart(for: firstOutput.uid)
         await waitUntil {
             model.lifecycleState == .running
                 && model.currentOutputUID == secondOutput.uid
@@ -354,7 +356,7 @@ struct GlassEQAppModelLifecycleTests {
     func userStopDuringSlowStartCleansUpAfterCancelledStartFinishes() async {
         let output = makeOutput(uid: "slow-start-output", name: "Slow Start Output", id: 200)
         let engine = FakeAudioEngine()
-        engine.startDelaySeconds = 0.08
+        engine.blockStart(for: output.uid)
         let lookup = FakeDefaultOutputLookup(.success(output))
         let observers = FakeDefaultOutputObserverFactory()
         let model = makeModel(
@@ -369,8 +371,10 @@ struct GlassEQAppModelLifecycleTests {
         await waitUntil {
             engine.startCalls.count == 1
         }
+        #expect(engine.waitUntilStartIsBlocked(for: output.uid, timeout: .now() + 1))
 
         model.stop()
+        engine.unblockStart(for: output.uid)
 
         await waitUntil {
             engine.stopCallCount == 2
@@ -779,7 +783,7 @@ struct GlassEQAppModelLifecycleTests {
             model.lifecycleState == .running && engine.startCalls.count == 1
         }
 
-        engine.startDelaySeconds = 0.08
+        engine.blockStart(for: output.uid)
         model.handleWillSleep()
         model.handleDidWake()
         await waitUntil {
@@ -789,6 +793,7 @@ struct GlassEQAppModelLifecycleTests {
         await waitUntil {
             model.lifecycleState == .waking && engine.startCalls.count == 2
         }
+        #expect(engine.waitUntilStartIsBlocked(for: output.uid, timeout: .now() + 1))
 
         try model.apply(profile: applied)
         try model.useForCurrentOutput(profile: mapped)
@@ -805,6 +810,7 @@ struct GlassEQAppModelLifecycleTests {
         #expect(engine.setBypassedCalls.isEmpty)
         #expect(model.profileStore.profile(forOutputUID: output.uid).id == mapped.id)
 
+        engine.unblockStart(for: output.uid)
         await waitUntil {
             model.lifecycleState == .running
                 && engine.startCalls.last?.profile.id == mapped.id
@@ -1786,6 +1792,7 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private var _updateDSPResult = true
     private var _startDelaySeconds: TimeInterval = 0
     private var _startDelaySecondsByUID: [String: TimeInterval] = [:]
+    private var _startBlockersByUID: [String: FakeStartBlocker] = [:]
     private var _startCalls: [StartCall] = []
     private var _updateCalls: [EQProfile] = []
     private var _updateDSPCalls: [EQProfile] = []
@@ -1869,14 +1876,37 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         withLock { _events }
     }
 
+    func blockStart(for outputUID: String) {
+        withLock {
+            _startBlockersByUID[outputUID] = FakeStartBlocker()
+        }
+    }
+
+    func waitUntilStartIsBlocked(for outputUID: String, timeout: DispatchTime) -> Bool {
+        withLock {
+            _startBlockersByUID[outputUID]
+        }?.waitUntilEntered(timeout: timeout) ?? false
+    }
+
+    func unblockStart(for outputUID: String) {
+        let blocker = withLock {
+            _startBlockersByUID.removeValue(forKey: outputUID)
+        }
+        blocker?.unblock()
+    }
+
     func start(output: AudioOutputDevice, profile: EQProfile) throws {
-        let delay = withLock {
+        let startControl = withLock {
             _events.append("start:\(output.uid)")
             _startCalls.append(StartCall(output: output, profile: profile))
-            return _startDelaySecondsByUID[output.uid] ?? _startDelaySeconds
+            return (
+                delay: _startDelaySecondsByUID[output.uid] ?? _startDelaySeconds,
+                blocker: _startBlockersByUID[output.uid]
+            )
         }
-        if delay > 0 {
-            Thread.sleep(forTimeInterval: delay)
+        startControl.blocker?.waitUntilUnblocked()
+        if startControl.delay > 0 {
+            Thread.sleep(forTimeInterval: startControl.delay)
         }
         if let startError = withLock({ _startError }) {
             withLock {
@@ -1956,5 +1986,23 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         lock.lock()
         defer { lock.unlock() }
         return body()
+    }
+}
+
+private final class FakeStartBlocker: @unchecked Sendable {
+    private let entered = DispatchSemaphore(value: 0)
+    private let release = DispatchSemaphore(value: 0)
+
+    func waitUntilUnblocked() {
+        entered.signal()
+        _ = release.wait(timeout: .now() + 5)
+    }
+
+    func waitUntilEntered(timeout: DispatchTime) -> Bool {
+        entered.wait(timeout: timeout) == .success
+    }
+
+    func unblock() {
+        release.signal()
     }
 }

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -901,6 +901,29 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsApplyProfileRejectsDisabledFilterOverloadWithoutMutation() async throws {
+        let model = makeModel()
+        let initialStore = model.profileStore
+        let initialActiveProfile = model.activeProfile
+        var overloaded = model.activeProfile
+        overloaded.filters = (0...ProfilePersistence.maxFiltersPerChannel).map {
+            EQFilter(kind: .peak, frequency: Double($0 + 1), gainDB: 0, q: 1, isEnabled: false)
+        }
+
+        await #expect(throws: ProfileStoreValidationError.tooManyFilters(
+            profileID: overloaded.id,
+            channel: "linked",
+            count: ProfilePersistence.maxFiltersPerChannel + 1,
+            maximum: ProfilePersistence.maxFiltersPerChannel
+        )) {
+            _ = try await model.performSettingsCommand(.applyProfile(overloaded))
+        }
+
+        #expect(model.profileStore == initialStore)
+        #expect(model.activeProfile == initialActiveProfile)
+    }
+
+    @Test
     func settingsCreateProfileAtLimitThrowsWithoutMutation() async throws {
         let store = makeStore(profileCount: ProfilePersistence.profileCountRange.upperBound)
         let model = makeModel(store: store)
@@ -915,6 +938,35 @@ struct GlassEQAppModelLifecycleTests {
 
         #expect(model.profileStore == store)
         #expect(model.selectedProfileID == initialSelection)
+    }
+
+    @Test
+    func settingsDuplicateUsesExplicitProfileID() async throws {
+        let first = makeProfile(name: "First")
+        let second = makeProfile(name: "Second")
+        let store = ProfileStore(profiles: [first, second], fallbackProfileID: first.id)
+        let model = makeModel(store: store)
+        model.selectProfile(first.id)
+
+        let response = try await model.performSettingsCommand(.duplicateProfile(second.id))
+
+        let snapshot = try #require(response.snapshot)
+        #expect(snapshot.profiles.count == 3)
+        #expect(snapshot.draftProfile.name == "Second Copy")
+        #expect(snapshot.draftProfile.id != second.id)
+        #expect(snapshot.selectedProfileID == snapshot.draftProfile.id)
+    }
+
+    @Test
+    func settingsDuplicateStaleIDThrowsWithoutDuplicatingSelectedProfile() async throws {
+        let model = makeModel()
+        let initialStore = model.profileStore
+
+        await #expect(throws: SettingsCommandFailure.self) {
+            _ = try await model.performSettingsCommand(.duplicateProfile(UUID()))
+        }
+
+        #expect(model.profileStore == initialStore)
     }
 
     @Test
@@ -974,32 +1026,104 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
-    func settingsDuplicateUsesExplicitProfileID() async throws {
-        let first = makeProfile(name: "First")
-        let second = makeProfile(name: "Second")
-        let store = ProfileStore(profiles: [first, second], fallbackProfileID: first.id)
-        let model = makeModel(store: store)
-        model.selectProfile(first.id)
+    func unsupportedSchemaStoreIsProtectedUntilExplicitReset() async throws {
+        let storeURL = temporaryAppStoreURL()
+        defer { removeTemporaryStoreDirectory(for: storeURL) }
+        let futureProfile = makeProfile(name: "Future Profile")
+        let futureStore = ProfileStore(
+            schemaVersion: ProfileStore.currentSchemaVersion + 1,
+            profiles: [futureProfile],
+            fallbackProfileID: futureProfile.id
+        )
+        let futureData = try ProfilePersistence.encoder.encode(futureStore)
+        try FileManager.default.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try futureData.write(to: storeURL)
 
-        let response = try await model.performSettingsCommand(.duplicateProfile(second.id))
+        let model = GlassEQAppModel(
+            storeURL: storeURL,
+            engine: FakeAudioEngine(),
+            defaultOutputLookup: FakeDefaultOutputLookup(.success(makeOutput())),
+            observerFactory: FakeDefaultOutputObserverFactory(),
+            autoStart: false,
+            installLifecycleObservers: false,
+            registerAppDelegate: false
+        )
 
+        #expect(model.settingsSnapshot().profileStoreProtection.isProtected)
+        #expect(model.profileStore.profiles == ProfileStore.defaultProfiles)
+        #expect(await model.flushStoreBeforeQuit())
+        #expect(try Data(contentsOf: storeURL) == futureData)
+
+        await #expect(throws: SettingsCommandFailure.self) {
+            _ = try await model.performSettingsCommand(.createProfile(.parametric))
+        }
+        await #expect(throws: SettingsCommandFailure.self) {
+            _ = try await model.performSettingsCommand(.applyProfile(model.activeProfile))
+        }
+        #expect(try Data(contentsOf: storeURL) == futureData)
+
+        let response = try await model.performSettingsCommand(.resetUnsupportedProfileStore)
         let snapshot = try #require(response.snapshot)
-        #expect(snapshot.profiles.count == 3)
-        #expect(snapshot.draftProfile.name == "Second Copy")
-        #expect(snapshot.draftProfile.id != second.id)
-        #expect(snapshot.selectedProfileID == snapshot.draftProfile.id)
+        #expect(!snapshot.profileStoreProtection.isProtected)
+        #expect(try ProfilePersistence.decode(Data(contentsOf: storeURL)).profiles == ProfileStore.defaultProfiles)
+
+        let backups = try FileManager.default.contentsOfDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            includingPropertiesForKeys: nil
+        )
+            .filter { $0.lastPathComponent.hasPrefix("Profiles.invalid-") }
+        #expect(backups.count == 1)
+        if let backup = backups.first {
+            #expect(try Data(contentsOf: backup) == futureData)
+        }
+
+        _ = try await model.performSettingsCommand(.createProfile(.parametric))
+        #expect(model.profileStore.profiles.count == ProfileStore.defaultProfiles.count + 1)
     }
 
     @Test
-    func settingsDuplicateStaleIDThrowsWithoutDuplicatingSelectedProfile() async throws {
-        let model = makeModel()
-        let initialStore = model.profileStore
+    func preservedRunningProfileUpdateFailureRevertsModelToRunningProfile() async throws {
+        let running = makeProfile(name: "Running")
+        let requested = makeProfile(name: "Requested")
+        let output = makeOutput(uid: "preserved-output", name: "Preserved Output")
+        let store = ProfileStore(profiles: [running, requested], fallbackProfileID: running.id)
+        let engine = FakeAudioEngine()
+        let observers = FakeDefaultOutputObserverFactory()
+        let lookup = FakeDefaultOutputLookup(.success(output))
+        let model = makeModel(
+            store: store,
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero
+        )
 
-        await #expect(throws: SettingsCommandFailure.self) {
-            _ = try await model.performSettingsCommand(.duplicateProfile(UUID()))
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+        engine.updateDSPResult = false
+        engine.updateError = TestAudioError.updateFailed
+        engine.updateErrorPreservesRunningState = true
+
+        try model.apply(profile: requested)
+
+        await waitUntil {
+            engine.updateCalls.count == 1 && model.statusMessage.contains("not applied")
         }
 
-        #expect(model.profileStore == initialStore)
+        #expect(model.lifecycleState == .running)
+        #expect(model.isRunning)
+        #expect(model.currentOutputUID == output.uid)
+        #expect(model.activeProfile == running)
+        #expect(model.selectedProfileID == running.id)
+        #expect(model.draftProfile == running)
+        #expect(model.profileStore == store)
+        #expect(engine.state == .running(output: output))
     }
 
     @Test
@@ -1342,6 +1466,16 @@ private func makeOutput(
     )
 }
 
+private func temporaryAppStoreURL() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("GlassEQAppTests-\(UUID().uuidString)", isDirectory: true)
+        .appendingPathComponent("Profiles.json")
+}
+
+private func removeTemporaryStoreDirectory(for url: URL) {
+    try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+}
+
 private func makeFakeAppBundle(
     at appURL: URL,
     bundleIdentifier: String,
@@ -1388,6 +1522,7 @@ private func waitUntil(_ predicate: @MainActor () -> Bool) async {
 
 private enum TestAudioError: Error {
     case startFailed
+    case updateFailed
     case defaultOutputUnavailable
 }
 

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -199,6 +199,35 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
+    func monoSourceDuplicatesIntoSingleInterleavedStereoOutputBuffer() {
+        let samples: [Float] = [1, 2]
+        var destination: [Float] = [-1, -1, -1, -1, -1, -1]
+
+        samples.withUnsafeBufferPointer { source in
+            destination.withUnsafeMutableBufferPointer { destinationBuffer in
+                let audioBuffer = AudioBuffer(
+                    mNumberChannels: 2,
+                    mDataByteSize: UInt32(destinationBuffer.count * MemoryLayout<Float>.stride),
+                    mData: destinationBuffer.baseAddress
+                )
+                var audioBufferList = AudioBufferList(mNumberBuffers: 1, mBuffers: audioBuffer)
+                withUnsafeMutablePointer(to: &audioBufferList) { audioBufferListPointer in
+                    SystemTapAudioEngine.copyInterleavedSamples(
+                        source,
+                        sourceFrameOffset: 0,
+                        destinationFrameOffset: 1,
+                        frameCount: 2,
+                        sourceChannelCount: 1,
+                        to: UnsafeMutableAudioBufferListPointer(audioBufferListPointer)
+                    )
+                }
+            }
+        }
+
+        #expect(destination == [-1, -1, 1, 1, 2, 2])
+    }
+
+    @Test
     func preferredBufferFrameSizeShrinksStandardSpeakerRoutesForLowLatency() {
         #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 128)) == 256)
         #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 512)) == 256)

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -59,6 +59,27 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
+    func unsupportedRuntimeChannelCountSkipsDevicePreparation() {
+        var didPrepareDevice = false
+
+        do {
+            _ = try SystemTapAudioEngine.performAfterRuntimeChannelValidation(
+                for: output(channelCount: 6, sampleRate: 44_100)
+            ) {
+                didPrepareDevice = true
+                return output(channelCount: 6, sampleRate: 48_000)
+            }
+            Issue.record("Expected multichannel output to be rejected")
+        } catch let error as AudioDeviceAvailabilityError {
+            #expect(error == .unsupportedOutputChannelCount(42, 6))
+        } catch {
+            Issue.record("Expected unsupported channel count error, got \(error)")
+        }
+
+        #expect(!didPrepareDevice)
+    }
+
+    @Test
     func outputDeviceUIDLookupResolvesDefaultOutput() throws {
         let defaultOutput = try CoreAudioDeviceQuery.defaultOutputDevice()
         let resolvedOutput = try #require(try CoreAudioDeviceQuery.outputDevice(uid: defaultOutput.uid))
@@ -66,6 +87,55 @@ struct CoreAudioDeviceTests {
         #expect(resolvedOutput.uid == defaultOutput.uid)
         #expect(resolvedOutput.outputChannelCount > 0)
         #expect(try CoreAudioDeviceQuery.outputDevice(uid: "") == nil)
+    }
+
+    @Test
+    func sampleRateMutationRecordsRestorationBeforeDeviceWrite() throws {
+        let output = output(uid: "record-before-set", channelCount: 2, sampleRate: 44_100)
+        var events: [String] = []
+
+        try SystemTapAudioEngine.setSampleRateAfterRecordingRestoration(
+            48_000,
+            on: output,
+            needsRestoration: true,
+            recordRestoration: { restoration in
+                #expect(restoration.uid == output.uid)
+                #expect(restoration.originalSampleRate == 44_100)
+                events.append("record")
+            },
+            installRestoration: { restoration in
+                #expect(restoration.uid == output.uid)
+                events.append("install")
+            },
+            setSampleRate: { sampleRate, objectID in
+                #expect(sampleRate == 48_000)
+                #expect(objectID == output.id)
+                events.append("set")
+            }
+        )
+
+        #expect(events == ["record", "install", "set"])
+    }
+
+    @Test
+    func sampleRateMutationSkipsDeviceWriteWhenRestorationRecordFails() {
+        let output = output(uid: "record-fails", channelCount: 2, sampleRate: 44_100)
+        var didInstall = false
+        var didSet = false
+
+        #expect(throws: TestDeviceMutationError.recordFailed) {
+            try SystemTapAudioEngine.setSampleRateAfterRecordingRestoration(
+                48_000,
+                on: output,
+                needsRestoration: true,
+                recordRestoration: { _ in throw TestDeviceMutationError.recordFailed },
+                installRestoration: { _ in didInstall = true },
+                setSampleRate: { _, _ in didSet = true }
+            )
+        }
+
+        #expect(!didInstall)
+        #expect(!didSet)
     }
 
     @Test
@@ -179,6 +249,97 @@ struct CoreAudioDeviceTests {
 
         #expect(restored)
         #expect(!didSet)
+    }
+
+    @Test
+    func persistedDeviceRestorationRestoresAndClearsVerifiedSettings() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQDeviceRestoration-\(UUID().uuidString).json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+        try PersistedAudioDeviceRestorationStore.recordSampleRate(uid: "dac", originalSampleRate: 48_000, at: url)
+        try PersistedAudioDeviceRestorationStore.recordBufferFrameSize(uid: "dac", originalFrameSize: 256, at: url)
+        var sampleRate = 44_100.0
+        var frameSize: UInt32 = 512
+
+        SystemTapAudioEngine.restorePersistedDeviceSettings(
+            at: url,
+            outputForUID: { uid in
+                output(uid: uid, channelCount: 2, sampleRate: sampleRate, bufferFrameSize: frameSize)
+            },
+            setSampleRate: { nextSampleRate, _ in
+                sampleRate = nextSampleRate
+            },
+            setBufferFrameSize: { nextFrameSize, _ in
+                frameSize = nextFrameSize
+            }
+        )
+
+        #expect(PersistedAudioDeviceRestorationStore.load(from: url).isEmpty)
+        #expect(sampleRate == 48_000)
+        #expect(frameSize == 256)
+    }
+
+    @Test
+    func persistedDeviceRestorationKeepsUnavailableDeviceRecords() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQDeviceRestoration-\(UUID().uuidString).json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+        try PersistedAudioDeviceRestorationStore.recordSampleRate(uid: "missing", originalSampleRate: 48_000, at: url)
+
+        SystemTapAudioEngine.restorePersistedDeviceSettings(
+            at: url,
+            outputForUID: { _ in nil },
+            setSampleRate: { _, _ in Issue.record("Unexpected sample-rate write") },
+            setBufferFrameSize: { _, _ in Issue.record("Unexpected buffer-size write") }
+        )
+
+        #expect(PersistedAudioDeviceRestorationStore.load(from: url)["missing"]?.originalSampleRate == 48_000)
+    }
+
+    @Test
+    func persistedDeviceRestorationDoesNotOverwritePendingOriginals() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQDeviceRestoration-\(UUID().uuidString).json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        try PersistedAudioDeviceRestorationStore.recordSampleRate(uid: "dac", originalSampleRate: 48_000, at: url)
+        try PersistedAudioDeviceRestorationStore.recordSampleRate(uid: "dac", originalSampleRate: 44_100, at: url)
+        try PersistedAudioDeviceRestorationStore.recordBufferFrameSize(uid: "dac", originalFrameSize: 256, at: url)
+        try PersistedAudioDeviceRestorationStore.recordBufferFrameSize(uid: "dac", originalFrameSize: 512, at: url)
+
+        let record = try #require(PersistedAudioDeviceRestorationStore.load(from: url)["dac"])
+        #expect(record.originalSampleRate == 48_000)
+        #expect(record.originalBufferFrameSize == 256)
+    }
+
+    @Test
+    func persistedDeviceRestorationFoldsDuplicateUIDRecordsWithoutTrapping() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQDeviceRestoration-\(UUID().uuidString).json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+        let records = [
+            PersistedAudioDeviceRestorationRecord(uid: "dac", originalSampleRate: 48_000),
+            PersistedAudioDeviceRestorationRecord(uid: "dac", originalSampleRate: 44_100),
+            PersistedAudioDeviceRestorationRecord(uid: "dac", originalBufferFrameSize: 256),
+            PersistedAudioDeviceRestorationRecord(uid: "dac", originalBufferFrameSize: 512),
+            PersistedAudioDeviceRestorationRecord(uid: "headphones", originalBufferFrameSize: 1_024)
+        ]
+        try JSONEncoder().encode(records).write(to: url)
+
+        let loaded = PersistedAudioDeviceRestorationStore.load(from: url)
+
+        let dac = try #require(loaded["dac"])
+        #expect(dac.originalSampleRate == 48_000)
+        #expect(dac.originalBufferFrameSize == 256)
+        #expect(loaded["headphones"]?.originalBufferFrameSize == 1_024)
     }
 
     @Test
@@ -314,6 +475,49 @@ struct CoreAudioDeviceTests {
             deviceID: 42,
             selfChangeGuard: changeGuard
         ))
+    }
+
+    @Test
+    func refreshCoalescerRunsOnlyLatestScheduledAction() {
+        let queue = DispatchQueue(label: "com.glasseq.tests.refresh-coalescer")
+        let coalescer = DispatchRefreshCoalescer(queue: queue, delay: .milliseconds(10))
+        let counter = LockedCounter()
+
+        queue.sync {
+            coalescer.schedule {
+                counter.increment()
+            }
+            coalescer.schedule {
+                counter.increment()
+            }
+            coalescer.schedule {
+                counter.increment()
+            }
+        }
+
+        Thread.sleep(forTimeInterval: 0.05)
+        queue.sync {}
+
+        #expect(counter.value == 1)
+    }
+
+    @Test
+    func refreshCoalescerCancelSuppressesPendingAction() {
+        let queue = DispatchQueue(label: "com.glasseq.tests.refresh-coalescer-cancel")
+        let coalescer = DispatchRefreshCoalescer(queue: queue, delay: .milliseconds(10))
+        let counter = LockedCounter()
+
+        queue.sync {
+            coalescer.schedule {
+                counter.increment()
+            }
+            coalescer.cancelPending()
+        }
+
+        Thread.sleep(forTimeInterval: 0.05)
+        queue.sync {}
+
+        #expect(counter.value == 0)
     }
 
     @Test
@@ -465,6 +669,29 @@ struct CoreAudioDeviceTests {
             bufferFrameSize: bufferFrameSize,
             transportType: transportType
         )
+    }
+}
+
+private enum TestDeviceMutationError: Error {
+    case recordFailed
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return count
     }
 }
 

--- a/Tests/GlassEQAudioTests/RealtimeAudioRingBufferTests.swift
+++ b/Tests/GlassEQAudioTests/RealtimeAudioRingBufferTests.swift
@@ -1,4 +1,6 @@
 @testable import GlassEQAudio
+import Foundation
+import Synchronization
 import Testing
 
 @Suite
@@ -51,6 +53,32 @@ struct RealtimeAudioRingBufferTests {
         #expect(output == [2])
         _ = output.withUnsafeMutableBufferPointer { ring.read(into: $0) }
         #expect(output == [3])
+    }
+
+    @Test
+    func overwriteAfterReadAdvancesFromCurrentReadFrame() {
+        let ring = RealtimeAudioRingBuffer(channelCount: 1, capacityFrames: 4)
+        let first: [Float] = [1, 2, 3]
+        let second: [Float] = [4, 5, 6, 7]
+        var discarded = [Float](repeating: 0, count: 1)
+        var output = [Float](repeating: 0, count: 4)
+
+        _ = first.withUnsafeBufferPointer {
+            ring.writeInterleaved($0, frameCount: 3, sourceChannelCount: 1)
+        }
+        _ = discarded.withUnsafeMutableBufferPointer {
+            ring.readInterleaved(into: $0, frameCount: 1, destinationChannelCount: 1)
+        }
+        let result = second.withUnsafeBufferPointer {
+            ring.writeInterleaved($0, frameCount: 4, sourceChannelCount: 1)
+        }
+        let readFrames = output.withUnsafeMutableBufferPointer {
+            ring.readInterleaved(into: $0, frameCount: 4, destinationChannelCount: 1)
+        }
+
+        #expect(result == RingBufferWriteResult(writtenFrames: 4, droppedInputFrames: 0, droppedBufferedFrames: 2))
+        #expect(readFrames == 4)
+        #expect(output == [4, 5, 6, 7])
     }
 
     @Test
@@ -198,5 +226,61 @@ struct RealtimeAudioRingBufferTests {
         }
         #expect(readFrames == 2)
         #expect(output == [4, 5])
+    }
+
+    @Test
+    func concurrentProducerConsumerKeepsReadFramesMonotonic() {
+        let ring = RealtimeAudioRingBuffer(channelCount: 1, capacityFrames: 64)
+        let producerDone = Atomic<Bool>(false)
+        let sawOutOfOrderFrame = Atomic<Bool>(false)
+        let consumedFrameCount = Atomic<Int>(0)
+        let totalFrames = 20_000
+        let group = DispatchGroup()
+
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            var frame = [Float](repeating: 0, count: 1)
+            for value in 1...totalFrames {
+                frame[0] = Float(value)
+                frame.withUnsafeBufferPointer {
+                    ring.write($0)
+                }
+                if value.isMultiple(of: 17) {
+                    Thread.sleep(forTimeInterval: 0.000_001)
+                }
+            }
+            producerDone.store(true, ordering: .releasing)
+            group.leave()
+        }
+
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            var lastFrame = 0
+            var frame = [Float](repeating: 0, count: 1)
+            while !producerDone.load(ordering: .acquiring) || ring.occupancyFrames() > 0 {
+                let hadData = frame.withUnsafeMutableBufferPointer {
+                    ring.read(into: $0)
+                }
+                guard hadData else {
+                    Thread.sleep(forTimeInterval: 0.000_001)
+                    continue
+                }
+
+                let currentFrame = Int(frame[0])
+                if currentFrame <= lastFrame {
+                    sawOutOfOrderFrame.store(true, ordering: .releasing)
+                    break
+                }
+                lastFrame = currentFrame
+                _ = consumedFrameCount.wrappingAdd(1, ordering: .relaxed)
+            }
+            group.leave()
+        }
+
+        #expect(group.wait(timeout: .now() + 5) == .success)
+        let outOfOrder = sawOutOfOrderFrame.load(ordering: .acquiring)
+        let consumed = consumedFrameCount.load(ordering: .acquiring)
+        #expect(!outOfOrder)
+        #expect(consumed > 0)
     }
 }

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -75,6 +75,25 @@ struct EQCoreTests {
     }
 
     @Test
+    func recommendedPreampFallbackUsesQuieterStereoPreamp() {
+        let profile = EQProfile(
+            name: "Stereo Cut",
+            mode: .parametric,
+            channelMode: .stereo,
+            preampDB: 0,
+            filters: [],
+            leftPreampDB: -3,
+            leftFilters: [EQFilter(kind: .peak, frequency: 1_000, gainDB: -6, q: 1)],
+            rightPreampDB: -9,
+            rightFilters: [EQFilter(kind: .peak, frequency: 1_000, gainDB: -3, q: 1)]
+        )
+
+        let recommended = EQProfileAnalysis.recommendedPreampDB(profile: profile, sampleRate: 48_000)
+
+        #expect(recommended == -9)
+    }
+
+    @Test
     func bypassLeavesSamplesUntouched() {
         var profile = EQProfile(
             name: "Bypass",

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -341,6 +341,57 @@ struct EQCoreTests {
     }
 
     @Test
+    func realtimeCompatiblePreparedConfigurationUpdatesConfigAndResetsChangedState() throws {
+        let initial = EQProfile(
+            name: "Initial",
+            mode: .parametric,
+            preampDB: -2,
+            filters: [
+                EQFilter(kind: .peak, frequency: 500, gainDB: 8, q: 1),
+                EQFilter(kind: .highShelf, frequency: 8_000, gainDB: 1, q: 0.7)
+            ]
+        )
+        var updated = initial
+        updated.name = "Updated"
+        updated.preampDB = -4
+        updated.filters[0].frequency = 2_000
+        updated.filters[0].gainDB = -8
+        updated.filters[1].frequency = 10_000
+        updated.filters[1].gainDB = -3
+        updated.isBypassed = true
+
+        var processor = EQProcessor(configuration: EQConfiguration(profile: initial, sampleRate: 48_000, channelCount: 2))
+        var warmup = makeStereoTestBlock(frameCount: 512, sampleRate: 48_000)
+        processor.processInterleaved(&warmup, channelCount: 2)
+
+        let retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(
+            EQRenderConfiguration(profile: updated, sampleRate: 48_000, channelCount: 2)
+        )
+
+        #expect(retiredStorage != nil)
+        #expect(processor.configuration.isBypassed)
+        #expect(processor.configuration.preampLinearGain == EQConfiguration(
+            profile: updated,
+            sampleRate: 48_000,
+            channelCount: 2
+        ).preampLinearGain)
+
+        updated.isBypassed = false
+        _ = processor.applyRealtimeCompatiblePreparedConfiguration(
+            EQRenderConfiguration(profile: updated, sampleRate: 48_000, channelCount: 2)
+        )
+        var fresh = EQProcessor(configuration: EQConfiguration(profile: updated, sampleRate: 48_000, channelCount: 2))
+        var warmedNext = makeStereoTestBlock(frameCount: 128, sampleRate: 48_000)
+        var freshNext = warmedNext
+
+        processor.processInterleaved(&warmedNext, channelCount: 2)
+        fresh.processInterleaved(&freshNext, channelCount: 2)
+
+        let maxDelta = zip(warmedNext, freshNext).map { abs($0 - $1) }.max() ?? 0
+        #expect(maxDelta < 0.000_001)
+    }
+
+    @Test
     func identicalPreparedConfigurationPreservesWarmedState() {
         let profile = EQProfile(
             name: "Stateful",
@@ -353,13 +404,16 @@ struct EQCoreTests {
 
         var withoutApply = processor
         var withIdenticalApply = processor
-        withIdenticalApply.applyPreparedConfiguration(EQRenderConfiguration(profile: profile, sampleRate: 48_000, channelCount: 2))
+        let retiredStorage = withIdenticalApply.applyRealtimeCompatiblePreparedConfiguration(
+            EQRenderConfiguration(profile: profile, sampleRate: 48_000, channelCount: 2)
+        )
 
         var expected = makeStereoTestBlock(frameCount: 128, sampleRate: 48_000)
         var actual = expected
         withoutApply.processInterleaved(&expected, channelCount: 2)
         withIdenticalApply.processInterleaved(&actual, channelCount: 2)
 
+        #expect(retiredStorage != nil)
         #expect(actual == expected)
     }
 

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import GlassEQCore
 import Foundation
 import Testing
@@ -271,6 +272,9 @@ struct EQCoreTests {
 
     @Test
     func dspCallbackPathStaysWithinGenerousDebugBudget() {
+        guard !isThreadSanitizerRuntimeLoaded else {
+            return
+        }
         let profile = EQProfile.flatGraphic31
         var processor = EQProcessor(configuration: EQConfiguration(profile: profile, sampleRate: 48_000, channelCount: 2))
         var samples = makeStereoTestBlock(frameCount: 256, sampleRate: 48_000)
@@ -613,4 +617,16 @@ struct EQCoreTests {
         }
         return value
     }
+}
+
+private var isThreadSanitizerRuntimeLoaded: Bool {
+    for index in 0..<_dyld_image_count() {
+        guard let imageName = _dyld_get_image_name(index) else {
+            continue
+        }
+        if String(cString: imageName).contains("libclang_rt.tsan") {
+            return true
+        }
+    }
+    return false
 }

--- a/Tests/GlassEQCoreTests/ProfileImporterTests.swift
+++ b/Tests/GlassEQCoreTests/ProfileImporterTests.swift
@@ -64,6 +64,53 @@ struct ProfileImporterTests {
     }
 
     @Test
+    func importsEqualizerAPOChannelPreampsWithoutFiltersAsStereoProfile() throws {
+        let text = """
+        Preamp: -1 dB
+
+        Channel: L
+        Preamp: -3 dB
+
+        Channel: R
+        Preamp: -4 dB
+        """
+
+        let profile = try EQProfileTextImporter.importAutoEQ(text)
+
+        #expect(profile.channelMode == .stereo)
+        #expect(profile.preampDB == -1)
+        #expect(profile.leftPreampDB == -3)
+        #expect(profile.rightPreampDB == -4)
+        #expect(profile.filters.isEmpty)
+        #expect(profile.leftFilters.isEmpty)
+        #expect(profile.rightFilters.isEmpty)
+    }
+
+    @Test
+    func importsEqualizerAPOChannelPreampsWithLinkedFiltersAsStereoFallback() throws {
+        let text = """
+        Preamp: -1 dB
+        Filter 1: ON PK Fc 1000 Hz Gain 2 dB Q 1
+
+        Channel: L
+        Preamp: -3 dB
+
+        Channel: R
+        Preamp: -4 dB
+        """
+
+        let profile = try EQProfileTextImporter.importAutoEQ(text)
+
+        #expect(profile.channelMode == .stereo)
+        #expect(profile.preampDB == -1)
+        #expect(profile.leftPreampDB == -3)
+        #expect(profile.rightPreampDB == -4)
+        #expect(profile.filters.count == 1)
+        #expect(profile.leftFilters == profile.filters)
+        #expect(profile.rightFilters == profile.filters)
+    }
+
+    @Test
     func importsREWText() throws {
         let text = """
         Filter 1: ON PK Fc 45.0 Hz Gain -4.5 dB Q 3.20
@@ -76,6 +123,87 @@ struct ProfileImporterTests {
         #expect(profile.filters[0].frequency == 45)
         #expect(profile.filters[0].gainDB == -4.5)
         #expect(profile.filters[0].q == 3.2)
+    }
+
+    @Test
+    func importsREWFilterKindsAndDecimalCommas() throws {
+        let text = """
+        Filter 1: ON LS Fc 80,5 Hz Gain 3,5 dB Q 0,70
+        Filter 2: ON HS Fc 12000 Hz Gain -2 dB Q 0.80
+        Filter 3: ON HP Fc 30 Hz Gain 0 dB Q 0.707
+        Filter 4: ON LP Fc 18000 Hz Gain 0 dB Q 0.707
+        """
+
+        let profile = try EQProfileTextImporter.importREW(text)
+
+        #expect(profile.filters.map(\.kind) == [.lowShelf, .highShelf, .highPass, .lowPass])
+        #expect(profile.filters[0].frequency == 80.5)
+        #expect(profile.filters[0].gainDB == 3.5)
+        #expect(profile.filters[0].q == 0.7)
+    }
+
+    @Test
+    func importsREWMissingQAsDefaultInsteadOfLastNumericToken() throws {
+        let profile = try EQProfileTextImporter.importREW("Filter 1: ON PK Fc 45.0 Hz Gain -4.5 dB")
+
+        #expect(profile.filters.count == 1)
+        #expect(profile.filters[0].q == 0.707_106_781_18)
+    }
+
+    @Test
+    func rejectsHexFloatNumericTokens() throws {
+        do {
+            _ = try EQProfileTextImporter.importREW("Filter 1: ON PK Fc 0x1p10 Hz Gain 0 dB Q 1")
+            Issue.record("Expected hex float to fail")
+        } catch let error as ProfileImportError {
+            #expect(error == .invalidNumber(line: 1, field: "frequency", value: "0x1p10"))
+        }
+    }
+
+    @Test
+    func importsGraphicProfileRoundTripAsGraphicMode() throws {
+        let exported = EQProfileTextExporter.exportEqualizerAPO(.flatGraphic10)
+
+        let profile = try EQProfileTextImporter.importAutoEQ(exported)
+
+        #expect(profile.mode == .graphic10)
+        #expect(profile.filters.count == GraphicEQBands.tenBand.count)
+    }
+
+    @Test
+    func importsGraphicBandFrequenciesWithNonGraphicQAsParametric() throws {
+        let text = GraphicEQBands.tenBand.enumerated().map { index, frequency in
+            "Filter \(index + 1): ON PK Fc \(frequency) Hz Gain 0 dB Q 1.00"
+        }.joined(separator: "\n")
+
+        let profile = try EQProfileTextImporter.importAutoEQ(text)
+
+        #expect(profile.mode == .parametric)
+        #expect(profile.filters.map(\.frequency) == GraphicEQBands.tenBand)
+    }
+
+    @Test
+    func importsStereoGraphicProfileAndPersistsWithEmptyLinkedFilters() throws {
+        let stereoGraphic = EQProfile(
+            name: "Stereo Graphic",
+            mode: .graphic10,
+            channelMode: .stereo,
+            filters: [],
+            leftFilters: EQProfile.flatGraphic10.filters,
+            rightFilters: EQProfile.flatGraphic10.filters
+        )
+        let exported = EQProfileTextExporter.exportEqualizerAPO(stereoGraphic)
+
+        let profile = try EQProfileTextImporter.importAutoEQ(exported)
+        let store = ProfileStore(profiles: [profile], fallbackProfileID: profile.id)
+        let decoded = try ProfilePersistence.decode(ProfilePersistence.encode(store))
+
+        #expect(profile.mode == .graphic10)
+        #expect(profile.channelMode == .stereo)
+        #expect(profile.filters.isEmpty)
+        #expect(profile.leftFilters.count == GraphicEQBands.tenBand.count)
+        #expect(profile.rightFilters.count == GraphicEQBands.tenBand.count)
+        #expect(decoded.profiles == [profile])
     }
 
     @Test
@@ -149,14 +277,14 @@ struct ProfileImporterTests {
     func rejectsAutoEQNumericFieldsOutsideLimitsWithLineNumber() throws {
         let text = """
         Preamp: -3 dB
-        Filter 1: ON PK Fc 97000 Hz Gain 0 dB Q 1
+        Filter 1: ON PK Fc 25000 Hz Gain 0 dB Q 1
         """
 
         do {
             _ = try EQProfileTextImporter.importAutoEQ(text)
             Issue.record("Expected frequency limit to fail")
         } catch let error as ProfileImportError {
-            #expect(error == .valueOutOfRange(line: 2, field: "frequency", value: 97_000, range: 1...96_000))
+            #expect(error == .valueOutOfRange(line: 2, field: "frequency", value: 25_000, range: 1...24_000))
             #expect(error.errorDescription?.contains("Line 2") == true)
         }
     }

--- a/Tests/GlassEQCoreTests/ProfilePersistenceTests.swift
+++ b/Tests/GlassEQCoreTests/ProfilePersistenceTests.swift
@@ -31,7 +31,7 @@ struct ProfilePersistenceTests {
     }
 
     @Test
-    func loadLeavesInvalidOriginalUntouchedWhenBackupFails() throws {
+    func loadUsesUniqueInvalidBackupNameWhenTimestampCollides() throws {
         let url = try temporaryStoreURL()
         defer { removeTemporaryStoreDirectory(for: url) }
         let invalidData = Data("not json".utf8)
@@ -42,9 +42,14 @@ struct ProfilePersistenceTests {
 
         let result = ProfilePersistence.load(from: url, timestamp: timestamp)
 
-        #expect(result.status == .backupFailed)
+        guard case .recoveredDefaults(let recoveredBackupURL) = result.status else {
+            Issue.record("Expected invalid store recovery, got \(result.status)")
+            return
+        }
         #expect(result.store.profiles == ProfileStore.defaultProfiles)
-        #expect(try Data(contentsOf: url) == invalidData)
+        #expect(recoveredBackupURL != backupURL)
+        #expect(recoveredBackupURL.lastPathComponent.contains("-2"))
+        #expect(try Data(contentsOf: recoveredBackupURL) == invalidData)
         #expect(try Data(contentsOf: backupURL) == collisionData)
     }
 
@@ -63,6 +68,177 @@ struct ProfilePersistenceTests {
         }
         #expect((try Data(contentsOf: backupURL)).count == oversizedData.count)
         #expect(try ProfilePersistence.decode(Data(contentsOf: url)).profiles == ProfileStore.defaultProfiles)
+    }
+
+    @Test
+    func loadFutureSchemaUsesDefaultsWithoutModifyingStore() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let profile = EQProfile(name: "Future", mode: .parametric, filters: [])
+        let futureStore = ProfileStore(
+            schemaVersion: ProfileStore.currentSchemaVersion + 1,
+            profiles: [profile],
+            fallbackProfileID: profile.id
+        )
+        let data = try ProfilePersistence.encoder.encode(futureStore)
+        try data.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        #expect(result.store.profiles == ProfileStore.defaultProfiles)
+        #expect(result.status == .unsupportedSchemaVersion(
+            version: ProfileStore.currentSchemaVersion + 1,
+            maximumSupported: ProfileStore.currentSchemaVersion
+        ))
+        #expect(try Data(contentsOf: url) == data)
+    }
+
+    @Test
+    func loadRepairsInvalidProfileWithoutDroppingValidProfiles() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let valid = EQProfile(name: "Valid", mode: .parametric, filters: [])
+        let invalid = EQProfile(name: "", mode: .parametric, filters: [])
+        let store = ProfileStore(
+            profiles: [valid, invalid],
+            outputMappings: [
+                OutputDeviceProfileMapping(outputDeviceUID: "speaker", profileID: valid.id),
+                OutputDeviceProfileMapping(outputDeviceUID: "broken", profileID: invalid.id)
+            ],
+            fallbackProfileID: invalid.id
+        )
+        let invalidData = try ProfilePersistence.encoder.encode(store)
+        try invalidData.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        guard case .repairedInvalidStore(let backupURL, let summary) = result.status else {
+            Issue.record("Expected invalid profile repair, got \(result.status)")
+            return
+        }
+        #expect(try Data(contentsOf: backupURL) == invalidData)
+        #expect(result.store.profiles == [valid])
+        #expect(result.store.outputMappings == [OutputDeviceProfileMapping(outputDeviceUID: "speaker", profileID: valid.id)])
+        #expect(result.store.fallbackProfileID == valid.id)
+        #expect(summary.removedInvalidProfiles == 1)
+        #expect(summary.repairedFallbackProfileID)
+        #expect(summary.removedOutputMappings == 1)
+    }
+
+    @Test
+    func loadDropsProfileWithMalformedFilterWithoutResettingStore() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let valid = EQProfile(name: "Valid", mode: .parametric, filters: [])
+        let invalid = EQProfile(
+            name: "Malformed",
+            mode: .parametric,
+            filters: [EQFilter(kind: .peak, frequency: 1_000, gainDB: 1, q: 1)]
+        )
+        var invalidObject = try profileJSONObject(invalid)
+        var filters = try #require(invalidObject["filters"] as? [[String: Any]])
+        filters[0]["frequency"] = "not-a-number"
+        invalidObject["filters"] = filters
+        let invalidData = try rawStoreData(
+            profiles: [
+                try profileJSONObject(valid),
+                invalidObject
+            ],
+            outputMappings: [
+                OutputDeviceProfileMapping(outputDeviceUID: "speaker", profileID: valid.id),
+                OutputDeviceProfileMapping(outputDeviceUID: "broken", profileID: invalid.id)
+            ],
+            fallbackProfileID: invalid.id
+        )
+        try invalidData.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        guard case .repairedInvalidStore(let backupURL, let summary) = result.status else {
+            Issue.record("Expected malformed profile repair, got \(result.status)")
+            return
+        }
+        #expect(try Data(contentsOf: backupURL) == invalidData)
+        #expect(result.store.profiles == [valid])
+        #expect(result.store.outputMappings == [
+            OutputDeviceProfileMapping(outputDeviceUID: "speaker", profileID: valid.id)
+        ])
+        #expect(result.store.fallbackProfileID == valid.id)
+        #expect(summary.removedInvalidProfiles == 1)
+        #expect(summary.removedOutputMappings == 1)
+        #expect(summary.repairedFallbackProfileID)
+        #expect(try ProfilePersistence.decode(Data(contentsOf: url)) == result.store)
+    }
+
+    @Test
+    func loadRecoversDefaultsWhenAllProfilesFailRepairableDecode() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let invalid = EQProfile(
+            name: "Malformed",
+            mode: .parametric,
+            filters: [EQFilter(kind: .peak, frequency: 1_000, gainDB: 1, q: 1)]
+        )
+        var invalidObject = try profileJSONObject(invalid)
+        var filters = try #require(invalidObject["filters"] as? [[String: Any]])
+        filters[0]["q"] = "bad-q"
+        invalidObject["filters"] = filters
+        let invalidData = try rawStoreData(
+            profiles: [invalidObject],
+            outputMappings: [
+                OutputDeviceProfileMapping(outputDeviceUID: "broken", profileID: invalid.id)
+            ],
+            fallbackProfileID: invalid.id
+        )
+        try invalidData.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        guard case .recoveredDefaults(let backupURL) = result.status else {
+            Issue.record("Expected malformed store recovery, got \(result.status)")
+            return
+        }
+        #expect(try Data(contentsOf: backupURL) == invalidData)
+        #expect(result.store.profiles == ProfileStore.defaultProfiles)
+        #expect(try ProfilePersistence.decode(Data(contentsOf: url)).profiles == ProfileStore.defaultProfiles)
+    }
+
+    @Test
+    func loadRepairsDuplicateProfileIDsByKeepingFirstProfile() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let duplicateID = UUID()
+        let first = EQProfile(id: duplicateID, name: "First", mode: .parametric, filters: [])
+        let duplicate = EQProfile(id: duplicateID, name: "Duplicate", mode: .parametric, filters: [])
+        let valid = EQProfile(name: "Valid", mode: .parametric, filters: [])
+        let missingProfileID = UUID()
+        let store = ProfileStore(
+            profiles: [first, duplicate, valid],
+            outputMappings: [
+                OutputDeviceProfileMapping(outputDeviceUID: "speaker", profileID: duplicateID),
+                OutputDeviceProfileMapping(outputDeviceUID: "missing", profileID: missingProfileID)
+            ],
+            fallbackProfileID: missingProfileID
+        )
+        let invalidData = try ProfilePersistence.encoder.encode(store)
+        try invalidData.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        guard case .repairedInvalidStore(let backupURL, let summary) = result.status else {
+            Issue.record("Expected invalid store repair, got \(result.status)")
+            return
+        }
+        #expect(try Data(contentsOf: backupURL) == invalidData)
+        #expect(result.store.profiles == [first, valid])
+        #expect(result.store.outputMappings == [
+            OutputDeviceProfileMapping(outputDeviceUID: "speaker", profileID: duplicateID)
+        ])
+        #expect(result.store.fallbackProfileID == first.id)
+        #expect(summary.removedInvalidProfiles == 1)
+        #expect(summary.repairedFallbackProfileID)
+        #expect(summary.removedOutputMappings == 1)
+        #expect(try ProfilePersistence.decode(Data(contentsOf: url)) == result.store)
     }
 
     @Test
@@ -128,6 +304,14 @@ struct ProfilePersistenceTests {
         try expectValidationFailure(
             ProfileStore(profiles: [profile], fallbackProfileID: missingFallbackID),
             expected: .missingFallbackProfile(profileID: missingFallbackID)
+        )
+
+        let duplicateID = UUID()
+        let firstDuplicate = EQProfile(id: duplicateID, name: "First", mode: .parametric, filters: [])
+        let secondDuplicate = EQProfile(id: duplicateID, name: "Second", mode: .parametric, filters: [])
+        try expectValidationFailure(
+            ProfileStore(profiles: [firstDuplicate, secondDuplicate], fallbackProfileID: duplicateID),
+            expected: .duplicateProfileID(profileID: duplicateID)
         )
 
         let tooManyMappings = (0...ProfilePersistence.outputMappingCountRange.upperBound).map {
@@ -206,6 +390,21 @@ struct ProfilePersistenceTests {
             )
         )
 
+        let abovePolicyFrequency = EQProfile(
+            name: "Above Policy Frequency",
+            mode: .parametric,
+            filters: [EQFilter(kind: .peak, frequency: 24_001, gainDB: 0, q: 1)]
+        )
+        try expectValidationFailure(
+            ProfileStore(profiles: [abovePolicyFrequency], fallbackProfileID: abovePolicyFrequency.id),
+            expected: .valueOutOfRange(
+                profileID: abovePolicyFrequency.id,
+                field: "frequency",
+                value: 24_001,
+                range: ProfilePersistence.frequencyRange
+            )
+        )
+
         let tooManyFilters = EQProfile(
             name: "Too Many",
             mode: .parametric,
@@ -220,6 +419,23 @@ struct ProfilePersistenceTests {
                 channel: "linked",
                 count: ProfilePersistence.maxActiveFiltersPerChannel + 1,
                 maximum: ProfilePersistence.maxActiveFiltersPerChannel
+            )
+        )
+
+        let tooManyDisabledFilters = EQProfile(
+            name: "Too Many Disabled",
+            mode: .parametric,
+            filters: (0...ProfilePersistence.maxFiltersPerChannel).map {
+                EQFilter(kind: .peak, frequency: Double($0 + 1), gainDB: 0, q: 1, isEnabled: false)
+            }
+        )
+        try expectValidationFailure(
+            ProfileStore(profiles: [tooManyDisabledFilters], fallbackProfileID: tooManyDisabledFilters.id),
+            expected: .tooManyFilters(
+                profileID: tooManyDisabledFilters.id,
+                channel: "linked",
+                count: ProfilePersistence.maxFiltersPerChannel + 1,
+                maximum: ProfilePersistence.maxFiltersPerChannel
             )
         )
     }
@@ -262,5 +478,27 @@ struct ProfilePersistenceTests {
 
     private func removeTemporaryStoreDirectory(for url: URL) {
         try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+    }
+
+    private func profileJSONObject(_ profile: EQProfile) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: ProfilePersistence.encoder.encode(profile))
+        return try #require(object as? [String: Any])
+    }
+
+    private func rawStoreData(
+        profiles: [[String: Any]],
+        outputMappings: [OutputDeviceProfileMapping],
+        fallbackProfileID: UUID
+    ) throws -> Data {
+        let mappingObject = try JSONSerialization.jsonObject(
+            with: ProfilePersistence.encoder.encode(outputMappings)
+        )
+        let object: [String: Any] = [
+            "schemaVersion": ProfileStore.currentSchemaVersion,
+            "profiles": profiles,
+            "outputMappings": try #require(mappingObject as? [[String: Any]]),
+            "fallbackProfileID": fallbackProfileID.uuidString
+        ]
+        return try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
     }
 }

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -1,9 +1,9 @@
 import Foundation
 import GlassEQCore
 import GlassEQSettingsIPC
-import GlassEQSettingsUI
 import Testing
 @testable import GlassEQSettings
+@testable import GlassEQSettingsUI
 
 @Suite
 struct SettingsIPCTests {
@@ -65,6 +65,33 @@ struct SettingsIPCTests {
         #expect(metrics.playbackBufferObservations == 0)
         #expect(metrics.maximumCaptureCallbackFrames == 0)
         #expect(metrics.maximumPlaybackCallbackFrames == 0)
+    }
+
+    @Test
+    func settingsAnalysisUsesCurrentOutputSampleRateWithFallback() {
+        let profile = EQProfile(
+            name: "Analysis",
+            mode: .parametric,
+            filters: [
+                EQFilter(kind: .peak, frequency: 20_000, gainDB: 8, q: 8)
+            ]
+        )
+
+        let routeAnalysis = EQAnalysisSnapshot(profile: profile, sampleRate: 44_100)
+        let fallbackAnalysis = EQAnalysisSnapshot(profile: profile, sampleRate: 0)
+
+        #expect(routeAnalysis.signature.sampleRate == 44_100)
+        #expect(fallbackAnalysis.signature.sampleRate == EQAnalysisSignature.defaultSampleRate)
+        #expect(routeAnalysis.signature != fallbackAnalysis.signature)
+        #expect(routeAnalysis.linkedPoints == FrequencyResponse.points(
+            for: profile.filters,
+            preampDB: profile.preampDB,
+            sampleRate: 44_100
+        ))
+        #expect(routeAnalysis.recommendedPreampDB == EQProfileAnalysis.recommendedPreampDB(
+            profile: profile,
+            sampleRate: 44_100
+        ))
     }
 
     @Test

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -19,6 +19,17 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func pipeMessageRoundTripsBootstrapToken() throws {
+        let message = SettingsPipeMessage.bootstrap(sessionToken: "bootstrap-token")
+
+        let encoded = try SettingsPipeCodec.encodeLine(message)
+        let decoded = try SettingsPipeCodec.decodeLine(Data(encoded.dropLast()))
+
+        #expect(decoded == message)
+        try decoded.validateSessionToken("bootstrap-token")
+    }
+
+    @Test
     func pipeMessageRoundTripsCommandResponseAndEvent() throws {
         let response = SettingsPipeMessage.response(
             sessionToken: "token",
@@ -104,6 +115,19 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func pipeMessageValidatesUTF8TokenBytes() throws {
+        let message = SettingsPipeMessage.event(sessionToken: "å-token", event: .shutdown)
+
+        try message.validateSessionToken("å-token")
+        #expect(throws: SettingsPipeError.sessionTokenMismatch) {
+            try message.validateSessionToken("å-tokem")
+        }
+        #expect(throws: SettingsPipeError.sessionTokenMismatch) {
+            try message.validateSessionToken("å-token-extra")
+        }
+    }
+
+    @Test
     func pipeCodecRejectsOversizedEncodedLine() throws {
         let message = SettingsPipeMessage.event(sessionToken: "token", event: .shutdown)
 
@@ -128,6 +152,228 @@ struct SettingsIPCTests {
         #expect(completedLines.count == 2)
         #expect(try completedLines.map(SettingsPipeCodec.decodeLine) == [first, second])
         #expect(buffer.bufferedByteCount == 0)
+    }
+
+    @Test
+    func pipeReadPumpPreservesChunkOrder() throws {
+        let first = SettingsPipeMessage.bootstrap(sessionToken: "token")
+        let second = SettingsPipeMessage.request(sessionToken: "token", id: "request-1", kind: .connect, command: nil)
+        let third = SettingsPipeMessage.event(sessionToken: "token", event: .shutdown)
+        let firstLine = try SettingsPipeCodec.encodeLine(first)
+        let secondLine = try SettingsPipeCodec.encodeLine(second)
+        let thirdLine = try SettingsPipeCodec.encodeLine(third)
+        let splitIndex = firstLine.index(firstLine.startIndex, offsetBy: firstLine.count / 2)
+        let recorder = SettingsPipePumpRecorder(expectedMessageCount: 3)
+        let pipe = Pipe()
+        let pump = SettingsPipeReadPump(
+            label: "com.glasseq.tests.settings-pipe-read-pump",
+            onMessages: { recorder.record($0) },
+            onEndOfFile: { recorder.recordEndOfFile() }
+        )
+
+        pump.install(on: pipe.fileHandleForReading)
+        defer {
+            pump.invalidate(handle: pipe.fileHandleForReading)
+            try? pipe.fileHandleForReading.close()
+            try? pipe.fileHandleForWriting.close()
+        }
+
+        try pipe.fileHandleForWriting.write(contentsOf: Data(firstLine[..<splitIndex]))
+        try pipe.fileHandleForWriting.write(contentsOf: Data(firstLine[splitIndex...]) + secondLine + thirdLine)
+
+        #expect(recorder.waitForMessages(timeout: .now() + 2))
+        let snapshot = recorder.snapshot()
+        #expect(snapshot.messages == [first, second, third])
+        #expect(snapshot.errorCount == 0)
+    }
+
+    @Test
+    func pipeWritePumpEnqueueDoesNotBlockOnSlowSink() {
+        let sink = BlockingSettingsPipeWriteSink()
+        let completion = DispatchSemaphore(value: 0)
+        let pump = SettingsPipeWritePump(
+            label: "com.glasseq.tests.settings-pipe-write-pump.blocking",
+            sink: SettingsPipeWriteSink { data in
+                sink.write(data)
+            }
+        )
+        let message = SettingsPipeMessage.event(sessionToken: "token", event: .shutdown)
+
+        let start = Date()
+        pump.enqueue(message) { _ in
+            completion.signal()
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 0.05)
+        #expect(sink.waitUntilWriteStarted(timeout: .now() + 1))
+        sink.unblock()
+        #expect(completion.wait(timeout: .now() + 1) == .success)
+    }
+
+    @Test
+    func pipeWritePumpPreservesFIFOOrder() {
+        let recorder = SettingsPipeWriteRecorder(expectedWriteCount: 3)
+        let pump = SettingsPipeWritePump(
+            label: "com.glasseq.tests.settings-pipe-write-pump.order",
+            sink: SettingsPipeWriteSink { data in
+                try recorder.write(data)
+            }
+        )
+        let messages: [SettingsPipeMessage] = [
+            .bootstrap(sessionToken: "token"),
+            .request(sessionToken: "token", id: "request-1", kind: .connect, command: nil),
+            .event(sessionToken: "token", event: .shutdown)
+        ]
+
+        for message in messages {
+            pump.enqueue(message) { result in
+                recorder.recordCompletion(result)
+            }
+        }
+
+        #expect(recorder.waitForCompletions(timeout: .now() + 2))
+        let snapshot = recorder.snapshot()
+        #expect(snapshot.messages == messages)
+        #expect(snapshot.successCount == 3)
+        #expect(snapshot.errorCount == 0)
+    }
+
+    @Test
+    func pipeWritePumpReportsWriteFailure() {
+        let recorder = SettingsPipeWriteRecorder(expectedWriteCount: 1)
+        let pump = SettingsPipeWritePump(
+            label: "com.glasseq.tests.settings-pipe-write-pump.failure",
+            sink: SettingsPipeWriteSink { _ in
+                throw SettingsPipeWriteTestError.failed
+            }
+        )
+
+        let start = Date()
+        pump.enqueue(.event(sessionToken: "token", event: .shutdown)) { result in
+            recorder.recordCompletion(result)
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 0.05)
+        #expect(recorder.waitForCompletions(timeout: .now() + 1))
+        let snapshot = recorder.snapshot()
+        #expect(snapshot.messages.isEmpty)
+        #expect(snapshot.successCount == 0)
+        #expect(snapshot.errorCount == 1)
+    }
+
+    @Test
+    func pipeWritePumpReportsBrokenPipeWithoutSIGPIPETermination() throws {
+        let pipe = Pipe()
+        try pipe.fileHandleForReading.close()
+        defer {
+            try? pipe.fileHandleForWriting.close()
+        }
+        let completion = SettingsPipeResultRecorder()
+        let pump = SettingsPipeWritePump(
+            label: "com.glasseq.tests.settings-pipe-write-pump.closed-pipe",
+            fileHandle: pipe.fileHandleForWriting
+        )
+
+        pump.enqueue(.event(sessionToken: "token", event: .shutdown)) { result in
+            completion.record(result)
+        }
+
+        #expect(completion.wait(timeout: .now() + 2))
+        guard case .failure = completion.result else {
+            Issue.record("Expected broken pipe write to fail")
+            return
+        }
+    }
+
+    @Test
+    func pipeWritePumpDrainClosesAfterQueuedWritesFinish() {
+        let sink = BlockingSettingsPipeWriteSink()
+        let writeCompletion = SettingsPipeResultRecorder()
+        let drainCompletion = SettingsPipeResultRecorder()
+        let pump = SettingsPipeWritePump(
+            label: "com.glasseq.tests.settings-pipe-write-pump.drain",
+            sink: SettingsPipeWriteSink(
+                { data in
+                    sink.write(data)
+                },
+                close: {
+                    sink.close()
+                }
+            )
+        )
+
+        pump.enqueue(.event(sessionToken: "token", event: .shutdown)) { result in
+            writeCompletion.record(result)
+        }
+        #expect(sink.waitUntilWriteStarted(timeout: .now() + 1))
+
+        pump.drainAndClose { result in
+            drainCompletion.record(result)
+        }
+
+        #expect(!sink.waitUntilClosed(timeout: .now() + 0.05))
+        sink.unblock()
+
+        #expect(writeCompletion.wait(timeout: .now() + 1))
+        #expect(drainCompletion.wait(timeout: .now() + 1))
+        #expect(sink.closeCount == 1)
+        #expect(writeCompletion.result?.isSuccess == true)
+        #expect(drainCompletion.result?.isSuccess == true)
+    }
+
+    @Test
+    func pipeWritePumpRejectsEnqueueAfterDrain() {
+        let sink = BlockingSettingsPipeWriteSink()
+        let drainCompletion = SettingsPipeResultRecorder()
+        let enqueueCompletion = SettingsPipeResultRecorder()
+        let pump = SettingsPipeWritePump(
+            label: "com.glasseq.tests.settings-pipe-write-pump.closed",
+            sink: SettingsPipeWriteSink(
+                { _ in },
+                close: {
+                    sink.close()
+                }
+            )
+        )
+
+        pump.drainAndClose { result in
+            drainCompletion.record(result)
+        }
+        #expect(drainCompletion.wait(timeout: .now() + 1))
+
+        pump.enqueue(.event(sessionToken: "token", event: .shutdown)) { result in
+            enqueueCompletion.record(result)
+        }
+
+        #expect(enqueueCompletion.wait(timeout: .now() + 1))
+        #expect(sink.closeCount == 1)
+        #expect(enqueueCompletion.result?.isClosedPipePumpFailure == true)
+    }
+
+    @Test
+    func orderedMainActorDeliveryPreservesCallbackOrder() {
+        let delivery = SettingsPipeOrderedMainActorDelivery(
+            label: "com.glasseq.tests.settings-pipe-delivery.order"
+        )
+        let recorder = OrderedDeliveryRecorder(expectedCount: 4)
+
+        delivery.enqueue {
+            recorder.record("messages-1")
+        }
+        delivery.enqueue {
+            recorder.record("failure")
+        }
+        delivery.enqueue {
+            recorder.record("messages-2")
+        }
+        delivery.enqueue {
+            recorder.record("eof")
+        }
+
+        #expect(recorder.wait(timeout: .now() + 2))
+        #expect(recorder.events == ["messages-1", "failure", "messages-2", "eof"])
     }
 
     @Test
@@ -166,7 +412,6 @@ struct SettingsIPCTests {
     func settingsHostValidationChecksProcessParentAndBundleID() throws {
         let launchInfo = try #require(SettingsLaunchInfo(commandLineArguments: [
             "GlassEQSettings",
-            "--glasseq-settings-token", "token",
             "--glasseq-main-pid", "123"
         ]))
 
@@ -219,12 +464,12 @@ struct SettingsIPCTests {
 
         coordinator.attach(model: model)
         #expect(model.commandErrorMessage == nil)
-        coordinator.finishLaunching(arguments: launchArguments(token: "token-before"))
+        coordinator.finishLaunching(arguments: launchArguments())
         await coordinator.waitForConnectionTask()
 
         #expect(model.isConnected)
         #expect(model.commandErrorMessage == nil)
-        #expect(factory.launchInfos.map(\.token) == ["token-before"])
+        #expect(factory.launchInfos.map(\.mainProcessIdentifier) == [123])
     }
 
     @Test
@@ -234,13 +479,13 @@ struct SettingsIPCTests {
         let coordinator = SettingsLaunchCoordinator(clientFactory: factory)
         let model = GlassEQSettingsViewModel()
 
-        coordinator.finishLaunching(arguments: launchArguments(token: "token-after"))
+        coordinator.finishLaunching(arguments: launchArguments())
         coordinator.attach(model: model)
         await coordinator.waitForConnectionTask()
 
         #expect(model.isConnected)
         #expect(model.commandErrorMessage == nil)
-        #expect(factory.launchInfos.map(\.token) == ["token-after"])
+        #expect(factory.launchInfos.map(\.mainProcessIdentifier) == [123])
     }
 
     @Test
@@ -267,7 +512,7 @@ struct SettingsIPCTests {
         let coordinator = SettingsLaunchCoordinator(clientFactory: factory)
         let model = GlassEQSettingsViewModel()
 
-        coordinator.finishLaunching(arguments: launchArguments(token: "invalid-host"))
+        coordinator.finishLaunching(arguments: launchArguments())
         coordinator.attach(model: model)
         await coordinator.waitForConnectionTask()
 
@@ -310,7 +555,6 @@ private final class FakeSettingsPipeClientFactory: SettingsPipeClientMaking {
         }
         launchInfos.append(launchInfo)
         return FakeSettingsPipeClient(
-            token: launchInfo.token,
             snapshot: snapshot,
             connectError: connectError
         )
@@ -319,13 +563,12 @@ private final class FakeSettingsPipeClientFactory: SettingsPipeClientMaking {
 
 @MainActor
 private final class FakeSettingsPipeClient: SettingsPipeClientConnection, @unchecked Sendable {
-    let token: String
+    let token: String? = "fake-token"
     private let snapshot: SettingsSnapshotDTO
     private let connectError: (any Error)?
     private(set) var didDisconnect = false
 
-    init(token: String, snapshot: SettingsSnapshotDTO, connectError: (any Error)?) {
-        self.token = token
+    init(snapshot: SettingsSnapshotDTO, connectError: (any Error)?) {
         self.snapshot = snapshot
         self.connectError = connectError
     }
@@ -346,10 +589,226 @@ private final class FakeSettingsPipeClient: SettingsPipeClientConnection, @unche
     }
 }
 
-private func launchArguments(token: String) -> [String] {
+private func launchArguments() -> [String] {
     [
         "GlassEQSettings",
-        "--glasseq-settings-token", token,
         "--glasseq-main-pid", "123"
     ]
+}
+
+private final class SettingsPipePumpRecorder: @unchecked Sendable {
+    private let expectedMessageCount: Int
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var messages: [SettingsPipeMessage] = []
+    private var errorCount = 0
+    private var endOfFileCount = 0
+
+    init(expectedMessageCount: Int) {
+        self.expectedMessageCount = expectedMessageCount
+    }
+
+    func record(_ result: Result<[SettingsPipeMessage], any Error>) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
+        switch result {
+        case .success(let messages):
+            self.messages.append(contentsOf: messages)
+        case .failure:
+            errorCount += 1
+        }
+
+        if self.messages.count >= expectedMessageCount {
+            semaphore.signal()
+        }
+    }
+
+    func recordEndOfFile() {
+        lock.lock()
+        endOfFileCount += 1
+        lock.unlock()
+    }
+
+    func waitForMessages(timeout: DispatchTime) -> Bool {
+        semaphore.wait(timeout: timeout) == .success
+    }
+
+    func snapshot() -> (messages: [SettingsPipeMessage], errorCount: Int, endOfFileCount: Int) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return (messages, errorCount, endOfFileCount)
+    }
+}
+
+private enum SettingsPipeWriteTestError: Error {
+    case failed
+}
+
+private extension Result where Success == Void, Failure == any Error {
+    var isSuccess: Bool {
+        if case .success = self {
+            return true
+        }
+        return false
+    }
+
+    var isClosedPipePumpFailure: Bool {
+        if case .failure(let error as SettingsPipeWritePumpError) = self,
+           error == .closed {
+            return true
+        }
+        return false
+    }
+}
+
+private final class SettingsPipeResultRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var _result: Result<Void, any Error>?
+
+    var result: Result<Void, any Error>? {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return _result
+    }
+
+    func record(_ result: Result<Void, any Error>) {
+        lock.lock()
+        _result = result
+        lock.unlock()
+        semaphore.signal()
+    }
+
+    func wait(timeout: DispatchTime) -> Bool {
+        semaphore.wait(timeout: timeout) == .success
+    }
+}
+
+private final class OrderedDeliveryRecorder: @unchecked Sendable {
+    private let expectedCount: Int
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var _events: [String] = []
+
+    init(expectedCount: Int) {
+        self.expectedCount = expectedCount
+    }
+
+    var events: [String] {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return _events
+    }
+
+    func record(_ event: String) {
+        lock.lock()
+        _events.append(event)
+        let shouldSignal = _events.count >= expectedCount
+        lock.unlock()
+
+        if shouldSignal {
+            semaphore.signal()
+        }
+    }
+
+    func wait(timeout: DispatchTime) -> Bool {
+        semaphore.wait(timeout: timeout) == .success
+    }
+}
+
+private final class BlockingSettingsPipeWriteSink: @unchecked Sendable {
+    private let started = DispatchSemaphore(value: 0)
+    private let unblocker = DispatchSemaphore(value: 0)
+    private let closed = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var _closeCount = 0
+
+    var closeCount: Int {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return _closeCount
+    }
+
+    func write(_ data: Data) {
+        started.signal()
+        _ = unblocker.wait(timeout: .now() + 2)
+    }
+
+    func waitUntilWriteStarted(timeout: DispatchTime) -> Bool {
+        started.wait(timeout: timeout) == .success
+    }
+
+    func unblock() {
+        unblocker.signal()
+    }
+
+    func close() {
+        lock.lock()
+        _closeCount += 1
+        lock.unlock()
+        closed.signal()
+    }
+
+    func waitUntilClosed(timeout: DispatchTime) -> Bool {
+        closed.wait(timeout: timeout) == .success
+    }
+}
+
+private final class SettingsPipeWriteRecorder: @unchecked Sendable {
+    private let expectedWriteCount: Int
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var messages: [SettingsPipeMessage] = []
+    private var successCount = 0
+    private var errorCount = 0
+
+    init(expectedWriteCount: Int) {
+        self.expectedWriteCount = expectedWriteCount
+    }
+
+    func write(_ data: Data) throws {
+        let message = try SettingsPipeCodec.decodeLine(Data(data.dropLast()))
+        lock.lock()
+        messages.append(message)
+        lock.unlock()
+    }
+
+    func recordCompletion(_ result: Result<Void, any Error>) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        switch result {
+        case .success:
+            successCount += 1
+        case .failure:
+            errorCount += 1
+        }
+        if successCount + errorCount >= expectedWriteCount {
+            semaphore.signal()
+        }
+    }
+
+    func waitForCompletions(timeout: DispatchTime) -> Bool {
+        semaphore.wait(timeout: timeout) == .success
+    }
+
+    func snapshot() -> (messages: [SettingsPipeMessage], successCount: Int, errorCount: Int) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return (messages, successCount, errorCount)
+    }
 }

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -399,7 +399,12 @@ struct SettingsIPCTests {
                 channelCount: 2,
                 bufferFrameSize: 256
             ),
-            currentOutputMappedProfileID: .set(profileID)
+            currentOutputMappedProfileID: .set(profileID),
+            profileStoreProtection: SettingsProfileStoreProtectionDTO(
+                isProtected: true,
+                message: "Newer store",
+                resetButtonTitle: "Reset profiles for this version"
+            )
         )
         let message = SettingsPipeMessage.event(sessionToken: "token", event: .snapshotPatched(patch))
 


### PR DESCRIPTION
## Summary

This PR addresses the validated release-polish audit findings across audio safety, settings IPC, profile persistence, importers, lifecycle handling, CI, and alpha-0.8 release metadata.

Key changes include:

- Harden realtime audio paths, output rebuild recovery, device restoration, and mono-tap stereo output copying.
- Move settings-helper session token bootstrap off argv and onto the private pipe, with ordered read/write pumps and SIGPIPE-safe broken-pipe handling.
- Improve profile-store validation, salvage, duplicate-ID handling, future-schema protection, and explicit reset flow.
- Tighten AutoEQ / REW parsing and graphic EQ round-trip detection.
- Serialize engine lifecycle work, fix menu-bar bypass desync, and preserve running audio state when a profile update cannot be applied.
- Use active output sample rate in settings EQ analysis.
- Add macOS CI, stricter codesign verification, and alpha-0.8 docs/versioning.

## Impact

Users should see safer route changes, better crash recovery, less risk of profile-store data loss, more reliable settings-helper behavior, and cleaner alpha-0.8 packaging.

The settings UI now blocks profile edits when a store was written by a newer GlassEQ version, while offering an explicit reset action that backs up the newer store first.