### PR TITLE
fix(settings): fall back to in-process settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,8 @@ let package = Package(
             dependencies: [
                 "GlassEQCore",
                 "GlassEQAudio",
-                "GlassEQSettingsIPC"
+                "GlassEQSettingsIPC",
+                "GlassEQSettingsUI"
             ],
             exclude: [
                 "Info.plist"
@@ -104,7 +105,8 @@ let package = Package(
                 "GlassEQApp",
                 "GlassEQAudio",
                 "GlassEQCore",
-                "GlassEQSettingsIPC"
+                "GlassEQSettingsIPC",
+                "GlassEQSettingsUI"
             ]
         ),
         .testTarget(

--- a/Scripts/build-debug-app.sh
+++ b/Scripts/build-debug-app.sh
@@ -76,8 +76,10 @@ if [[ -f "$ICON_FILE" ]]; then
     cp "$ICON_FILE" "$SETTINGS_RESOURCES_DIR/GlassEQ.icns"
 fi
 copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "$APP_TARGET" "$RESOURCES_DIR"
+copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "GlassEQSettingsUI" "$RESOURCES_DIR" 1
 copy_spm_resources "$BUILD_BIN_DIR" "$SETTINGS_APP_NAME" "$SETTINGS_APP_TARGET" "$SETTINGS_RESOURCES_DIR" 0
 copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "GlassEQSettingsUI" "$SETTINGS_RESOURCES_DIR" 1
+[[ -d "$RESOURCES_DIR/GlassEQ_GlassEQSettingsUI.bundle" ]] || fail "GlassEQSettingsUI fallback resource bundle was not copied into the main app resources"
 [[ -d "$SETTINGS_RESOURCES_DIR/GlassEQ_GlassEQSettingsUI.bundle" ]] || fail "GlassEQSettingsUI resource bundle was not copied into the settings helper resources"
 verify_no_unresolved_plist_tokens "$INFO_PLIST" "$SETTINGS_INFO_PLIST"
 

--- a/Scripts/build-release-app.sh
+++ b/Scripts/build-release-app.sh
@@ -211,8 +211,10 @@ cp "$ICON_FILE" "$RESOURCES_DIR/GlassEQ.icns"
 cp "$ICON_FILE" "$SETTINGS_RESOURCES_DIR/GlassEQ.icns"
 cp "$MIGRATION_PLIST" "$RESOURCES_DIR/container-migration.plist"
 copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "$APP_TARGET" "$RESOURCES_DIR"
+copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "GlassEQSettingsUI" "$RESOURCES_DIR" 1
 copy_spm_resources "$BUILD_BIN_DIR" "$SETTINGS_APP_NAME" "$SETTINGS_APP_TARGET" "$SETTINGS_RESOURCES_DIR" 0
 copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "GlassEQSettingsUI" "$SETTINGS_RESOURCES_DIR" 1
+[[ -d "$RESOURCES_DIR/GlassEQ_GlassEQSettingsUI.bundle" ]] || fail "GlassEQSettingsUI fallback resource bundle was not copied into the main app resources"
 [[ -d "$SETTINGS_RESOURCES_DIR/GlassEQ_GlassEQSettingsUI.bundle" ]] || fail "GlassEQSettingsUI resource bundle was not copied into the settings helper resources"
 
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$INFO_PLIST"

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -29,6 +29,12 @@ struct GlassEQApp: App {
         Window(localized("Configure GlassEQ"), id: GlassEQWindowID.inProcessSettings) {
             SettingsView(model: model.inProcessSettingsViewModel())
                 .frame(minWidth: 760, minHeight: 500)
+                .onAppear {
+                    model.inProcessSettingsDidAppear()
+                }
+                .onDisappear {
+                    model.inProcessSettingsDidDisappear()
+                }
         }
         .defaultSize(width: 1180, height: 720)
         .windowResizability(.contentMinSize)
@@ -392,6 +398,7 @@ final class GlassEQAppModel {
     @ObservationIgnored private let engineWorkExecutor = EngineWorkExecutor()
     @ObservationIgnored lazy var settingsCoordinator = SettingsCoordinator(model: self)
     @ObservationIgnored var inProcessSettingsViewModelStorage: GlassEQSettingsViewModel?
+    @ObservationIgnored var inProcessSettingsIsPresented = false
 
     private enum ProfilePersistenceMode: Equatable, Sendable {
         case normal
@@ -1928,7 +1935,10 @@ private struct MenuBarView: View {
 
                 Button {
                     dismiss()
-                    if case .inProcessFallback = model.openSettings() {
+                    switch model.openSettings() {
+                    case .helper:
+                        break
+                    case .inProcessFallback, .activeInProcessFallback:
                         openWindow(id: GlassEQWindowID.inProcessSettings)
                         NSApplication.shared.activate(ignoringOtherApps: true)
                     }

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -2,7 +2,12 @@ import AppKit
 import GlassEQAudio
 import GlassEQCore
 import GlassEQSettingsIPC
+import GlassEQSettingsUI
 import SwiftUI
+
+private enum GlassEQWindowID {
+    static let inProcessSettings = "in-process-settings"
+}
 
 @main
 struct GlassEQApp: App {
@@ -20,6 +25,15 @@ struct GlassEQApp: App {
                 .accessibilityHint(Text(localized("Opens GlassEQ controls")))
         }
         .menuBarExtraStyle(.window)
+
+        Window(localized("Configure GlassEQ"), id: GlassEQWindowID.inProcessSettings) {
+            SettingsView(model: model.inProcessSettingsViewModel())
+                .frame(minWidth: 760, minHeight: 500)
+        }
+        .defaultSize(width: 1180, height: 720)
+        .windowResizability(.contentMinSize)
+        .windowStyle(.hiddenTitleBar)
+        .defaultLaunchBehavior(.suppressed)
     }
 }
 
@@ -377,6 +391,7 @@ final class GlassEQAppModel {
     private var profilePersistenceMode: ProfilePersistenceMode = .normal
     @ObservationIgnored private let engineWorkExecutor = EngineWorkExecutor()
     @ObservationIgnored lazy var settingsCoordinator = SettingsCoordinator(model: self)
+    @ObservationIgnored var inProcessSettingsViewModelStorage: GlassEQSettingsViewModel?
 
     private enum ProfilePersistenceMode: Equatable, Sendable {
         case normal
@@ -1607,11 +1622,13 @@ final class GlassEQAppModel {
     func notifyModelDidChange() {
         NotificationCenter.default.post(name: .glassEQModelDidChange, object: self)
         settingsCoordinator.modelDidChange()
+        refreshInProcessSettingsSnapshot()
     }
 
     private func notifyMetricsDidChange() {
         NotificationCenter.default.post(name: .glassEQMetricsDidChange, object: self)
         settingsCoordinator.metricsDidChange()
+        refreshInProcessSettingsMetrics()
     }
 
     private func stopObserver() {
@@ -1863,6 +1880,7 @@ final class GlassEQAppModel {
 private struct MenuBarView: View {
     @Bindable var model: GlassEQAppModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
     @Environment(\.controlActiveState) private var controlActiveState
 
     var body: some View {
@@ -1910,7 +1928,10 @@ private struct MenuBarView: View {
 
                 Button {
                     dismiss()
-                    model.openSettings()
+                    if case .inProcessFallback = model.openSettings() {
+                        openWindow(id: GlassEQWindowID.inProcessSettings)
+                        NSApplication.shared.activate(ignoringOtherApps: true)
+                    }
                 } label: {
                     Label(localized("Settings"), systemImage: "slider.horizontal.3")
                         .frame(minWidth: 86, minHeight: 28)

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -83,9 +83,12 @@ final class GlassEQAppDelegate: NSObject, NSApplicationDelegate {
                 sender.reply(toApplicationShouldTerminate: true)
                 return
             }
+            await model.stopAcceptingSettingsCommandsAndWait()
             let shouldTerminate = await model.flushStoreBeforeQuit()
             if shouldTerminate {
                 await model.cleanupForTerminationAndWait()
+            } else {
+                model.resumeSettingsCommandsAfterCancelledQuit()
             }
             sender.reply(toApplicationShouldTerminate: shouldTerminate)
         }
@@ -399,6 +402,7 @@ final class GlassEQAppModel {
     private let defaultOutputLookup: any DefaultOutputLookingUp
     private let observerFactory: any DefaultOutputObservingMaking
     private let workspaceOpener: any WorkspaceOpening
+    private let profileImportOperation: @Sendable (ImportFormat, String, String) async -> Result<EQProfile, any Error>
     private let outputChangeSettlingDelayOverride: Duration?
     private let wakeReconnectDelayOverride: Duration?
     private let saveDebounceDelay: Duration
@@ -406,6 +410,9 @@ final class GlassEQAppModel {
     private var metricsTask: Task<Void, Never>?
     private var outputChangeTask: Task<Void, Never>?
     private var engineStartTask: Task<Void, Never>?
+    private var activeSettingsCommandCount = 0
+    private var acceptsSettingsCommands = true
+    private var settingsCommandDrainWaiters: [CheckedContinuation<Void, Never>] = []
     private var pendingSaveTask: Task<Void, Never>?
     private var lifecycleObserverTokens: [NSObjectProtocol] = []
     private var wasRunningBeforeSleep = false
@@ -473,6 +480,7 @@ final class GlassEQAppModel {
         installLifecycleObservers shouldInstallLifecycleObservers: Bool = true,
         registerAppDelegate: Bool = true,
         workspaceOpener: any WorkspaceOpening = NSWorkspace.shared,
+        profileImportOperation: (@Sendable (ImportFormat, String, String) async -> Result<EQProfile, any Error>)? = nil,
         saveDebounceDelay: Duration = .milliseconds(250),
         outputChangeSettlingDelayOverride: Duration? = nil,
         wakeReconnectDelayOverride: Duration? = nil
@@ -502,6 +510,18 @@ final class GlassEQAppModel {
         self.defaultOutputLookup = defaultOutputLookup
         self.observerFactory = observerFactory
         self.workspaceOpener = workspaceOpener
+        self.profileImportOperation = profileImportOperation ?? { format, name, text in
+            await Task.detached(priority: .userInitiated) {
+                Result<EQProfile, Error> {
+                    switch format {
+                    case .autoEQ:
+                        try EQProfileTextImporter.importAutoEQ(text, profileName: name)
+                    case .rew:
+                        try EQProfileTextImporter.importREW(text, profileName: name)
+                    }
+                }
+            }.value
+        }
         self.saveDebounceDelay = saveDebounceDelay
         self.outputChangeSettlingDelayOverride = outputChangeSettlingDelayOverride
         self.wakeReconnectDelayOverride = wakeReconnectDelayOverride
@@ -833,18 +853,11 @@ final class GlassEQAppModel {
         statusMessage = localized("Importing \(format.title)...")
         notifyModelDidChange()
 
-        let result = await Task.detached(priority: .userInitiated) {
-            Result<EQProfile, Error> {
-                let imported: EQProfile
-            switch format {
-            case .autoEQ:
-                imported = try EQProfileTextImporter.importAutoEQ(text, profileName: name)
-            case .rew:
-                imported = try EQProfileTextImporter.importREW(text, profileName: name)
-            }
-                return imported
-            }
-        }.value
+        let result = await profileImportOperation(format, name, text)
+        try Task.checkCancellation()
+        guard lifecycleState != .terminating else {
+            throw CancellationError()
+        }
 
         switch result {
         case .success(let imported):
@@ -1539,6 +1552,41 @@ final class GlassEQAppModel {
         }
     }
 
+    func beginSettingsCommand() throws {
+        guard acceptsSettingsCommands,
+              lifecycleState != .terminating else {
+            throw SettingsCommandFailure(message: localized("GlassEQ is shutting down."))
+        }
+        activeSettingsCommandCount += 1
+    }
+
+    func finishSettingsCommand() {
+        activeSettingsCommandCount -= 1
+        guard activeSettingsCommandCount == 0 else {
+            return
+        }
+        let waiters = settingsCommandDrainWaiters
+        settingsCommandDrainWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func stopAcceptingSettingsCommandsAndWait() async {
+        acceptsSettingsCommands = false
+        guard activeSettingsCommandCount > 0 else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            settingsCommandDrainWaiters.append(continuation)
+        }
+    }
+
+    func resumeSettingsCommandsAfterCancelledQuit() {
+        guard lifecycleState != .terminating else {
+            return
+        }
+        acceptsSettingsCommands = true
+    }
+
     func resetUnsupportedProfileStore() async throws {
         guard profilePersistenceMode.isProtected else {
             throw SettingsCommandFailure(message: localized("Profile store reset is only available for stores written by a newer GlassEQ."))
@@ -1564,7 +1612,9 @@ final class GlassEQAppModel {
                 NSApplication.shared.terminate(nil)
                 return
             }
+            await self.stopAcceptingSettingsCommandsAndWait()
             guard await self.flushStoreBeforeQuit() else {
+                self.resumeSettingsCommandsAfterCancelledQuit()
                 return
             }
             await self.cleanupForTerminationAndWait()
@@ -1817,6 +1867,7 @@ final class GlassEQAppModel {
     }
 
     func cleanupForTerminationAndWait() async {
+        await stopAcceptingSettingsCommandsAndWait()
         guard prepareForTermination(shutdownSettings: false) else {
             return
         }
@@ -1829,6 +1880,7 @@ final class GlassEQAppModel {
             return false
         }
         lifecycleState = .terminating
+        acceptsSettingsCommands = false
         wasRunningBeforeSleep = false
         invalidatePendingOutputChange()
         invalidatePendingEngineStart()

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -23,6 +23,9 @@ struct GlassEQApp: App {
                 .accessibilityLabel(Text(model.menuBarAccessibilityLabel))
                 .accessibilityValue(Text(model.statusMessage))
                 .accessibilityHint(Text(localized("Opens GlassEQ controls")))
+                .background {
+                    InProcessSettingsPresenter(model: model)
+                }
         }
         .menuBarExtraStyle(.window)
 
@@ -30,16 +33,34 @@ struct GlassEQApp: App {
             SettingsView(model: model.inProcessSettingsViewModel())
                 .frame(minWidth: 760, minHeight: 500)
                 .onAppear {
+                    NSApplication.shared.setActivationPolicy(.regular)
                     model.inProcessSettingsDidAppear()
                 }
                 .onDisappear {
                     model.inProcessSettingsDidDisappear()
+                    NSApplication.shared.setActivationPolicy(.accessory)
                 }
         }
         .defaultSize(width: 1180, height: 720)
         .windowResizability(.contentMinSize)
         .windowStyle(.hiddenTitleBar)
         .defaultLaunchBehavior(.suppressed)
+        .restorationBehavior(.disabled)
+    }
+}
+
+private struct InProcessSettingsPresenter: View {
+    let model: GlassEQAppModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .onChange(of: model.inProcessSettingsPresentationGeneration) {
+                NSApplication.shared.setActivationPolicy(.regular)
+                openWindow(id: GlassEQWindowID.inProcessSettings)
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
     }
 }
 
@@ -399,6 +420,8 @@ final class GlassEQAppModel {
     @ObservationIgnored lazy var settingsCoordinator = SettingsCoordinator(model: self)
     @ObservationIgnored var inProcessSettingsViewModelStorage: GlassEQSettingsViewModel?
     @ObservationIgnored var inProcessSettingsIsPresented = false
+    @ObservationIgnored var inProcessSettingsPresentationIsPending = false
+    var inProcessSettingsPresentationGeneration = 0
 
     private enum ProfilePersistenceMode: Equatable, Sendable {
         case normal
@@ -1887,7 +1910,6 @@ final class GlassEQAppModel {
 private struct MenuBarView: View {
     @Bindable var model: GlassEQAppModel
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.openWindow) private var openWindow
     @Environment(\.controlActiveState) private var controlActiveState
 
     var body: some View {
@@ -1935,13 +1957,7 @@ private struct MenuBarView: View {
 
                 Button {
                     dismiss()
-                    switch model.openSettings() {
-                    case .helper:
-                        break
-                    case .inProcessFallback, .activeInProcessFallback:
-                        openWindow(id: GlassEQWindowID.inProcessSettings)
-                        NSApplication.shared.activate(ignoringOtherApps: true)
-                    }
+                    model.openSettings()
                 } label: {
                     Label(localized("Settings"), systemImage: "slider.horizontal.3")
                         .frame(minWidth: 86, minHeight: 28)

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -94,6 +94,7 @@ final class SettingsCoordinator: NSObject {
     private var pipeReadDelivery: SettingsPipeOrderedMainActorDelivery?
     private var pipeWritePump: SettingsPipeWritePump?
     private var settingsConnected = false
+    private var readyAcknowledgmentPending = false
     private var pendingFocusRequest = false
     private var suppressedModelChangeDepth = 0
     private var lastSentSnapshot: SettingsSnapshot?
@@ -174,6 +175,7 @@ final class SettingsCoordinator: NSObject {
         let token = try Self.makeSessionToken()
         launchToken = token
         settingsConnected = false
+        readyAcknowledgmentPending = false
         pendingFocusRequest = false
         suppressedModelChangeDepth = 0
         lastSentSnapshot = nil
@@ -393,16 +395,27 @@ final class SettingsCoordinator: NSObject {
     }
 
     private func handleReady(requestID: String) {
-        settingsConnected = true
-        if let model {
-            let snapshot = model.settingsSnapshot()
-            lastSentSnapshot = snapshot
-            send(.snapshotChanged(snapshot))
+        guard !settingsConnected,
+              !readyAcknowledgmentPending else {
+            return
         }
-        sendResponse(SettingsCommandResponse(), requestID: requestID)
-        if pendingFocusRequest {
-            pendingFocusRequest = false
-            send(.focusRequested)
+        readyAcknowledgmentPending = true
+        sendResponse(SettingsCommandResponse(), requestID: requestID) { [weak self] in
+            guard let self,
+                  readyAcknowledgmentPending else {
+                return
+            }
+            readyAcknowledgmentPending = false
+            settingsConnected = true
+            if let model {
+                let snapshot = model.settingsSnapshot()
+                lastSentSnapshot = snapshot
+                send(.snapshotChanged(snapshot))
+            }
+            if pendingFocusRequest {
+                pendingFocusRequest = false
+                send(.focusRequested)
+            }
         }
     }
 
@@ -518,11 +531,18 @@ final class SettingsCoordinator: NSObject {
         }
     }
 
-    private func sendResponse(_ response: SettingsCommandResponse, requestID: String) {
+    private func sendResponse(
+        _ response: SettingsCommandResponse,
+        requestID: String,
+        onSuccess: (@MainActor @Sendable () -> Void)? = nil
+    ) {
         guard let launchToken else {
             return
         }
-        writePipeMessage(.response(sessionToken: launchToken, id: requestID, response: response, error: nil))
+        writePipeMessage(
+            .response(sessionToken: launchToken, id: requestID, response: response, error: nil),
+            onSuccess: onSuccess
+        )
     }
 
     private func sendError(_ message: String, requestID: String) {
@@ -532,7 +552,10 @@ final class SettingsCoordinator: NSObject {
         writePipeMessage(.response(sessionToken: launchToken, id: requestID, response: nil, error: message))
     }
 
-    private func writePipeMessage(_ message: SettingsPipeMessage) {
+    private func writePipeMessage(
+        _ message: SettingsPipeMessage,
+        onSuccess: (@MainActor @Sendable () -> Void)? = nil
+    ) {
         guard let pipeWritePump else {
             failPipeSession(SettingsCommandFailure(message: localized("Settings IPC pipe is not connected.")))
             return
@@ -540,18 +563,20 @@ final class SettingsCoordinator: NSObject {
         let expectedToken = message.sessionToken
         let expectedPump = pipeWritePump
         pipeWritePump.enqueue(message) { [weak self] result in
-            guard case .failure(let error) = result else {
-                return
-            }
             Task { @MainActor in
                 guard let self,
                       self.launchToken == expectedToken,
                       self.pipeWritePump === expectedPump else {
                     return
                 }
-                self.failPipeSession(SettingsCommandFailure(
-                    message: localized("Settings IPC write failed: \(error.localizedDescription)")
-                ))
+                switch result {
+                case .success:
+                    onSuccess?()
+                case .failure(let error):
+                    self.failPipeSession(SettingsCommandFailure(
+                        message: localized("Settings IPC write failed: \(error.localizedDescription)")
+                    ))
+                }
             }
         }
     }
@@ -602,6 +627,7 @@ final class SettingsCoordinator: NSObject {
         runningApplication = nil
         helperProcess = nil
         settingsConnected = false
+        readyAcknowledgmentPending = false
         if writePumpToDrain != nil || processToTerminate != nil {
             return Task {
                 if let writePumpToDrain {

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -266,6 +266,10 @@ final class SettingsCoordinator: NSObject {
             launchToken != nil ||
             runningApplication != nil
     }
+
+    var isHelperReadyForTesting: Bool {
+        settingsConnected
+    }
     #endif
 
     private func perform(_ command: SettingsCommand) async throws -> SettingsCommandResponse {
@@ -362,6 +366,8 @@ final class SettingsCoordinator: NSObject {
             break
         case let .request(_, id, .connect, _):
             handleConnect(requestID: id)
+        case let .request(_, id, .ready, _):
+            handleReady(requestID: id)
         case let .request(_, id, .command, command):
             guard let command else {
                 sendError("Settings IPC command payload was missing.", requestID: id)
@@ -380,10 +386,14 @@ final class SettingsCoordinator: NSObject {
             sendError("GlassEQ is shutting down.", requestID: requestID)
             return
         }
-        settingsConnected = true
         let snapshot = model.settingsSnapshot()
         lastSentSnapshot = snapshot
         sendResponse(SettingsCommandResponse(snapshot: snapshot), requestID: requestID)
+    }
+
+    private func handleReady(requestID: String) {
+        settingsConnected = true
+        sendResponse(SettingsCommandResponse(), requestID: requestID)
         if pendingFocusRequest {
             pendingFocusRequest = false
             send(.focusRequested)

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -533,8 +533,15 @@ final class SettingsCoordinator: NSObject {
     }
 
     private func failPipeSession(_ error: Error) {
-        statusMessageForIPCFailure(error)
+        let shouldUseFallback = launchToken != nil && !settingsConnected
         cleanupSession(terminateHelper: true)
+        if shouldUseFallback {
+            model?.requestInProcessSettingsPresentation(
+                statusMessage: localized("Settings IPC failed before connecting: \(error.localizedDescription). Opened Settings in GlassEQ instead.")
+            )
+        } else {
+            statusMessageForIPCFailure(error)
+        }
     }
 
     private func statusMessageForIPCFailure(_ error: Error) {

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -200,9 +200,9 @@ final class SettingsCoordinator: NSObject {
             arguments: [
                 "--glasseq-main-pid", String(ProcessInfo.processInfo.processIdentifier)
             ],
-            terminationHandler: { [weak self] _ in
+            terminationHandler: { [weak self] process in
                 Task { @MainActor in
-                    self?.cleanupSession(terminateHelper: false)
+                    self?.handleHelperTermination(process)
                 }
             }
         )
@@ -218,7 +218,7 @@ final class SettingsCoordinator: NSObject {
         )
         pipeReader = helperOutput.fileHandleForReading
         pipeErrorReader = helperError.fileHandleForReading
-        installPipeReader(helperOutput.fileHandleForReading)
+        installPipeReader(helperOutput.fileHandleForReading, sessionToken: token)
         pipeErrorReader?.readabilityHandler = { handle in
             _ = handle.availableData
         }
@@ -289,7 +289,7 @@ final class SettingsCoordinator: NSObject {
         writePipeMessage(.event(sessionToken: launchToken, event: event))
     }
 
-    private func installPipeReader(_ readHandle: FileHandle) {
+    private func installPipeReader(_ readHandle: FileHandle, sessionToken: String) {
         let delivery = SettingsPipeOrderedMainActorDelivery(
             label: "com.glasseq.settings-coordinator.pipe-read.delivery"
         )
@@ -307,13 +307,38 @@ final class SettingsCoordinator: NSObject {
             },
             onEndOfFile: { [weak self, delivery] in
                 delivery.enqueue {
-                    self?.cleanupSession(terminateHelper: false)
+                    self?.handlePipeEndOfFile(sessionToken: sessionToken)
                 }
             }
         )
         pipeReadDelivery = delivery
         pipeReadPump = pump
         pump.install(on: readHandle)
+    }
+
+    private func handleHelperTermination(_ process: Process) {
+        guard helperProcess === process else {
+            return
+        }
+        handleHelperExitBeforeConnectionIfNeeded()
+    }
+
+    private func handlePipeEndOfFile(sessionToken: String) {
+        guard launchToken == sessionToken else {
+            return
+        }
+        handleHelperExitBeforeConnectionIfNeeded()
+    }
+
+    private func handleHelperExitBeforeConnectionIfNeeded() {
+        let shouldUseFallback = !settingsConnected
+        cleanupSession(terminateHelper: false)
+        guard shouldUseFallback else {
+            return
+        }
+        model?.requestInProcessSettingsPresentation(
+            statusMessage: localized("Settings helper exited before connecting. Opened Settings in GlassEQ instead.")
+        )
     }
 
     private func handlePipeMessages(_ messages: [SettingsPipeMessage]) {
@@ -519,7 +544,9 @@ final class SettingsCoordinator: NSObject {
 
     @discardableResult
     private func cleanupSession(terminateHelper: Bool) -> Task<Void, Never>? {
-        model?.stopMetricsPolling()
+        if settingsConnected {
+            model?.stopMetricsPolling()
+        }
         let processToTerminate = terminateHelper ? helperProcess : nil
         let writePumpToDrain = pipeWritePump
         let writerToCloseDirectly = writePumpToDrain == nil ? pipeWriter : nil
@@ -823,18 +850,38 @@ struct SecuritySettingsCodeSigningValidator: SettingsCodeSigningValidating {
 }
 
 extension GlassEQAppModel {
+    @discardableResult
     func openSettings() -> SettingsOpenDisposition {
-        guard !inProcessSettingsIsPresented else {
+        guard !inProcessSettingsIsPresented,
+              !inProcessSettingsPresentationIsPending else {
+            requestInProcessSettingsPresentation()
             return .activeInProcessFallback
         }
-        return settingsCoordinator.openSettings()
+        let disposition = settingsCoordinator.openSettings()
+        if case .inProcessFallback(let reason) = disposition {
+            requestInProcessSettingsPresentation(
+                statusMessage: localized("Settings helper unavailable: \(reason). Opened Settings in GlassEQ instead.")
+            )
+        }
+        return disposition
+    }
+
+    func requestInProcessSettingsPresentation(statusMessage: String? = nil) {
+        if let statusMessage {
+            self.statusMessage = statusMessage
+            notifyModelDidChange()
+        }
+        inProcessSettingsPresentationIsPending = true
+        inProcessSettingsPresentationGeneration &+= 1
     }
 
     func inProcessSettingsDidAppear() {
+        inProcessSettingsPresentationIsPending = false
         inProcessSettingsIsPresented = true
     }
 
     func inProcessSettingsDidDisappear() {
+        inProcessSettingsPresentationIsPending = false
         inProcessSettingsIsPresented = false
     }
 

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -155,7 +155,8 @@ final class SettingsCoordinator: NSObject {
     }
 
     func metricsDidChange() {
-        guard let model else {
+        guard settingsConnected,
+              let model else {
             return
         }
         let metrics = SettingsAudioMetricsDTO(model.engineMetrics)
@@ -393,6 +394,11 @@ final class SettingsCoordinator: NSObject {
 
     private func handleReady(requestID: String) {
         settingsConnected = true
+        if let model {
+            let snapshot = model.settingsSnapshot()
+            lastSentSnapshot = snapshot
+            send(.snapshotChanged(snapshot))
+        }
         sendResponse(SettingsCommandResponse(), requestID: requestID)
         if pendingFocusRequest {
             pendingFocusRequest = false

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -3,11 +3,20 @@ import Darwin
 import Foundation
 import GlassEQCore
 import GlassEQSettingsIPC
+import GlassEQSettingsUI
+import OSLog
 import Security
 
 private struct UncheckedSendable<Value>: @unchecked Sendable {
     var value: Value
 }
+
+enum SettingsOpenDisposition: Equatable {
+    case helper
+    case inProcessFallback(reason: String)
+}
+
+private let settingsLogger = Logger(subsystem: "com.glasseq.app", category: "Settings")
 
 struct SettingsHelperLaunch {
     var process: Process
@@ -101,7 +110,8 @@ final class SettingsCoordinator: NSObject {
         super.init()
     }
 
-    func openSettings() {
+    @discardableResult
+    func openSettings() -> SettingsOpenDisposition {
         if let helperProcess, helperProcess.isRunning {
             if settingsConnected {
                 send(.focusRequested)
@@ -109,17 +119,19 @@ final class SettingsCoordinator: NSObject {
                 pendingFocusRequest = true
             }
             focusSettings()
-            return
+            return .helper
         }
 
         do {
             let token = try prepareSession()
             pendingFocusRequest = true
             try launchHelper(token: token)
+            return .helper
         } catch {
-            model?.statusMessage = localized("Settings failed to open: \(error.localizedDescription)")
-            model?.notifyModelDidChangeFromCoordinator()
+            let reason = error.localizedDescription
+            settingsLogger.error("Settings helper failed to launch; using in-process fallback: \(reason, privacy: .public)")
             cleanupSession(terminateHelper: true)
+            return .inProcessFallback(reason: reason)
         }
     }
 
@@ -810,8 +822,30 @@ struct SecuritySettingsCodeSigningValidator: SettingsCodeSigningValidating {
 }
 
 extension GlassEQAppModel {
-    func openSettings() {
+    func openSettings() -> SettingsOpenDisposition {
         settingsCoordinator.openSettings()
+    }
+
+    func inProcessSettingsViewModel() -> GlassEQSettingsViewModel {
+        if let inProcessSettingsViewModelStorage {
+            return inProcessSettingsViewModelStorage
+        }
+
+        let settingsModel = GlassEQSettingsViewModel()
+        settingsModel.attach(
+            client: InProcessSettingsClient(model: self),
+            snapshot: settingsSnapshot()
+        )
+        inProcessSettingsViewModelStorage = settingsModel
+        return settingsModel
+    }
+
+    func refreshInProcessSettingsSnapshot() {
+        inProcessSettingsViewModelStorage?.accept(snapshot: settingsSnapshot())
+    }
+
+    func refreshInProcessSettingsMetrics() {
+        inProcessSettingsViewModelStorage?.accept(metrics: SettingsAudioMetricsDTO(engineMetrics))
     }
 
     func notifyModelDidChangeFromCoordinator() {
@@ -895,5 +929,21 @@ extension GlassEQAppModel {
             store.profiles.append(profile)
         }
         try ProfilePersistence.validateForCommit(store)
+    }
+}
+
+@MainActor
+private final class InProcessSettingsClient: SettingsCommanding {
+    private weak var model: GlassEQAppModel?
+
+    init(model: GlassEQAppModel) {
+        self.model = model
+    }
+
+    func perform(_ command: SettingsCommand) async throws -> SettingsCommandResponse {
+        guard let model else {
+            throw SettingsCommandFailure(message: "GlassEQ is shutting down.")
+        }
+        return try await model.performSettingsCommand(command)
     }
 }

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -14,6 +14,7 @@ private struct UncheckedSendable<Value>: @unchecked Sendable {
 enum SettingsOpenDisposition: Equatable {
     case helper
     case inProcessFallback(reason: String)
+    case activeInProcessFallback
 }
 
 private let settingsLogger = Logger(subsystem: "com.glasseq.app", category: "Settings")
@@ -823,7 +824,18 @@ struct SecuritySettingsCodeSigningValidator: SettingsCodeSigningValidating {
 
 extension GlassEQAppModel {
     func openSettings() -> SettingsOpenDisposition {
-        settingsCoordinator.openSettings()
+        guard !inProcessSettingsIsPresented else {
+            return .activeInProcessFallback
+        }
+        return settingsCoordinator.openSettings()
+    }
+
+    func inProcessSettingsDidAppear() {
+        inProcessSettingsIsPresented = true
+    }
+
+    func inProcessSettingsDidDisappear() {
+        inProcessSettingsIsPresented = false
     }
 
     func inProcessSettingsViewModel() -> GlassEQSettingsViewModel {

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -437,6 +437,8 @@ final class SettingsCoordinator: NSObject {
             return
         }
 
+        let metricsChanged = previous.metrics != snapshot.metrics
+
         var patch = SettingsSnapshotPatchDTO()
         var didPatch = false
 
@@ -497,11 +499,17 @@ final class SettingsCoordinator: NSObject {
 
         guard didPatch else {
             lastSentSnapshot = snapshot
+            if metricsChanged {
+                send(.metricsChanged(snapshot.metrics))
+            }
             return
         }
 
         lastSentSnapshot = snapshot
         send(.snapshotPatched(patch))
+        if metricsChanged {
+            send(.metricsChanged(snapshot.metrics))
+        }
     }
 
     private func sendResponse(_ response: SettingsCommandResponse, requestID: String) {

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -943,6 +943,11 @@ extension GlassEQAppModel {
     }
 
     func performSettingsCommand(_ command: SettingsCommand) async throws -> SettingsCommandResponse {
+        try beginSettingsCommand()
+        defer {
+            finishSettingsCommand()
+        }
+
         switch command {
         case .createProfile(let kind):
             try createProfile(kind: kind)

--- a/Sources/GlassEQSettings/GlassEQSettingsApp.swift
+++ b/Sources/GlassEQSettings/GlassEQSettingsApp.swift
@@ -61,6 +61,7 @@ protocol SettingsPipeClientConnection: SettingsCommanding {
     var token: String? { get }
 
     func connect() async throws -> SettingsSnapshotDTO
+    func acknowledgeReady() async throws
     func disconnect()
 }
 
@@ -165,6 +166,7 @@ final class SettingsLaunchCoordinator {
             connectedToken = client.token
             connectedMainProcessIdentifier = launchInfo.mainProcessIdentifier
             model.attach(client: client, snapshot: snapshot)
+            try await client.acknowledgeReady()
         } catch {
             guard !Task.isCancelled else {
                 return
@@ -223,6 +225,10 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
 
     func perform(_ command: SettingsCommand) async throws -> SettingsCommandResponse {
         try await send(kind: .command, command: command)
+    }
+
+    func acknowledgeReady() async throws {
+        _ = try await send(kind: .ready)
     }
 
     func disconnect() {

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -319,6 +319,7 @@ public enum SettingsEvent: Codable, Equatable, Sendable {
 
 public enum SettingsPipeRequestKind: String, Codable, Equatable, Sendable {
     case connect
+    case ready
     case command
     case disconnect
 }

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1299,7 +1299,7 @@ struct GlassEQAppModelLifecycleTests {
             settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
         )
 
-        coordinator.openSettings()
+        let disposition = coordinator.openSettings()
 
         let process = try #require(launcher.launchedProcesses.first)
         defer {
@@ -1308,6 +1308,11 @@ struct GlassEQAppModelLifecycleTests {
             }
         }
         #expect(!coordinator.hasActiveSessionResourcesForTesting)
+        if case .inProcessFallback(let reason) = disposition {
+            #expect(reason.contains("Intentional post-launch validation failure"))
+        } else {
+            Issue.record("Expected in-process Settings fallback")
+        }
         for _ in 0..<250 {
             if !process.isRunning {
                 break
@@ -1315,7 +1320,42 @@ struct GlassEQAppModelLifecycleTests {
             try? await Task.sleep(for: .milliseconds(10))
         }
         #expect(!process.isRunning)
-        #expect(model.statusMessage.contains("Settings failed to open"))
+    }
+
+    @Test
+    func settingsLaunchPermissionFailureRequestsInProcessFallback() {
+        let model = makeModel()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: PermissionDeniedSettingsHelperLauncher(),
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        let disposition = coordinator.openSettings()
+
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+        if case .inProcessFallback(let reason) = disposition {
+            #expect(reason.contains("Operation not permitted"))
+        } else {
+            Issue.record("Expected in-process Settings fallback after EPERM")
+        }
+    }
+
+    @Test
+    func inProcessSettingsFallbackPerformsCommandsAndTracksModelChanges() async throws {
+        let model = makeModel()
+        let settingsModel = model.inProcessSettingsViewModel()
+        let snapshotVersion = settingsModel.snapshotVersion
+
+        #expect(settingsModel.isConnected)
+        #expect(settingsModel.snapshot == model.settingsSnapshot())
+        #expect(model.inProcessSettingsViewModel() === settingsModel)
+        #expect(settingsModel.snapshotVersion == snapshotVersion)
+
+        let response = await settingsModel.perform(.createProfile(.parametric))
+        #expect(response?.snapshot?.profiles.count == 2)
+        #expect(settingsModel.snapshot == model.settingsSnapshot())
     }
 
     @Test
@@ -1643,6 +1683,24 @@ private struct FailingSettingsHelperLaunchValidator: SettingsHelperLaunchValidat
 
     func validateRunningProcess(processIdentifier: pid_t, expectedHelperURL: URL) throws {
         throw SettingsCommandFailure(message: "Intentional post-launch validation failure")
+    }
+}
+
+private struct PermissiveSettingsHelperLaunchValidator: SettingsHelperLaunchValidating {
+    func validatedExecutableURL(for helperURL: URL) throws -> URL {
+        URL(fileURLWithPath: "/bin/true")
+    }
+
+    func validateRunningProcess(processIdentifier: pid_t, expectedHelperURL: URL) throws {}
+}
+
+private struct PermissionDeniedSettingsHelperLauncher: SettingsHelperLaunching {
+    func launch(
+        executableURL: URL,
+        arguments: [String],
+        terminationHandler: @escaping @Sendable (Process) -> Void
+    ) throws -> SettingsHelperLaunch {
+        throw POSIXError(.EPERM)
     }
 }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1363,6 +1363,36 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsHelperExitAfterConnectBeforeReadyRequestsInProcessFallback() async throws {
+        let model = makeModel()
+        let launcher = ControllableSettingsHelperLauncher()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: launcher,
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+        let bootstrap = try #require(launcher.readHostMessages().first)
+        guard case .bootstrap(let token) = bootstrap else {
+            Issue.record("Expected Settings bootstrap message")
+            return
+        }
+        try launcher.writeHelperOutput(try SettingsPipeCodec.encodeLine(
+            .request(sessionToken: token, id: "connect", kind: .connect, command: nil)
+        ))
+        try launcher.closeHelperOutput()
+
+        for _ in 0..<100 where model.inProcessSettingsPresentationGeneration == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(model.inProcessSettingsPresentationGeneration == 1)
+        #expect(model.statusMessage.contains("exited before connecting"))
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+    }
+
+    @Test
     func malformedSettingsIPCBeforeConnectingRequestsInProcessFallback() async throws {
         let model = makeModel()
         let launcher = ControllableSettingsHelperLauncher()
@@ -1802,6 +1832,17 @@ private final class ControllableSettingsHelperLauncher: SettingsHelperLaunching 
 
     func writeHelperOutput(_ data: Data) throws {
         try output.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    func closeHelperOutput() throws {
+        try output.fileHandleForWriting.close()
+    }
+
+    func readHostMessages() throws -> [SettingsPipeMessage] {
+        let data = input.fileHandleForReading.availableData
+        return try data.split(separator: 0x0A).map { line in
+            try SettingsPipeCodec.decodeLine(Data(line))
+        }
     }
 }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1343,6 +1343,26 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsHelperExitBeforeConnectingRequestsInProcessFallback() async throws {
+        let model = makeModel()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: ProcessSettingsHelperLauncher(),
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+
+        for _ in 0..<100 where model.inProcessSettingsPresentationGeneration == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(model.inProcessSettingsPresentationGeneration == 1)
+        #expect(model.statusMessage.contains("exited before connecting"))
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+    }
+
+    @Test
     func activeInProcessSettingsFallbackIsReusedWithoutLaunchingHelper() {
         let model = makeModel()
 
@@ -1350,6 +1370,17 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.openSettings() == .activeInProcessFallback)
 
         model.inProcessSettingsDidDisappear()
+    }
+
+    @Test
+    func pendingInProcessSettingsFallbackIsReusedWithoutLaunchingHelper() {
+        let model = makeModel()
+
+        model.requestInProcessSettingsPresentation()
+        let firstGeneration = model.inProcessSettingsPresentationGeneration
+
+        #expect(model.openSettings() == .activeInProcessFallback)
+        #expect(model.inProcessSettingsPresentationGeneration == firstGeneration + 1)
     }
 
     @Test
@@ -1698,7 +1729,7 @@ private struct FailingSettingsHelperLaunchValidator: SettingsHelperLaunchValidat
 
 private struct PermissiveSettingsHelperLaunchValidator: SettingsHelperLaunchValidating {
     func validatedExecutableURL(for helperURL: URL) throws -> URL {
-        URL(fileURLWithPath: "/bin/true")
+        URL(fileURLWithPath: "/usr/bin/true")
     }
 
     func validateRunningProcess(processIdentifier: pid_t, expectedHelperURL: URL) throws {}

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1414,7 +1414,15 @@ struct GlassEQAppModelLifecycleTests {
         )
 
         #expect(coordinator.openSettings() == .helper)
-        let bootstrap = try #require(launcher.readHostMessages().first)
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                if case .bootstrap = message {
+                    return true
+                }
+                return false
+            }
+        }
+        let bootstrap = try #require(launcher.receivedAppMessages.first)
         guard case .bootstrap(let token) = bootstrap else {
             Issue.record("Expected Settings bootstrap message")
             return
@@ -1466,7 +1474,15 @@ struct GlassEQAppModelLifecycleTests {
         )
 
         #expect(coordinator.openSettings() == .helper)
-        let bootstrap = try #require(launcher.readHostMessages().first)
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                if case .bootstrap = message {
+                    return true
+                }
+                return false
+            }
+        }
+        let bootstrap = try #require(launcher.receivedAppMessages.first)
         guard case .bootstrap(let token) = bootstrap else {
             Issue.record("Expected Settings bootstrap message")
             return
@@ -1481,7 +1497,7 @@ struct GlassEQAppModelLifecycleTests {
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(coordinator.isHelperReadyForTesting)
-        _ = try launcher.readHostMessages()
+        let baselineMessageCount = launcher.receivedAppMessages.count
 
         model.engineMetrics = AudioEngineMetrics(capturedFrames: 42)
         coordinator.modelDidChange()
@@ -1490,12 +1506,12 @@ struct GlassEQAppModelLifecycleTests {
             sessionToken: token,
             event: .metricsChanged(SettingsAudioMetricsDTO(capturedFrames: 42))
         )
-        var messages: [SettingsPipeMessage] = []
-        for _ in 0..<100 where !messages.contains(expectedMessage) {
-            try await Task.sleep(for: .milliseconds(10))
-            messages.append(contentsOf: try launcher.readHostMessages())
+        await waitUntil {
+            launcher.receivedAppMessages
+                .dropFirst(baselineMessageCount)
+                .contains(expectedMessage)
         }
-        #expect(messages.contains(expectedMessage))
+        #expect(launcher.receivedAppMessages.contains(expectedMessage))
         coordinator.shutdown()
     }
 
@@ -2000,33 +2016,52 @@ private struct PermissionDeniedSettingsHelperLauncher: SettingsHelperLaunching {
     }
 }
 
-private final class ControllableSettingsHelperLauncher: SettingsHelperLaunching {
+private final class ControllableSettingsHelperLauncher: SettingsHelperLaunching, @unchecked Sendable {
     private let input = Pipe()
     private let output = Pipe()
     private let error = Pipe()
+    private let messagesLock = NSLock()
+    private var messages: [SettingsPipeMessage] = []
+    private var appReadPump: SettingsPipeReadPump?
+
+    var receivedAppMessages: [SettingsPipeMessage] {
+        messagesLock.withLock { messages }
+    }
 
     func launch(
         executableURL: URL,
         arguments: [String],
         terminationHandler: @escaping @Sendable (Process) -> Void
     ) throws -> SettingsHelperLaunch {
-        SettingsHelperLaunch(process: Process(), input: input, output: output, error: error)
+        let pump = SettingsPipeReadPump(
+            label: "com.glasseq.tests.settings-helper-input",
+            onMessages: { [weak self] result in
+                guard let self, case .success(let messages) = result else {
+                    return
+                }
+                messagesLock.withLock {
+                    self.messages.append(contentsOf: messages)
+                }
+            },
+            onEndOfFile: {}
+        )
+        appReadPump = pump
+        pump.install(on: input.fileHandleForReading)
+        return SettingsHelperLaunch(process: Process(), input: input, output: output, error: error)
     }
 
     func writeHelperOutput(_ data: Data) throws {
         try output.fileHandleForWriting.write(contentsOf: data)
     }
 
+    func writeHelperMessage(_ message: SettingsPipeMessage) throws {
+        try writeHelperOutput(SettingsPipeCodec.encodeLine(message))
+    }
+
     func closeHelperOutput() throws {
         try output.fileHandleForWriting.close()
     }
 
-    func readHostMessages() throws -> [SettingsPipeMessage] {
-        let data = input.fileHandleForReading.availableData
-        return try data.split(separator: 0x0A).map { line in
-            try SettingsPipeCodec.decodeLine(Data(line))
-        }
-    }
 }
 
 private final class ClosedInputSettingsHelperLauncher: SettingsHelperLaunching {

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1415,6 +1415,46 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsModelNotificationPublishesMetricsOnlyChanges() async throws {
+        let model = makeModel()
+        let launcher = ControllableSettingsHelperLauncher()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: launcher,
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+        let bootstrap = try #require(launcher.readHostMessages().first)
+        guard case .bootstrap(let token) = bootstrap else {
+            Issue.record("Expected Settings bootstrap message")
+            return
+        }
+        let requests = try SettingsPipeCodec.encodeLine(
+            .request(sessionToken: token, id: "connect", kind: .connect, command: nil)
+        ) + SettingsPipeCodec.encodeLine(
+            .request(sessionToken: token, id: "ready", kind: .ready, command: nil)
+        )
+        try launcher.writeHelperOutput(requests)
+        for _ in 0..<100 where !coordinator.isHelperReadyForTesting {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(coordinator.isHelperReadyForTesting)
+        _ = try launcher.readHostMessages()
+
+        model.engineMetrics = AudioEngineMetrics(capturedFrames: 42)
+        coordinator.modelDidChange()
+
+        let messages = try launcher.readHostMessages()
+        #expect(messages.contains(.event(
+            sessionToken: token,
+            event: .metricsChanged(SettingsAudioMetricsDTO(capturedFrames: 42))
+        )))
+        coordinator.shutdown()
+    }
+
+    @Test
     func settingsBootstrapWriteFailureRequestsInProcessFallback() async throws {
         let model = makeModel()
         let coordinator = SettingsCoordinator(

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1343,6 +1343,16 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func activeInProcessSettingsFallbackIsReusedWithoutLaunchingHelper() {
+        let model = makeModel()
+
+        model.inProcessSettingsDidAppear()
+        #expect(model.openSettings() == .activeInProcessFallback)
+
+        model.inProcessSettingsDidDisappear()
+    }
+
+    @Test
     func inProcessSettingsFallbackPerformsCommandsAndTracksModelChanges() async throws {
         let model = makeModel()
         let settingsModel = model.inProcessSettingsViewModel()

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1460,6 +1460,70 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsReadyPublishesChangesThatOccurredAfterConnect() async throws {
+        let model = makeModel()
+        let launcher = ControllableSettingsHelperLauncher()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: launcher,
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                if case .bootstrap = message {
+                    return true
+                }
+                return false
+            }
+        }
+        let bootstrap = try #require(launcher.receivedAppMessages.first)
+        guard case .bootstrap(let token) = bootstrap else {
+            Issue.record("Expected Settings bootstrap message")
+            return
+        }
+        try launcher.writeHelperMessage(.request(
+            sessionToken: token,
+            id: "connect",
+            kind: .connect,
+            command: nil
+        ))
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                if case .response(_, "connect", _, _) = message {
+                    return true
+                }
+                return false
+            }
+        }
+
+        model.statusMessage = "Changed before ready"
+        model.engineMetrics = AudioEngineMetrics(capturedFrames: 42)
+        coordinator.modelDidChange()
+        coordinator.metricsDidChange()
+        try launcher.writeHelperMessage(.request(
+            sessionToken: token,
+            id: "ready",
+            kind: .ready,
+            command: nil
+        ))
+
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                guard case .event(_, .snapshotChanged(let snapshot)) = message else {
+                    return false
+                }
+                return snapshot.statusMessage == "Changed before ready"
+                    && snapshot.metrics.capturedFrames == 42
+            }
+        }
+        #expect(coordinator.isHelperReadyForTesting)
+        coordinator.shutdown()
+    }
+
+    @Test
     func settingsBootstrapWriteFailureRequestsInProcessFallback() async throws {
         let model = makeModel()
         let coordinator = SettingsCoordinator(

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1389,7 +1389,7 @@ struct GlassEQAppModelLifecycleTests {
         let model = makeModel()
         let coordinator = SettingsCoordinator(
             model: model,
-            helperLauncher: ClosedInputSettingsHelperLauncher(),
+            helperLauncher: try ClosedInputSettingsHelperLauncher(),
             helperValidator: PermissiveSettingsHelperLaunchValidator(),
             settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
         )
@@ -1805,15 +1805,21 @@ private final class ControllableSettingsHelperLauncher: SettingsHelperLaunching 
     }
 }
 
-private struct ClosedInputSettingsHelperLauncher: SettingsHelperLaunching {
+private final class ClosedInputSettingsHelperLauncher: SettingsHelperLaunching {
+    private let input = Pipe()
+    private let output = Pipe()
+    private let error = Pipe()
+
+    init() throws {
+        try input.fileHandleForReading.close()
+    }
+
     func launch(
         executableURL: URL,
         arguments: [String],
         terminationHandler: @escaping @Sendable (Process) -> Void
     ) throws -> SettingsHelperLaunch {
-        let input = Pipe()
-        try input.fileHandleForReading.close()
-        return SettingsHelperLaunch(process: Process(), input: input, output: Pipe(), error: Pipe())
+        SettingsHelperLaunch(process: Process(), input: input, output: output, error: error)
     }
 }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1289,6 +1289,46 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func quitWaitsForInFlightImportBeforeFlushingProfiles() async throws {
+        let storeURL = temporaryAppStoreURL()
+        defer { removeTemporaryStoreDirectory(for: storeURL) }
+        let importer = BlockingProfileImportOperation()
+        let importedProfile = makeProfile(name: "Imported Before Quit")
+        let model = makeModel(
+            storeURL: storeURL,
+            profileImportOperation: { format, name, text in
+                await importer.run(format: format, name: name, text: text)
+            }
+        )
+
+        let importTask = Task {
+            try await model.performSettingsCommand(.importProfile(
+                format: .autoEQ,
+                name: importedProfile.name,
+                text: "1 0"
+            ))
+        }
+        await waitUntil {
+            importer.hasEntered
+        }
+
+        let flushTask = Task {
+            await model.stopAcceptingSettingsCommandsAndWait()
+            return await model.flushStoreBeforeQuit()
+        }
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(!FileManager.default.fileExists(atPath: storeURL.path))
+
+        importer.complete(with: .success(importedProfile))
+        _ = try await importTask.value
+        #expect(await flushTask.value)
+
+        let loaded = ProfilePersistence.load(from: storeURL).store
+        #expect(loaded.profiles.contains { $0.name == importedProfile.name })
+        model.resumeSettingsCommandsAfterCancelledQuit()
+    }
+
+    @Test
     func settingsLaunchValidationFailureTerminatesPartiallyStartedHelper() async throws {
         let model = makeModel()
         let launcher = SleepingSettingsHelperLauncher()
@@ -1744,6 +1784,7 @@ private func makeModel(
     lookup: FakeDefaultOutputLookup = FakeDefaultOutputLookup(.success(makeOutput())),
     observers: any DefaultOutputObservingMaking = FakeDefaultOutputObserverFactory(),
     workspaceOpener: any WorkspaceOpening = FakeWorkspaceOpener(results: []),
+    profileImportOperation: (@Sendable (ImportFormat, String, String) async -> Result<EQProfile, any Error>)? = nil,
     saveDelay: Duration = .zero,
     outputDelay: Duration? = nil,
     wakeDelay: Duration? = nil
@@ -1759,10 +1800,43 @@ private func makeModel(
         installLifecycleObservers: false,
         registerAppDelegate: false,
         workspaceOpener: workspaceOpener,
+        profileImportOperation: profileImportOperation,
         saveDebounceDelay: saveDelay,
         outputChangeSettlingDelayOverride: outputDelay,
         wakeReconnectDelayOverride: wakeDelay
     )
+}
+
+private final class BlockingProfileImportOperation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entered = false
+    private var continuation: CheckedContinuation<Result<EQProfile, any Error>, Never>?
+
+    var hasEntered: Bool {
+        lock.withLock { entered }
+    }
+
+    func run(
+        format: ImportFormat,
+        name: String,
+        text: String
+    ) async -> Result<EQProfile, any Error> {
+        await withCheckedContinuation { continuation in
+            lock.withLock {
+                self.continuation = continuation
+                entered = true
+            }
+        }
+    }
+
+    func complete(with result: Result<EQProfile, any Error>) {
+        let continuation = lock.withLock {
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        continuation?.resume(returning: result)
+    }
 }
 
 private func normalizedStore(_ store: ProfileStore) -> ProfileStore {

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1363,6 +1363,48 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func malformedSettingsIPCBeforeConnectingRequestsInProcessFallback() async throws {
+        let model = makeModel()
+        let launcher = ControllableSettingsHelperLauncher()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: launcher,
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+        try launcher.writeHelperOutput(Data("not-json\n".utf8))
+
+        for _ in 0..<100 where model.inProcessSettingsPresentationGeneration == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(model.inProcessSettingsPresentationGeneration == 1)
+        #expect(model.statusMessage.contains("IPC failed before connecting"))
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+    }
+
+    @Test
+    func settingsBootstrapWriteFailureRequestsInProcessFallback() async throws {
+        let model = makeModel()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: ClosedInputSettingsHelperLauncher(),
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+
+        for _ in 0..<100 where model.inProcessSettingsPresentationGeneration == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(model.inProcessSettingsPresentationGeneration == 1)
+        #expect(model.statusMessage.contains("IPC failed before connecting"))
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+    }
+
+    @Test
     func activeInProcessSettingsFallbackIsReusedWithoutLaunchingHelper() {
         let model = makeModel()
 
@@ -1742,6 +1784,36 @@ private struct PermissionDeniedSettingsHelperLauncher: SettingsHelperLaunching {
         terminationHandler: @escaping @Sendable (Process) -> Void
     ) throws -> SettingsHelperLaunch {
         throw POSIXError(.EPERM)
+    }
+}
+
+private final class ControllableSettingsHelperLauncher: SettingsHelperLaunching {
+    private let input = Pipe()
+    private let output = Pipe()
+    private let error = Pipe()
+
+    func launch(
+        executableURL: URL,
+        arguments: [String],
+        terminationHandler: @escaping @Sendable (Process) -> Void
+    ) throws -> SettingsHelperLaunch {
+        SettingsHelperLaunch(process: Process(), input: input, output: output, error: error)
+    }
+
+    func writeHelperOutput(_ data: Data) throws {
+        try output.fileHandleForWriting.write(contentsOf: data)
+    }
+}
+
+private struct ClosedInputSettingsHelperLauncher: SettingsHelperLaunching {
+    func launch(
+        executableURL: URL,
+        arguments: [String],
+        terminationHandler: @escaping @Sendable (Process) -> Void
+    ) throws -> SettingsHelperLaunch {
+        let input = Pipe()
+        try input.fileHandleForReading.close()
+        return SettingsHelperLaunch(process: Process(), input: input, output: Pipe(), error: Pipe())
     }
 }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -364,7 +364,9 @@ struct GlassEQAppModelLifecycleTests {
         observers.observers.last?.emit(.success(output))
 
         await waitUntil {
-            engine.stopCallCount == 1 && engine.startCalls.count == 2
+            engine.stopCallCount == 1
+                && engine.startCalls.count == 2
+                && model.lifecycleState == .running
         }
 
         #expect(engine.events == ["start:\(output.uid)", "stop", "start:\(output.uid)"])

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1446,11 +1446,16 @@ struct GlassEQAppModelLifecycleTests {
         model.engineMetrics = AudioEngineMetrics(capturedFrames: 42)
         coordinator.modelDidChange()
 
-        let messages = try launcher.readHostMessages()
-        #expect(messages.contains(.event(
+        let expectedMessage = SettingsPipeMessage.event(
             sessionToken: token,
             event: .metricsChanged(SettingsAudioMetricsDTO(capturedFrames: 42))
-        )))
+        )
+        var messages: [SettingsPipeMessage] = []
+        for _ in 0..<100 where !messages.contains(expectedMessage) {
+            try await Task.sleep(for: .milliseconds(10))
+            messages.append(contentsOf: try launcher.readHostMessages())
+        }
+        #expect(messages.contains(expectedMessage))
         coordinator.shutdown()
     }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1582,6 +1582,62 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func settingsReadyAcknowledgmentFailureRequestsInProcessFallback() async throws {
+        let model = makeModel()
+        let launcher = ControllableSettingsHelperLauncher()
+        let coordinator = SettingsCoordinator(
+            model: model,
+            helperLauncher: launcher,
+            helperValidator: PermissiveSettingsHelperLaunchValidator(),
+            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
+        )
+
+        #expect(coordinator.openSettings() == .helper)
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                if case .bootstrap = message {
+                    return true
+                }
+                return false
+            }
+        }
+        let bootstrap = try #require(launcher.receivedAppMessages.first)
+        guard case .bootstrap(let token) = bootstrap else {
+            Issue.record("Expected Settings bootstrap message")
+            return
+        }
+        try launcher.writeHelperMessage(.request(
+            sessionToken: token,
+            id: "connect",
+            kind: .connect,
+            command: nil
+        ))
+        await waitUntil {
+            launcher.receivedAppMessages.contains { message in
+                if case .response(_, "connect", _, _) = message {
+                    return true
+                }
+                return false
+            }
+        }
+
+        try launcher.closeHelperInput()
+        try launcher.writeHelperMessage(.request(
+            sessionToken: token,
+            id: "ready",
+            kind: .ready,
+            command: nil
+        ))
+
+        await waitUntil {
+            model.inProcessSettingsPresentationGeneration == 1
+        }
+        #expect(model.statusMessage.contains("IPC failed before connecting"))
+        #expect(!coordinator.isHelperReadyForTesting)
+        #expect(!coordinator.hasActiveSessionResourcesForTesting)
+    }
+
+    @Test
     func settingsBootstrapWriteFailureRequestsInProcessFallback() async throws {
         let model = makeModel()
         let coordinator = SettingsCoordinator(
@@ -2062,6 +2118,12 @@ private final class ControllableSettingsHelperLauncher: SettingsHelperLaunching,
 
     func closeHelperOutput() throws {
         try output.fileHandleForWriting.close()
+    }
+
+    func closeHelperInput() throws {
+        appReadPump?.invalidate(handle: input.fileHandleForReading)
+        appReadPump = nil
+        try input.fileHandleForReading.close()
     }
 
 }

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -19,6 +19,16 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func pipeMessageRoundTripsReadyRequest() throws {
+        let message = SettingsPipeMessage.request(sessionToken: "token", id: "request-2", kind: .ready, command: nil)
+
+        let encoded = try SettingsPipeCodec.encodeLine(message)
+        let decoded = try SettingsPipeCodec.decodeLine(Data(encoded.dropLast()))
+
+        #expect(decoded == message)
+    }
+
+    @Test
     func pipeMessageRoundTripsBootstrapToken() throws {
         let message = SettingsPipeMessage.bootstrap(sessionToken: "bootstrap-token")
 
@@ -588,6 +598,8 @@ private final class FakeSettingsPipeClient: SettingsPipeClientConnection, @unche
     func perform(_ command: SettingsCommand) async throws -> SettingsCommandResponse {
         SettingsCommandResponse()
     }
+
+    func acknowledgeReady() async throws {}
 
     func disconnect() {
         didDisconnect = true


### PR DESCRIPTION
- The bundled Settings helper can fail to launch or validate in ad hoc alpha builds, which previously left no way to edit profiles.
- Fall back to the same Settings interface inside the menu bar process, sharing its command path and state instead of maintaining a second implementation.
- Keep the helper as the preferred path and package the shared Settings resources into both app bundles.