### PR TITLE
Stop audio capture when processing is disabled

### DIFF
--- a/Docs/Distribution.md
+++ b/Docs/Distribution.md
@@ -1,6 +1,6 @@
 # Distribution Notes
 
-GlassEQ alpha-0.8 is intended for ad hoc-signed distribution to technical testers. It is not Developer ID signed and is not notarized. A later non-alpha build will move to Developer ID distribution outside the Mac App Store.
+GlassEQ alpha-0.8.1 is intended for ad hoc-signed distribution to technical testers. It is not Developer ID signed and is not notarized. A later non-alpha build will move to Developer ID distribution outside the Mac App Store.
 
 ## Current Alpha Distribution
 
@@ -13,7 +13,7 @@ Build the alpha artifact:
 The script produces:
 
 - `.build/release-app/GlassEQ.app`
-- `.build/dist/GlassEQ-alpha-0.8-macos26-arm64.zip`
+- `.build/dist/GlassEQ-alpha-0.8.1-macos26-arm64.zip`
 
 The bundle is ad hoc-signed with `codesign --sign -`. It is not Developer ID signed and is not notarized, so this command should reject it:
 

--- a/Docs/ReleaseNotes-alpha-0.8.1.md
+++ b/Docs/ReleaseNotes-alpha-0.8.1.md
@@ -1,0 +1,50 @@
+# GlassEQ alpha-0.8.1 Release Notes
+
+This is a technical alpha for Apple Silicon Macs running macOS 26.
+
+## Distribution Warning
+
+This build is ad hoc-signed, not Developer ID signed, and not notarized. macOS Gatekeeper will reject it by default. Install only if you are comfortable testing ad hoc-signed macOS software and granting system audio capture permission.
+
+## Changes Since alpha-0.8
+
+- The menu bar Disable action now stops system audio processing instead of leaving the Core Audio tap running in bypass mode, allowing macOS to remove the system-audio recording indicator while GlassEQ is disabled.
+
+## Included
+
+- Menu bar app shell.
+- Core Audio system output tap.
+- Playback of processed audio to the current default output.
+- Parametric EQ, 10-band graphic EQ, and 31-band graphic EQ profiles.
+- AutoEQ / EqualizerAPO and REW text import.
+- Per-output profile mappings by Core Audio device UID.
+- Profile persistence under the GlassEQ sandbox container, with migration from legacy `~/Library/Application Support/GlassEQ` data.
+- Settings helper app and local IPC for editing profiles from the menu bar app.
+- Audio route recovery after system sleep, screen wake, session unlock, and Bluetooth route teardown while the screen is locked.
+- More conservative built-in speaker buffering to avoid steady-state playback underruns and distortion.
+- Basic callback metrics and diagnostics tooling.
+
+## Supported Alpha Target
+
+- macOS 26.0 or newer.
+- Apple Silicon / arm64 only.
+
+## Known Issues
+
+- Gatekeeper rejection is expected because the app is not notarized.
+- System audio capture permission may require manual cleanup or retrying on test machines.
+- Bluetooth and AirPods routes may still expose macOS Core Audio edge cases; report device model, macOS version, and steps to reproduce.
+- AirPlay outputs are not yet supported.
+- No automatic updates.
+- No crash reporting.
+- No notarized Developer ID build yet.
+- No x86_64 build.
+
+## Build Artifact
+
+The release script writes:
+
+```sh
+.build/dist/GlassEQ-alpha-0.8.1-macos26-arm64.zip
+.build/dist/GlassEQ-alpha-0.8.1-macos26-arm64.zip.sha256
+```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GlassEQ takes a different route. It uses **Core Audio process taps**, Apple's mo
 
 ## Download & install
 
-Grab `GlassEQ-alpha-0.8-macos26-arm64.zip` from the [alpha-0.8 release](https://github.com/juhokoskela/GlassEQ/releases/tag/alpha-0.8), then:
+Grab `GlassEQ-alpha-0.8.1-macos26-arm64.zip` from the [alpha-0.8.1 release](https://github.com/juhokoskela/GlassEQ/releases/tag/alpha-0.8.1), then:
 
 1. Unzip it.
 2. Move `GlassEQ.app` to `/Applications`.
@@ -37,7 +37,7 @@ On first run GlassEQ asks for **system audio capture permission** — that's wha
 
 ### About this alpha
 
-GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no automatic updates or crash reporting yet. Expect the occasional rough edge, and please report any hardware-specific audio issues you run into. See [Docs/AlphaTesting.md](Docs/AlphaTesting.md), [Docs/Distribution.md](Docs/Distribution.md), and [Docs/ReleaseNotes-alpha-0.8.md](Docs/ReleaseNotes-alpha-0.8.md) before installing a build.
+GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no automatic updates or crash reporting yet. Expect the occasional rough edge, and please report any hardware-specific audio issues you run into. See [Docs/AlphaTesting.md](Docs/AlphaTesting.md), [Docs/Distribution.md](Docs/Distribution.md), and [Docs/ReleaseNotes-alpha-0.8.1.md](Docs/ReleaseNotes-alpha-0.8.1.md) before installing a build.
 
 ## How it works
 

--- a/Scripts/build-release-app.sh
+++ b/Scripts/build-release-app.sh
@@ -47,7 +47,7 @@ is_dry_run() {
 }
 
 default_release_label() {
-    if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+    if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
         echo "${RELEASE_CHANNEL}-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
     else
         echo "${RELEASE_CHANNEL}-${VERSION}"

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -15,7 +15,7 @@ struct GlassEQApp: App {
                 .frame(width: 340)
         } label: {
             Image(systemName: model.isRunning ? "slider.horizontal.3" : "slider.horizontal.2.gobackward")
-                .accessibilityLabel(Text(model.isRunning ? localized("GlassEQ active") : localized("GlassEQ stopped")))
+                .accessibilityLabel(Text(model.menuBarAccessibilityLabel))
                 .accessibilityValue(Text(model.statusMessage))
                 .accessibilityHint(Text(localized("Opens GlassEQ controls")))
         }
@@ -495,6 +495,13 @@ final class GlassEQAppModel {
         profileStore.profiles.first(where: { $0.id == selectedProfileID }) ?? activeProfile
     }
 
+    var menuBarAccessibilityLabel: String {
+        if activeProfile.isBypassed {
+            return localized("GlassEQ disabled")
+        }
+        return isRunning ? localized("GlassEQ active") : localized("GlassEQ stopped")
+    }
+
     var currentOutputMappedProfileID: UUID? {
         profileStore.outputMappings.first(where: { $0.outputDeviceUID == currentOutputUID })?.profileID
     }
@@ -662,20 +669,7 @@ final class GlassEQAppModel {
         selectedProfileID = profile.id
         draftProfile = profile
         saveStore()
-        if lifecycleState == .waking {
-            reschedulePendingEngineStartWithActiveProfile()
-            notifyModelDidChange()
-            return
-        }
-        if isRunning {
-            if engine.updateDSP(profile: profile) {
-                statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
-            } else {
-                restartEngineWithActiveProfile(rollback: rollback)
-            }
-        } else {
-            restartEngineWithActiveProfile(rollback: rollback)
-        }
+        synchronizeActiveProfileProcessing(rollback: rollback)
         notifyModelDidChange()
     }
 
@@ -711,20 +705,7 @@ final class GlassEQAppModel {
         selectedProfileID = profile.id
         draftProfile = profile
         saveStore()
-        if lifecycleState == .waking {
-            reschedulePendingEngineStartWithActiveProfile()
-            notifyModelDidChange()
-            return
-        }
-        if isRunning {
-            if engine.updateDSP(profile: profile) {
-                statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
-            } else {
-                restartEngineWithActiveProfile(rollback: rollback)
-            }
-        } else {
-            restartEngineWithActiveProfile(rollback: rollback)
-        }
+        synchronizeActiveProfileProcessing(rollback: rollback)
         notifyModelDidChange()
     }
 
@@ -747,13 +728,7 @@ final class GlassEQAppModel {
                 draftProfile = profile
             }
             saveStore()
-            if lifecycleState == .waking {
-                reschedulePendingEngineStartWithActiveProfile()
-                notifyModelDidChange()
-                return
-            }
-            engine.setBypassed(isBypassed)
-            statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
+            synchronizeActiveProfileProcessing()
             notifyModelDidChange()
         } catch {
             reportProfileActionFailure(error)
@@ -887,7 +862,9 @@ final class GlassEQAppModel {
         activeProfile = profile
         selectedProfileID = profile.id
         draftProfile = profile
-        if engine.updateDSP(profile: profile) {
+        if activeProfile.isBypassed {
+            disableActiveProfileProcessing(updateMetrics: true)
+        } else if engine.updateDSP(profile: profile) {
             statusMessage = localized("Previewing settings for \(profile.name)")
         } else {
             restartEngineWithActiveProfile(rollback: rollback)
@@ -909,7 +886,9 @@ final class GlassEQAppModel {
         activeProfile = profile
         selectedProfileID = profile.id
         draftProfile = profile
-        if engine.updateDSP(profile: profile) {
+        if activeProfile.isBypassed {
+            disableActiveProfileProcessing(updateMetrics: true)
+        } else if engine.updateDSP(profile: profile) {
             statusMessage = processingStatus(outputName: currentOutputName, profileName: profile.name)
         } else {
             restartEngineWithActiveProfile(rollback: rollback)
@@ -1152,7 +1131,11 @@ final class GlassEQAppModel {
             selectedProfileID = activeProfile.id
             draftProfile = activeProfile
 
-            scheduleEngineWork(.start(output: output, profile: activeProfile))
+            if activeProfile.isBypassed {
+                disableActiveProfileProcessing(updateMetrics: false)
+            } else {
+                scheduleEngineWork(.start(output: output, profile: activeProfile))
+            }
         case .failure(let error):
             if lifecycleState == .waking {
                 scheduleWakeReconnectRetry(status: localized("Waiting for audio output after wake: \(error.localizedDescription)"))
@@ -1201,6 +1184,57 @@ final class GlassEQAppModel {
                 return
             }
             self?.completeEngineWork(result, generation: generation)
+        }
+    }
+
+    private func synchronizeActiveProfileProcessing(rollback: ProfileRollback? = nil) {
+        guard lifecycleState != .terminating,
+              lifecycleState != .sleeping else {
+            return
+        }
+
+        guard !activeProfile.isBypassed else {
+            disableActiveProfileProcessing(updateMetrics: true)
+            return
+        }
+
+        if lifecycleState == .waking {
+            reschedulePendingEngineStartWithActiveProfile()
+            return
+        }
+
+        startObserver(sendInitialValue: false)
+        if isRunning {
+            if engine.updateDSP(profile: activeProfile) {
+                statusMessage = processingStatus(outputName: currentOutputName, profileName: activeProfile.name)
+            } else {
+                restartEngineWithActiveProfile(rollback: rollback)
+            }
+        } else {
+            restartEngineWithActiveProfile(rollback: rollback)
+        }
+    }
+
+    private func disableActiveProfileProcessing(updateMetrics: Bool) {
+        let shouldStopEngine = isRunning || engineStartTask != nil || engineStateNeedsStop
+        invalidatePendingOutputChange()
+        invalidatePendingEngineStart()
+        if shouldStopEngine {
+            scheduleEngineStop(updateMetrics: updateMetrics)
+        }
+        lifecycleState = .stopped
+        isRunning = false
+        wakeReconnectAttempts = 0
+        wasRunningBeforeSleep = false
+        statusMessage = disabledStatus(outputName: currentOutputName)
+    }
+
+    private var engineStateNeedsStop: Bool {
+        switch engine.state {
+        case .running, .failed:
+            return true
+        case .stopped:
+            return false
         }
     }
 
@@ -1524,6 +1558,13 @@ final class GlassEQAppModel {
             return localized("Processing \(profileName)")
         }
         return localized("Processing \(outputName) with \(profileName)")
+    }
+
+    private func disabledStatus(outputName: String) -> String {
+        guard !outputName.isEmpty, outputName != noOutputName else {
+            return localized("Audio processing disabled")
+        }
+        return localized("Audio processing disabled for \(outputName)")
     }
 
     func startMetricsPolling() {
@@ -1860,7 +1901,7 @@ private struct MenuBarView: View {
                 .tint(popoverControlsAreActive ? enableButtonTint : nil)
                 .accessibilityLabel(Text(model.activeProfile.isBypassed ? localized("Enable equalizer") : localized("Disable equalizer")))
                 .accessibilityValue(Text(statusBadgeTitle))
-                .accessibilityHint(Text(localized("Toggles audio bypass for the active profile")))
+                .accessibilityHint(Text(localized("Starts or stops system audio processing for the active profile")))
 
                 Button {
                     dismiss()
@@ -1921,10 +1962,10 @@ private struct MenuBarView: View {
     }
 
     private var statusBadgeTitle: String {
-        guard model.isRunning else {
-            return localized("Stopped")
+        if model.activeProfile.isBypassed {
+            return localized("Disabled")
         }
-        return model.activeProfile.isBypassed ? localized("Disabled") : localized("Active")
+        return model.isRunning ? localized("Active") : localized("Stopped")
     }
 
     private var statusBadgeColor: Color {

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -85,8 +85,8 @@ private enum AppBuildInfo {
            !releaseLabel.isEmpty {
             return releaseLabel
         }
-        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.8.0"
-        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "10"
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.8.1"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "11"
         return "v\(version) (\(build))"
     }
 }

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -1533,6 +1533,11 @@ final class GlassEQAppModel {
               lifecycleState != .sleeping else {
             return
         }
+        guard !activeProfile.isBypassed else {
+            synchronizeActiveProfileProcessing()
+            notifyModelDidChange()
+            return
+        }
         guard lifecycleState != .waking else {
             requestWakeReconnectAttempt()
             return

--- a/Sources/GlassEQApp/Info.plist
+++ b/Sources/GlassEQApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-    <string>0.8.0</string>
+    <string>0.8.1</string>
 	<key>CFBundleVersion</key>
-    <string>10</string>
+    <string>11</string>
 	<key>GlassEQReleaseLabel</key>
-    <string>alpha-0.8</string>
+    <string>alpha-0.8.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/GlassEQSettings/Info.plist
+++ b/Sources/GlassEQSettings/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.0</string>
+    <string>0.8.1</string>
     <key>CFBundleVersion</key>
-    <string>10</string>
+    <string>11</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -79,6 +79,34 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsRetryDisabledActiveProfileDoesNotStartEngine() async throws {
+        var disabled = makeProfile(name: "Disabled")
+        disabled.isBypassed = true
+        let output = makeOutput(uid: "retry-disabled-output", name: "Retry Disabled Output")
+        let engine = FakeAudioEngine()
+        let lookup = FakeDefaultOutputLookup(.success(output))
+        let model = makeModel(
+            store: ProfileStore(profiles: [disabled], fallbackProfileID: disabled.id),
+            engine: engine,
+            lookup: lookup
+        )
+
+        let response = try await model.performSettingsCommand(.retryAudioEngine)
+        await settleAsyncWork()
+
+        let snapshot = try #require(response.snapshot)
+        #expect(snapshot.statusMessage == localized("Audio processing disabled"))
+        #expect(snapshot.activeProfileID == disabled.id)
+        #expect(engine.startCalls.isEmpty)
+        #expect(engine.updateCalls.isEmpty)
+        #expect(engine.updateDSPCalls.isEmpty)
+        #expect(engine.stopCallCount == 0)
+        #expect(lookup.defaultOutputCalls == 0)
+        #expect(!model.isRunning)
+        #expect(model.lifecycleState == .stopped)
+    }
+
+    @Test
     func outputChangeClearsPreviewAndStopPreviewIsNoOp() async {
         let fallback = makeProfile(name: "Fallback")
         let preview = makeProfile(name: "Preview")

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -124,6 +124,38 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func outputChangeToBypassedProfileDoesNotStartEngine() async {
+        let fallback = makeProfile(name: "Fallback")
+        var disabled = makeProfile(name: "Disabled")
+        disabled.isBypassed = true
+        let output = makeOutput(uid: "disabled-output", name: "Disabled Output")
+        let store = ProfileStore(
+            profiles: [fallback, disabled],
+            outputMappings: [
+                OutputDeviceProfileMapping(outputDeviceUID: output.uid, profileID: disabled.id)
+            ],
+            fallbackProfileID: fallback.id
+        )
+        let engine = FakeAudioEngine()
+        let lookup = FakeDefaultOutputLookup(.success(output))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(store: store, engine: engine, lookup: lookup, observers: observers, outputDelay: .zero)
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.activeProfile.id == disabled.id
+                && model.lifecycleState == .stopped
+                && model.statusMessage == localized("Audio processing disabled for \(output.name)")
+        }
+
+        #expect(engine.startCalls.isEmpty)
+        #expect(engine.stopCallCount == 0)
+        #expect(!model.isRunning)
+        #expect(model.activeProfile.isBypassed)
+    }
+
+    @Test
     func startDoesNotBlockOnAsyncObserverStart() async throws {
         let observers = BlockingAsyncDefaultOutputObserverFactory()
         let model = makeModel(observers: observers, outputDelay: .zero)
@@ -760,9 +792,8 @@ struct GlassEQAppModelLifecycleTests {
         let fallback = makeProfile(name: "Fallback")
         let applied = makeProfile(name: "Applied During Wake")
         let mapped = makeProfile(name: "Mapped During Wake")
-        let preview = makeProfile(name: "Preview During Wake")
         let store = ProfileStore(
-            profiles: [fallback, applied, mapped, preview],
+            profiles: [fallback, applied, mapped],
             fallbackProfileID: fallback.id
         )
         let engine = FakeAudioEngine()
@@ -798,10 +829,8 @@ struct GlassEQAppModelLifecycleTests {
         try model.apply(profile: applied)
         try model.useForCurrentOutput(profile: mapped)
         model.setBypass(true)
-        model.preview(profile: preview)
-        model.stopPreview()
 
-        #expect(model.lifecycleState == .waking)
+        #expect(model.lifecycleState == .stopped)
         #expect(model.activeProfile.id == mapped.id)
         #expect(model.activeProfile.isBypassed)
         #expect(model.previewReturnProfile == nil)
@@ -812,13 +841,12 @@ struct GlassEQAppModelLifecycleTests {
 
         engine.unblockStart(for: output.uid)
         await waitUntil {
-            model.lifecycleState == .running
-                && engine.startCalls.last?.profile.id == mapped.id
-                && engine.startCalls.last?.profile.isBypassed == true
+            engine.stopCallCount == 1
         }
 
-        #expect(model.isRunning)
-        #expect(model.statusMessage == localized("Processing \(output.name) with \(mapped.name)"))
+        #expect(!model.isRunning)
+        #expect(model.lifecycleState == .stopped)
+        #expect(model.statusMessage == localized("Audio processing disabled for \(output.name)"))
     }
 
     @Test
@@ -976,7 +1004,7 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
-    func bypassAfterSelectingDifferentDraftOnlyTogglesActiveProfile() async {
+    func bypassAfterSelectingDifferentDraftOnlyTogglesActiveProfileAndStopsEngine() async {
         let active = makeProfile(name: "Active")
         let draft = makeProfile(name: "Draft")
         let output = makeOutput(uid: "bypass-output", name: "Bypass Output")
@@ -993,6 +1021,9 @@ struct GlassEQAppModelLifecycleTests {
         model.selectProfile(draft.id)
 
         model.setBypass(true)
+        await waitUntil {
+            engine.stopCallCount == 1
+        }
 
         #expect(model.activeProfile.id == active.id)
         #expect(model.activeProfile.isBypassed)
@@ -1002,11 +1033,14 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.profileStore.profiles.first { $0.id == active.id }?.isBypassed == true)
         #expect(model.profileStore.profiles.first { $0.id == draft.id }?.isBypassed == false)
         #expect(engine.updateDSPCalls.isEmpty)
-        #expect(engine.setBypassedCalls == [true])
+        #expect(engine.setBypassedCalls.isEmpty)
+        #expect(engine.stopCallCount == 1)
+        #expect(!model.isRunning)
+        #expect(model.lifecycleState == .stopped)
     }
 
     @Test
-    func bypassMirrorsDraftWhenSelectedProfileIsActiveProfile() async {
+    func bypassMirrorsDraftWhenSelectedProfileIsActiveProfileAndStopsEngine() async {
         let active = makeProfile(name: "Active")
         let output = makeOutput(uid: "active-bypass-output", name: "Active Bypass Output")
         let store = ProfileStore(profiles: [active], fallbackProfileID: active.id)
@@ -1021,6 +1055,9 @@ struct GlassEQAppModelLifecycleTests {
         }
 
         model.setBypass(true)
+        await waitUntil {
+            engine.stopCallCount == 1
+        }
 
         #expect(model.activeProfile.id == active.id)
         #expect(model.activeProfile.isBypassed)
@@ -1028,7 +1065,10 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.draftProfile.isBypassed)
         #expect(model.profileStore.profiles.first { $0.id == active.id }?.isBypassed == true)
         #expect(engine.updateDSPCalls.isEmpty)
-        #expect(engine.setBypassedCalls == [true])
+        #expect(engine.setBypassedCalls.isEmpty)
+        #expect(engine.stopCallCount == 1)
+        #expect(!model.isRunning)
+        #expect(model.lifecycleState == .stopped)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Stop the Core Audio engine when the active profile is disabled instead of keeping the system tap running in bypass mode.
- Avoid starting audio processing when the mapped output profile is already disabled.
- Keep Settings retry from restarting audio capture while the active profile is disabled.
- Update menu bar state/accessibility copy so Disabled reflects stopped processing.
- Prepare alpha `0.8.1` with updated app/helper bundle versions, release label handling, docs, and release notes.

## Why

The previous Disable action only bypassed DSP while leaving the system audio capture tap active. That kept macOS showing the purple system-audio recording indicator even though the user had disabled GlassEQ processing.

With this change, disabling processing tears down active or pending engine work so macOS can remove the indicator. Re-enabling starts processing again with the active profile, while retry actions remain stopped for disabled profiles.
