### PR TITLE
Support multi-channel output devices with stereo pair mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ During normal listening GlassEQ is just a menu bar app and the audio engine, con
 ## Known limitations
 
 - **AirPlay outputs are not yet supported.** The DSP engine currently fails to start on AirPlay receivers and GlassEQ stops processing that route; macOS keeps routing normal system audio to the AirPlay device. Switching to any other output (built-in, USB, Bluetooth, HDMI) restores processing cleanly.
-- **Stereo only.** GlassEQ processes mono and 2-channel outputs, multichannel / surround outputs aren't supported yet.
+- **Stereo processing.** GlassEQ processes a stereo stream. On multi-channel interfaces it plays to the device's preferred stereo pair (configurable in Audio MIDI Setup → Configure Speakers) and writes silence to the remaining channels — the same routing macOS uses for system audio. There is no surround/per-channel EQ, and preferred-pair changes apply on the next output switch.
 - **Bluetooth** routes can still surface Core Audio edge cases, please report device model, macOS version, and steps to reproduce.
 - No automatic updates, no crash reporting, no x86_64 build.
 

--- a/Sources/GlassEQAudio/AudioDevice.swift
+++ b/Sources/GlassEQAudio/AudioDevice.swift
@@ -60,7 +60,7 @@ public enum AudioDeviceAvailabilityError: Error, Equatable, LocalizedError, Cust
         case .outputDeviceHasNoOutputChannels(let id):
             "Output device \(id) has no output channels"
         case .unsupportedOutputChannelCount(let id, let channelCount):
-            "Output device \(id) has unsupported channel count \(channelCount); GlassEQ currently supports mono and stereo outputs only"
+            "Output device \(id) reports channel count \(channelCount); GlassEQ supports up to \(CoreAudioDeviceQuery.maxChannelCount) output channels"
         case .invalidDeviceMetadata(let id, let message):
             "Output device \(id) reported invalid Core Audio metadata: \(message)"
         }
@@ -166,8 +166,6 @@ public enum CoreAudioDeviceQuery {
             do {
                 return try outputDevice(id: deviceID)
             } catch AudioDeviceAvailabilityError.outputDeviceHasNoOutputChannels {
-                return nil
-            } catch AudioDeviceAvailabilityError.unsupportedOutputChannelCount {
                 return nil
             }
         }

--- a/Sources/GlassEQAudio/AudioDevice.swift
+++ b/Sources/GlassEQAudio/AudioDevice.swift
@@ -404,6 +404,29 @@ public enum CoreAudioDeviceQuery {
         return value as String
     }
 
+    /// The device's preferred stereo pair as raw 1-based channel numbers; callers sanitize
+    /// (the HAL reports zeros when the pair was never configured).
+    static func preferredStereoChannels(objectID: AudioObjectID) throws -> (left: UInt32, right: UInt32) {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyPreferredChannelsForStereo,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var channels: (UInt32, UInt32) = (0, 0)
+        var size = UInt32(MemoryLayout<(UInt32, UInt32)>.size)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, &channels),
+            operation: "AudioObjectGetPropertyData(preferred stereo channels)"
+        )
+        try validatePropertySize(
+            actual: size,
+            expected: UInt32(MemoryLayout<(UInt32, UInt32)>.size),
+            operation: "AudioObjectGetPropertyData(preferred stereo channels)",
+            objectID: objectID
+        )
+        return (left: channels.0, right: channels.1)
+    }
+
     static func getChannelCount(
         objectID: AudioObjectID,
         scope: AudioObjectPropertyScope

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -204,6 +204,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let stopping = Atomic<Bool>(false)
         private let captureInCallback = Atomic<Bool>(false)
         private let playbackInCallback = Atomic<Bool>(false)
+        // Packed (left << 32 | right) so the playback callback can never observe a torn pair.
+        private let playbackChannelPair = Atomic<UInt64>(SystemTapAudioEngine.encodedPlaybackChannelPair(left: 0, right: 1))
 
         init(
             profile: EQProfile,
@@ -250,6 +252,15 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         func muteOutputForTransition() {
             outputMutedForTransition.store(true, ordering: .releasing)
             playbackPriming.store(true, ordering: .releasing)
+        }
+
+        // Stored by the control thread on every output rebuild, before the new output IOProc
+        // starts, so the first callback on the new device already maps to the right channels.
+        func setPlaybackChannelPair(left: Int, right: Int) {
+            playbackChannelPair.store(
+                SystemTapAudioEngine.encodedPlaybackChannelPair(left: left, right: right),
+                ordering: .releasing
+            )
         }
 
         // Called when a new output half is started. Clears any transition mute (the runtime
@@ -432,8 +443,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
             recordPlaybackBufferedFrames(ringBuffer.occupancyFrames())
 
+            let (destinationLeftChannel, destinationRightChannel) = SystemTapAudioEngine.decodedPlaybackChannelPair(
+                playbackChannelPair.load(ordering: .acquiring)
+            )
+
             var underrunFrames = 0
-            if let outputSamples = contiguousInterleavedOutputBuffer(
+            if destinationLeftChannel == 0,
+               destinationRightChannel == 1,
+               let outputSamples = contiguousInterleavedOutputBuffer(
                 outputBuffers,
                 frameCount: frameCount,
                 channelCount: channelCount
@@ -470,6 +487,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                             destinationFrameOffset: frameOffset,
                             frameCount: chunkFrames,
                             sourceChannelCount: channelCount,
+                            destinationLeftChannel: destinationLeftChannel,
+                            destinationRightChannel: destinationRightChannel,
                             to: outputBuffers
                         )
                         frameOffset += chunkFrames
@@ -773,6 +792,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             destinationFrameOffset: Int,
             frameCount: Int,
             sourceChannelCount: Int,
+            destinationLeftChannel: Int,
+            destinationRightChannel: Int,
             to buffers: UnsafeMutableAudioBufferListPointer
         ) {
             SystemTapAudioEngine.copyInterleavedSamples(
@@ -781,6 +802,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 destinationFrameOffset: destinationFrameOffset,
                 frameCount: frameCount,
                 sourceChannelCount: sourceChannelCount,
+                destinationLeftChannel: destinationLeftChannel,
+                destinationRightChannel: destinationRightChannel,
                 to: buffers
             )
         }
@@ -1139,6 +1162,16 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         // is ignored via CoreAudioSelfChangeGuard, so it no longer triggers a rebuild loop.
         runtime.muteOutputForTransition()
 
+        // Multi-channel devices play the stereo stream on their preferred stereo pair (the same
+        // channels macOS routes system audio to); every other channel receives silence. The pair
+        // must be stored before AudioDeviceStart so the first callback already maps correctly.
+        let preferredChannels = try? CoreAudioDeviceQuery.preferredStereoChannels(objectID: matchedOutput.id)
+        let channelPair = Self.playbackStereoPair(
+            preferredChannels: preferredChannels,
+            outputChannelCount: matchedOutput.outputChannelCount
+        )
+        runtime.setPlaybackChannelPair(left: channelPair.left, right: channelPair.right)
+
         guard let outputIOProcID = try createOutputIOProc(deviceID: matchedOutput.id, runtime: runtime) else {
             throw CoreAudioError(operation: "AudioDeviceCreateIOProcID(default output)", status: kAudioHardwareUnspecifiedError)
         }
@@ -1379,6 +1412,39 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         return output.outputChannelCount
     }
 
+    /// Normalizes a device-reported preferred stereo pair (1-based channel numbers; the HAL
+    /// reports zeros when the pair was never configured) into 0-based destination channel
+    /// indices. Falls back to the first two channels whenever the report is missing or
+    /// inconsistent; mono devices collapse to (0, 0).
+    static func playbackStereoPair(
+        preferredChannels: (left: UInt32, right: UInt32)?,
+        outputChannelCount: Int
+    ) -> (left: Int, right: Int) {
+        guard outputChannelCount > 1 else {
+            return outputChannelCount == 1 ? (0, 0) : (0, 1)
+        }
+        guard let preferredChannels,
+              preferredChannels.left >= 1,
+              preferredChannels.right >= 1,
+              preferredChannels.left != preferredChannels.right,
+              preferredChannels.left <= UInt32(outputChannelCount),
+              preferredChannels.right <= UInt32(outputChannelCount) else {
+            return (0, 1)
+        }
+        return (Int(preferredChannels.left) - 1, Int(preferredChannels.right) - 1)
+    }
+
+    static func encodedPlaybackChannelPair(left: Int, right: Int) -> UInt64 {
+        let maxChannelIndex = CoreAudioDeviceQuery.maxChannelCount - 1
+        let clampedLeft = UInt64(min(max(left, 0), maxChannelIndex))
+        let clampedRight = UInt64(min(max(right, 0), maxChannelIndex))
+        return (clampedLeft << 32) | clampedRight
+    }
+
+    static func decodedPlaybackChannelPair(_ encoded: UInt64) -> (left: Int, right: Int) {
+        (Int(encoded >> 32), Int(encoded & 0xFFFF_FFFF))
+    }
+
     static func performAfterRuntimeChannelValidation<T>(
         for output: AudioOutputDevice,
         _ operation: () throws -> T
@@ -1418,6 +1484,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         destinationFrameOffset: Int,
         frameCount: Int,
         sourceChannelCount: Int,
+        destinationLeftChannel: Int = 0,
+        destinationRightChannel: Int = 1,
         to buffers: UnsafeMutableAudioBufferListPointer
     ) {
         let sourceChannelCount = max(sourceChannelCount, 1)
@@ -1441,32 +1509,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
         if buffers.count == 1,
            let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
-           sourceChannelCount == 1,
-           Int(buffers[0].mNumberChannels) > 1,
-           frameCount > 0,
-           sourceFrameOffset >= 0,
-           destinationFrameOffset >= 0 {
-            let destinationChannelCount = Int(buffers[0].mNumberChannels)
-            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
-            for frameIndex in 0..<frameCount {
-                let sourceIndex = sourceFrameOffset + frameIndex
-                guard sourceIndex < samples.count else {
-                    continue
-                }
-                let destinationBase = (destinationFrameOffset + frameIndex) * destinationChannelCount
-                guard destinationBase < destinationSamples else {
-                    continue
-                }
-                for channel in 0..<destinationChannelCount where destinationBase + channel < destinationSamples {
-                    data[destinationBase + channel] = samples[sourceIndex]
-                }
-            }
-            return
-        }
-
-        if buffers.count == 1,
-           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
            Int(buffers[0].mNumberChannels) == sourceChannelCount,
+           destinationLeftChannel == 0,
+           destinationRightChannel == 1,
            frameCount > 0,
            sourceFrameOffset >= 0,
            destinationFrameOffset >= 0 {
@@ -1483,19 +1528,82 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             }
         }
 
+        // General mapped case: the destination pair channels receive source L/R (mono sources
+        // feed both); every other channel gets explicit zeros. Never trust HAL pre-zeroing —
+        // stray signal would leak into a multi-channel interface's DAW/loopback channels.
+        // Walks the AudioBufferList with a running global channel offset so interleaved,
+        // multi-stream, and per-channel-buffer layouts all map correctly.
+        guard frameCount > 0, sourceFrameOffset >= 0, destinationFrameOffset >= 0 else {
+            return
+        }
+        let sourceRightChannel = min(1, sourceChannelCount - 1)
+        var globalChannelOffset = 0
         for bufferIndex in buffers.indices {
-            guard let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self) else {
+            let bufferChannels = Int(buffers[bufferIndex].mNumberChannels)
+            guard bufferChannels > 0,
+                  let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self) else {
+                globalChannelOffset += max(bufferChannels, 0)
                 continue
             }
-            let sourceChannel = min(bufferIndex, sourceChannelCount - 1)
             let destinationSampleCount = Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride
-            for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSampleCount {
-                let sourceIndex = (sourceFrameOffset + frameIndex) * sourceChannelCount + sourceChannel
-                guard sourceIndex < samples.count else {
-                    continue
-                }
-                data[destinationFrameOffset + frameIndex] = samples[sourceIndex]
+            let zeroStart = destinationFrameOffset * bufferChannels
+            let zeroEnd = min((destinationFrameOffset + frameCount) * bufferChannels, destinationSampleCount)
+            if zeroStart < zeroEnd {
+                data.advanced(by: zeroStart).update(repeating: 0, count: zeroEnd - zeroStart)
             }
+            scatterMappedChannel(
+                samples,
+                sourceChannel: 0,
+                sourceFrameOffset: sourceFrameOffset,
+                sourceChannelCount: sourceChannelCount,
+                localChannel: destinationLeftChannel - globalChannelOffset,
+                destinationFrameOffset: destinationFrameOffset,
+                frameCount: frameCount,
+                bufferChannels: bufferChannels,
+                destinationSampleCount: destinationSampleCount,
+                into: data
+            )
+            scatterMappedChannel(
+                samples,
+                sourceChannel: sourceRightChannel,
+                sourceFrameOffset: sourceFrameOffset,
+                sourceChannelCount: sourceChannelCount,
+                localChannel: destinationRightChannel - globalChannelOffset,
+                destinationFrameOffset: destinationFrameOffset,
+                frameCount: frameCount,
+                bufferChannels: bufferChannels,
+                destinationSampleCount: destinationSampleCount,
+                into: data
+            )
+            globalChannelOffset += bufferChannels
+        }
+    }
+
+    private static func scatterMappedChannel(
+        _ samples: UnsafeBufferPointer<Float>,
+        sourceChannel: Int,
+        sourceFrameOffset: Int,
+        sourceChannelCount: Int,
+        localChannel: Int,
+        destinationFrameOffset: Int,
+        frameCount: Int,
+        bufferChannels: Int,
+        destinationSampleCount: Int,
+        into data: UnsafeMutablePointer<Float>
+    ) {
+        guard localChannel >= 0, localChannel < bufferChannels else {
+            return
+        }
+        for frameIndex in 0..<frameCount {
+            let sourceIndex = (sourceFrameOffset + frameIndex) * sourceChannelCount + sourceChannel
+            guard sourceIndex < samples.count else {
+                continue
+            }
+            let destinationIndex = (destinationFrameOffset + frameIndex) * bufferChannels + localChannel
+            guard destinationIndex < destinationSampleCount else {
+                continue
+            }
+            data[destinationIndex] = samples[sourceIndex]
         }
     }
 

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -1406,7 +1406,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         guard output.outputChannelCount > 0 else {
             throw AudioDeviceAvailabilityError.outputDeviceHasNoOutputChannels(output.id)
         }
-        guard output.outputChannelCount <= 2 else {
+        // getChannelCount sums per-buffer mNumberChannels without bounding them, so a broken
+        // device can still report absurd counts; the playback mapper handles anything below this.
+        guard output.outputChannelCount <= CoreAudioDeviceQuery.maxChannelCount else {
             throw AudioDeviceAvailabilityError.unsupportedOutputChannelCount(output.id, output.outputChannelCount)
         }
         return output.outputChannelCount

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -44,15 +44,30 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
-    func engineRuntimeChannelPolicyAcceptsMonoAndStereoOnly() throws {
+    func engineRuntimeChannelPolicyAcceptsUpToMaxChannelCount() throws {
         #expect(try SystemTapAudioEngine.supportedRuntimeChannelCount(for: output(channelCount: 1)) == 1)
         #expect(try SystemTapAudioEngine.supportedRuntimeChannelCount(for: output(channelCount: 2)) == 2)
+        #expect(try SystemTapAudioEngine.supportedRuntimeChannelCount(for: output(channelCount: 6)) == 6)
+        #expect(try SystemTapAudioEngine.supportedRuntimeChannelCount(
+            for: output(channelCount: CoreAudioDeviceQuery.maxChannelCount)
+        ) == CoreAudioDeviceQuery.maxChannelCount)
 
         do {
-            _ = try SystemTapAudioEngine.supportedRuntimeChannelCount(for: output(channelCount: 3))
-            Issue.record("Expected multichannel output to be rejected")
+            _ = try SystemTapAudioEngine.supportedRuntimeChannelCount(for: output(channelCount: 0))
+            Issue.record("Expected zero-channel output to be rejected")
         } catch let error as AudioDeviceAvailabilityError {
-            #expect(error == .unsupportedOutputChannelCount(42, 3))
+            #expect(error == .outputDeviceHasNoOutputChannels(42))
+        } catch {
+            Issue.record("Expected no-output-channels error, got \(error)")
+        }
+
+        do {
+            _ = try SystemTapAudioEngine.supportedRuntimeChannelCount(
+                for: output(channelCount: CoreAudioDeviceQuery.maxChannelCount + 1)
+            )
+            Issue.record("Expected out-of-range channel count to be rejected")
+        } catch let error as AudioDeviceAvailabilityError {
+            #expect(error == .unsupportedOutputChannelCount(42, CoreAudioDeviceQuery.maxChannelCount + 1))
         } catch {
             Issue.record("Expected unsupported channel count error, got \(error)")
         }
@@ -61,17 +76,18 @@ struct CoreAudioDeviceTests {
     @Test
     func unsupportedRuntimeChannelCountSkipsDevicePreparation() {
         var didPrepareDevice = false
+        let channelCount = CoreAudioDeviceQuery.maxChannelCount + 1
 
         do {
             _ = try SystemTapAudioEngine.performAfterRuntimeChannelValidation(
-                for: output(channelCount: 6, sampleRate: 44_100)
+                for: output(channelCount: channelCount, sampleRate: 44_100)
             ) {
                 didPrepareDevice = true
-                return output(channelCount: 6, sampleRate: 48_000)
+                return output(channelCount: channelCount, sampleRate: 48_000)
             }
-            Issue.record("Expected multichannel output to be rejected")
+            Issue.record("Expected out-of-range output to be rejected")
         } catch let error as AudioDeviceAvailabilityError {
-            #expect(error == .unsupportedOutputChannelCount(42, 6))
+            #expect(error == .unsupportedOutputChannelCount(42, channelCount))
         } catch {
             Issue.record("Expected unsupported channel count error, got \(error)")
         }

--- a/Tests/GlassEQAudioTests/MultiChannelOutputMappingTests.swift
+++ b/Tests/GlassEQAudioTests/MultiChannelOutputMappingTests.swift
@@ -1,0 +1,264 @@
+import CoreAudio
+import Foundation
+@testable import GlassEQAudio
+import Testing
+
+@Suite
+struct MultiChannelOutputMappingTests {
+    @Test
+    func playbackStereoPairNormalizesPreferredChannels() {
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: nil, outputChannelCount: 6) == (0, 1))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (1, 2), outputChannelCount: 6) == (0, 1))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (3, 4), outputChannelCount: 6) == (2, 3))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (0, 0), outputChannelCount: 6) == (0, 1))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (7, 8), outputChannelCount: 6) == (0, 1))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (3, 3), outputChannelCount: 6) == (0, 1))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (2, 1), outputChannelCount: 2) == (1, 0))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: (3, 4), outputChannelCount: 1) == (0, 0))
+        #expect(SystemTapAudioEngine.playbackStereoPair(preferredChannels: nil, outputChannelCount: 1) == (0, 0))
+    }
+
+    @Test
+    func playbackChannelPairEncodingRoundTripsAndClamps() {
+        #expect(SystemTapAudioEngine.decodedPlaybackChannelPair(
+            SystemTapAudioEngine.encodedPlaybackChannelPair(left: 0, right: 1)
+        ) == (0, 1))
+        #expect(SystemTapAudioEngine.decodedPlaybackChannelPair(
+            SystemTapAudioEngine.encodedPlaybackChannelPair(left: 2, right: 3)
+        ) == (2, 3))
+        #expect(SystemTapAudioEngine.decodedPlaybackChannelPair(
+            SystemTapAudioEngine.encodedPlaybackChannelPair(left: 255, right: 255)
+        ) == (255, 255))
+        #expect(SystemTapAudioEngine.decodedPlaybackChannelPair(
+            SystemTapAudioEngine.encodedPlaybackChannelPair(left: -5, right: 999)
+        ) == (0, 255))
+    }
+
+    @Test
+    func stereoSourceMapsToFirstPairOfInterleavedSixChannelBuffer() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [6],
+            frames: 3,
+            destinationFrameOffset: 1,
+            frameCount: 2
+        )
+
+        #expect(written == [[
+            -1, -1, -1, -1, -1, -1,
+            1, 2, 0, 0, 0, 0,
+            3, 4, 0, 0, 0, 0
+        ]])
+    }
+
+    @Test
+    func stereoSourceMapsToPreferredPairOfInterleavedSixChannelBuffer() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [6],
+            frames: 2,
+            pair: (2, 3)
+        )
+
+        #expect(written == [[
+            0, 0, 1, 2, 0, 0,
+            0, 0, 3, 4, 0, 0
+        ]])
+    }
+
+    @Test
+    func stereoSourceMapsIntoMiddleStreamOfMultiStreamLayout() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [2, 2, 2],
+            frames: 2,
+            pair: (2, 3)
+        )
+
+        #expect(written == [
+            [0, 0, 0, 0],
+            [1, 2, 3, 4],
+            [0, 0, 0, 0]
+        ])
+    }
+
+    @Test
+    func stereoSourcePairCanSpanStreamBoundaries() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [2, 2, 2],
+            frames: 2,
+            pair: (1, 2)
+        )
+
+        #expect(written == [
+            [0, 1, 0, 3],
+            [2, 0, 4, 0],
+            [0, 0, 0, 0]
+        ])
+    }
+
+    @Test
+    func monoSourceFeedsBothPairChannelsOnly() {
+        let written = mappedCopy(
+            source: [5, 6],
+            sourceChannelCount: 1,
+            channelLayout: [6],
+            frames: 2,
+            pair: (2, 3)
+        )
+
+        #expect(written == [[
+            0, 0, 5, 5, 0, 0,
+            0, 0, 6, 6, 0, 0
+        ]])
+    }
+
+    @Test
+    func pairBeyondDeviceBuffersProducesSilenceWithoutCrashing() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [2, 2],
+            frames: 2,
+            pair: (4, 5)
+        )
+
+        #expect(written == [
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ])
+    }
+
+    @Test
+    func chunkedMappedWritesTileWithoutOverwritingEachOther() {
+        let written = withMappedBuffers(channelLayout: [6], frames: 4) { buffers in
+            let firstChunk: [Float] = [1, 2, 3, 4]
+            let secondChunk: [Float] = [5, 6, 7, 8]
+            firstChunk.withUnsafeBufferPointer { source in
+                SystemTapAudioEngine.copyInterleavedSamples(
+                    source,
+                    sourceFrameOffset: 0,
+                    destinationFrameOffset: 0,
+                    frameCount: 2,
+                    sourceChannelCount: 2,
+                    destinationLeftChannel: 0,
+                    destinationRightChannel: 1,
+                    to: buffers
+                )
+            }
+            secondChunk.withUnsafeBufferPointer { source in
+                SystemTapAudioEngine.copyInterleavedSamples(
+                    source,
+                    sourceFrameOffset: 0,
+                    destinationFrameOffset: 2,
+                    frameCount: 2,
+                    sourceChannelCount: 2,
+                    destinationLeftChannel: 0,
+                    destinationRightChannel: 1,
+                    to: buffers
+                )
+            }
+        }
+
+        #expect(written == [[
+            1, 2, 0, 0, 0, 0,
+            3, 4, 0, 0, 0, 0,
+            5, 6, 0, 0, 0, 0,
+            7, 8, 0, 0, 0, 0
+        ]])
+    }
+
+    @Test
+    func reversedPairSwapsChannelsOnStereoDevice() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [2],
+            frames: 2,
+            pair: (1, 0)
+        )
+
+        #expect(written == [[2, 1, 4, 3]])
+    }
+
+    @Test
+    func identityPairKeepsStereoFastPathBehavior() {
+        let written = mappedCopy(
+            source: [1, 2, 3, 4],
+            sourceChannelCount: 2,
+            channelLayout: [2],
+            frames: 2,
+            pair: (0, 1)
+        )
+
+        #expect(written == [[1, 2, 3, 4]])
+    }
+
+    // MARK: - Helpers
+
+    /// Builds an AudioBufferList with one garbage-prefilled buffer per channelLayout entry,
+    /// runs the body against it, and returns the resulting buffer contents.
+    private func withMappedBuffers(
+        channelLayout: [Int],
+        frames: Int,
+        prefill: Float = -1,
+        _ body: (UnsafeMutableAudioBufferListPointer) -> Void
+    ) -> [[Float]] {
+        let storages = channelLayout.map { channels -> UnsafeMutableBufferPointer<Float> in
+            let storage = UnsafeMutableBufferPointer<Float>.allocate(capacity: channels * frames)
+            storage.initialize(repeating: prefill)
+            return storage
+        }
+        defer {
+            for storage in storages {
+                storage.deallocate()
+            }
+        }
+
+        let bufferList = AudioBufferList.allocate(maximumBuffers: channelLayout.count)
+        defer {
+            free(bufferList.unsafeMutablePointer)
+        }
+        for (index, channels) in channelLayout.enumerated() {
+            bufferList[index] = AudioBuffer(
+                mNumberChannels: UInt32(channels),
+                mDataByteSize: UInt32(channels * frames * MemoryLayout<Float>.stride),
+                mData: UnsafeMutableRawPointer(storages[index].baseAddress)
+            )
+        }
+
+        body(bufferList)
+
+        return storages.map(Array.init)
+    }
+
+    private func mappedCopy(
+        source: [Float],
+        sourceChannelCount: Int,
+        channelLayout: [Int],
+        frames: Int,
+        destinationFrameOffset: Int = 0,
+        frameCount: Int? = nil,
+        pair: (left: Int, right: Int) = (0, 1)
+    ) -> [[Float]] {
+        withMappedBuffers(channelLayout: channelLayout, frames: frames) { buffers in
+            source.withUnsafeBufferPointer { sourcePointer in
+                SystemTapAudioEngine.copyInterleavedSamples(
+                    sourcePointer,
+                    sourceFrameOffset: 0,
+                    destinationFrameOffset: destinationFrameOffset,
+                    frameCount: frameCount ?? frames,
+                    sourceChannelCount: sourceChannelCount,
+                    destinationLeftChannel: pair.left,
+                    destinationRightChannel: pair.right,
+                    to: buffers
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Allow multi-channel output devices up to the guarded Core Audio channel cap instead of rejecting anything above stereo.
- Route GlassEQ's stereo stream to the device's preferred stereo pair from Core Audio, falling back to channels 1/2 when needed.
- Replace playback fallback writes with mapped writes that handle interleaved, multi-stream, and per-channel buffer layouts while zeroing non-target channels.
- Update the README limitation to describe stereo processing on multi-channel interfaces.

Fixes #4