### PR TITLE
feat(settings): add precise EQ value controls

### DIFF
--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -1954,6 +1954,7 @@ private struct EditableValueText: View {
 
     @State private var isEditing = false
     @State private var editText = ""
+    @State private var editSession = EditableValueEditSession()
     @FocusState private var isFocused: Bool
 
     var body: some View {
@@ -1969,10 +1970,21 @@ private struct EditableValueText: View {
                     }
                     .onSubmit(commit)
                     .onExitCommand {
+                        if let originalValue = editSession.cancel() {
+                            value = originalValue
+                        }
                         isEditing = false
                     }
                     .onChange(of: editText) { _, text in
                         updateValue(from: text)
+                    }
+                    .onChange(of: value) { _, newValue in
+                        guard isEditing,
+                              editSession.valueChanged(newValue) else {
+                            return
+                        }
+                        editText = editableNumberText(newValue)
+                        isEditing = false
                     }
                     .onChange(of: isFocused) { _, focused in
                         if !focused {
@@ -1982,6 +1994,7 @@ private struct EditableValueText: View {
             } else {
                 Button {
                     editText = editableText
+                    editSession.begin(value: value)
                     isEditing = true
                 } label: {
                     Text(display)
@@ -2008,6 +2021,7 @@ private struct EditableValueText: View {
             return
         }
         updateValue(from: editText)
+        editSession.finish()
         isEditing = false
     }
 
@@ -2016,7 +2030,42 @@ private struct EditableValueText: View {
               let parsed = clampedEditableNumber(text, range: range) else {
             return
         }
+        editSession.recordTextDrivenValue(parsed)
         value = parsed
+    }
+}
+
+struct EditableValueEditSession: Equatable {
+    private var originalValue: Double?
+    private var textDrivenValue: Double?
+
+    mutating func begin(value: Double) {
+        originalValue = value
+        textDrivenValue = nil
+    }
+
+    mutating func recordTextDrivenValue(_ value: Double) {
+        textDrivenValue = value
+    }
+
+    mutating func valueChanged(_ value: Double) -> Bool {
+        if textDrivenValue == value {
+            textDrivenValue = nil
+            return false
+        }
+        finish()
+        return true
+    }
+
+    mutating func cancel() -> Double? {
+        let value = originalValue
+        finish()
+        return value
+    }
+
+    mutating func finish() {
+        originalValue = nil
+        textDrivenValue = nil
     }
 }
 

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -186,6 +186,7 @@ public struct SettingsView: View {
     @Bindable var model: GlassEQSettingsViewModel
     @State private var snapshot: SettingsSnapshot
     @State private var tab = EditorSection.editor
+    @State private var draftEditGeneration = 0
 
     public init(model: GlassEQSettingsViewModel) {
         self._model = Bindable(wrappedValue: model)
@@ -213,6 +214,7 @@ public struct SettingsView: View {
                 snapshot: snapshot,
                 draftProfile: $snapshot.draftProfile,
                 tab: $tab,
+                draftEditGeneration: draftEditGeneration,
                 hasUnsavedDraft: hasUnsavedDraft,
                 onApply: applyDraft,
                 onRevert: revertDraft,
@@ -293,6 +295,7 @@ public struct SettingsView: View {
 
     private func revertDraft() {
         snapshot.draftProfile = selectedProfile
+        draftEditGeneration &+= 1
     }
 
     private func useDraftForCurrentOutput() {
@@ -856,6 +859,7 @@ private struct ProfileDetail: View {
     var snapshot: SettingsSnapshot
     @Binding var draftProfile: EQProfile
     @Binding var tab: EditorSection
+    var draftEditGeneration: Int
     var hasUnsavedDraft: Bool
     var onApply: () -> Void
     var onRevert: () -> Void
@@ -897,7 +901,8 @@ private struct ProfileDetail: View {
                         case .editor:
                             EditorTab(
                                 draftProfile: $draftProfile,
-                                sampleRate: snapshot.currentOutputSampleRate
+                                sampleRate: snapshot.currentOutputSampleRate,
+                                draftEditGeneration: draftEditGeneration
                             )
                             .disabled(isProfileStoreProtected)
                         case .importer:
@@ -1111,13 +1116,15 @@ private extension EQChannelMode {
 private struct EditorTab: View {
     @Binding var draftProfile: EQProfile
     var sampleRate: Double
+    var draftEditGeneration: Int
     @State private var editChannel = EQEditChannel.left
     @State private var analysis: EQAnalysisSnapshot
     @State private var analysisTask: Task<Void, Never>?
 
-    init(draftProfile: Binding<EQProfile>, sampleRate: Double) {
+    init(draftProfile: Binding<EQProfile>, sampleRate: Double, draftEditGeneration: Int) {
         self._draftProfile = draftProfile
         self.sampleRate = sampleRate
+        self.draftEditGeneration = draftEditGeneration
         self._analysis = State(
             initialValue: EQAnalysisSnapshot(
                 profile: draftProfile.wrappedValue,
@@ -1185,6 +1192,7 @@ private struct EditorTab: View {
                     title: localized("Preamp"),
                     value: activePreampBinding,
                     range: -24...12,
+                    validationRange: ProfilePersistence.preampRange,
                     step: 0.1,
                     suffix: "dB"
                 )
@@ -1320,7 +1328,7 @@ private struct EditorTab: View {
 
     private var activeEditContextID: String {
         let channel = draftProfile.channelMode == .stereo ? editChannel.rawValue : "linked"
-        return "\(draftProfile.id.uuidString):\(channel)"
+        return "\(draftProfile.id.uuidString):\(channel):\(draftEditGeneration)"
     }
 
     private func setChannelMode(_ mode: EQChannelMode) {
@@ -1601,7 +1609,7 @@ private struct GraphicFilterEditor: View {
                     EditableValueText(
                         title: localized("Gain"),
                         value: $filter.gainDB,
-                        range: -12...12,
+                        range: ProfilePersistence.gainRange,
                         display: filter.gainDB.dbLabel,
                         width: 56
                     )
@@ -1822,9 +1830,31 @@ private struct ParametricFilterInspector: View {
                 .accessibilityHint(Text(localized("Changes the selected filter type")))
             }
 
-            SliderRow(title: localized("Frequency"), value: $filter.frequency, range: 20...20_000, step: 1, suffix: "Hz", scale: .logarithmic)
-            SliderRow(title: localized("Gain"), value: $filter.gainDB, range: -24...24, step: 0.1, suffix: "dB")
-            SliderRow(title: localized("Q"), value: $filter.q, range: 0.1...10, step: 0.01, suffix: "")
+            SliderRow(
+                title: localized("Frequency"),
+                value: $filter.frequency,
+                range: 20...20_000,
+                validationRange: ProfilePersistence.frequencyRange,
+                step: 1,
+                suffix: "Hz",
+                scale: .logarithmic
+            )
+            SliderRow(
+                title: localized("Gain"),
+                value: $filter.gainDB,
+                range: -24...24,
+                validationRange: ProfilePersistence.gainRange,
+                step: 0.1,
+                suffix: "dB"
+            )
+            SliderRow(
+                title: localized("Q"),
+                value: $filter.q,
+                range: 0.1...10,
+                validationRange: ProfilePersistence.qRange,
+                step: 0.01,
+                suffix: ""
+            )
         }
         .cardPanel(padding: 16)
     }
@@ -1849,6 +1879,7 @@ private struct SliderRow: View {
     var title: String
     @Binding var value: Double
     var range: ClosedRange<Double>
+    var validationRange: ClosedRange<Double>? = nil
     var step: Double
     var suffix: String
     var scale = SliderScale.linear
@@ -1868,7 +1899,7 @@ private struct SliderRow: View {
             EditableValueText(
                 title: title,
                 value: $value,
-                range: range,
+                range: validationRange ?? range,
                 display: label
             )
         }

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -185,6 +185,18 @@ func settingsSnapshotPreservingLocalDraft(
     return merged
 }
 
+func settingsSnapshotAfterCommand(
+    current: SettingsSnapshot,
+    dispatched: SettingsSnapshot,
+    latest: SettingsSnapshot
+) -> SettingsSnapshot {
+    guard current.selectedProfileID == dispatched.selectedProfileID,
+          current.draftProfile == dispatched.draftProfile else {
+        return settingsSnapshotPreservingLocalDraft(current: current, latest: latest)
+    }
+    return latest
+}
+
 private func localizedLatency(milliseconds: Double) -> String {
     let number = localizedDecimal(milliseconds, minimumFractionDigits: 2, maximumFractionDigits: 2)
     return localized("\(number) ms")
@@ -326,8 +338,9 @@ public struct SettingsView: View {
     }
 
     private func importProfile(format: ImportFormat, name: String, text: String) async -> Bool {
+        let dispatchedSnapshot = snapshot
         let response = await model.perform(.importProfile(format: format, name: name, text: text))
-        refreshSnapshotFromModel()
+        refreshSnapshotFromModel(afterCommandDispatchedFrom: dispatchedSnapshot)
         return response?.importSucceeded ?? false
     }
 
@@ -383,6 +396,14 @@ public struct SettingsView: View {
         snapshot = settingsSnapshotPreservingLocalDraft(current: snapshot, latest: model.snapshot)
     }
 
+    private func refreshSnapshotFromModel(afterCommandDispatchedFrom dispatchedSnapshot: SettingsSnapshot) {
+        snapshot = settingsSnapshotAfterCommand(
+            current: snapshot,
+            dispatched: dispatchedSnapshot,
+            latest: model.snapshot
+        )
+    }
+
     private func updateMetricsPolling() {
         if tab == .output {
             perform(.startMetricsPolling)
@@ -397,9 +418,10 @@ public struct SettingsView: View {
     }
 
     private func perform(_ command: SettingsCommand) {
+        let dispatchedSnapshot = snapshot
         Task { @MainActor in
             await model.perform(command)
-            refreshSnapshotFromModel()
+            refreshSnapshotFromModel(afterCommandDispatchedFrom: dispatchedSnapshot)
         }
     }
 }

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -97,7 +97,17 @@ func parseEditableNumber(_ text: String, locale: Locale = .autoupdatingCurrent) 
        plusSign != "+" {
         normalized = normalized.replacingOccurrences(of: plusSign, with: "+")
     }
-    let parsed = Double(normalized)
+    var asciiNormalized = ""
+    for scalar in normalized.unicodeScalars {
+        if scalar.properties.numericType == .decimal,
+           let numericValue = scalar.properties.numericValue,
+           let asciiDigit = UnicodeScalar(Int(numericValue) + 48) {
+            asciiNormalized.unicodeScalars.append(asciiDigit)
+        } else {
+            asciiNormalized.unicodeScalars.append(scalar)
+        }
+    }
+    let parsed = Double(asciiNormalized)
     guard let parsed, parsed.isFinite else {
         return nil
     }
@@ -1178,6 +1188,7 @@ private struct EditorTab: View {
                     step: 0.1,
                     suffix: "dB"
                 )
+                .id("preamp:\(activeEditContextID)")
 
                 SettingRow(title: localized("Bypass")) {
                     Toggle(localized("Bypass"), isOn: $draftProfile.isBypassed)
@@ -1211,8 +1222,10 @@ private struct EditorTab: View {
 
             if draftProfile.mode == .parametric {
                 ParametricFilterEditor(filters: activeFiltersBinding)
+                    .id("parametric:\(activeEditContextID)")
             } else {
                 GraphicFilterEditor(filters: activeFiltersBinding)
+                    .id("graphic:\(activeEditContextID)")
                     .cardPanel(padding: 16)
             }
 
@@ -1303,6 +1316,11 @@ private struct EditorTab: View {
         default:
             $draftProfile.filters
         }
+    }
+
+    private var activeEditContextID: String {
+        let channel = draftProfile.channelMode == .stereo ? editChannel.rawValue : "linked"
+        return "\(draftProfile.id.uuidString):\(channel)"
     }
 
     private func setChannelMode(_ mode: EQChannelMode) {
@@ -1647,6 +1665,7 @@ private struct ParametricFilterEditor: View {
                         selectedFilterID = filters.first?.id
                     }
                 )
+                .id(binding.wrappedValue.id)
                 .frame(minWidth: 260, maxWidth: .infinity, alignment: .topLeading)
             } else {
                 ContentUnavailableView(localized("No Filter Selected"), systemImage: "slider.horizontal.3")

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -1121,7 +1121,7 @@ private struct EditorTab: View {
                     suffix: "dB"
                 )
 
-                    SettingRow(title: localized("Bypass")) {
+                SettingRow(title: localized("Bypass")) {
                     Toggle(localized("Bypass"), isOn: $draftProfile.isBypassed)
                         .labelsHidden()
                         .accessibilityLabel(Text(localized("Bypass")))
@@ -1511,14 +1511,25 @@ private struct GraphicFilterEditor: View {
                     Text(filter.frequency.frequencyLabel)
                         .font(.caption.monospacedDigit())
                         .frame(width: 64, alignment: .trailing)
-                    Slider(value: $filter.gainDB, in: -12...12, step: 0.1)
+                    Slider(
+                        value: Binding(
+                            get: { filter.gainDB },
+                            set: { filter.gainDB = quantized($0, step: 0.1) }
+                        ),
+                        in: -12...12
+                    )
                         .frame(maxWidth: 640)
                         .accessibilityLabel(Text(localized("Gain at \(filter.frequency.frequencyLabel)")))
                         .accessibilityValue(Text(filter.gainDB.dbLabel))
                         .accessibilityHint(Text(localized("Adjusts this graphic EQ band")))
-                    Text(filter.gainDB.dbLabel)
-                        .font(.caption.monospacedDigit())
-                        .frame(width: 56, alignment: .trailing)
+                    EditableValueText(
+                        title: localized("Gain"),
+                        value: $filter.gainDB,
+                        range: -12...12,
+                        step: 0.1,
+                        display: filter.gainDB.dbLabel,
+                        width: 56
+                    )
                 }
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(Text(localized("Graphic filter row")))
@@ -1735,12 +1746,26 @@ private struct ParametricFilterInspector: View {
                 .accessibilityHint(Text(localized("Changes the selected filter type")))
             }
 
-            SliderRow(title: localized("Frequency"), value: $filter.frequency, range: 20...20_000, step: 1, suffix: "Hz")
+            SliderRow(title: localized("Frequency"), value: $filter.frequency, range: 20...20_000, step: 1, suffix: "Hz", scale: .logarithmic)
             SliderRow(title: localized("Gain"), value: $filter.gainDB, range: -24...24, step: 0.1, suffix: "dB")
             SliderRow(title: localized("Q"), value: $filter.q, range: 0.1...10, step: 0.01, suffix: "")
         }
         .cardPanel(padding: 16)
     }
+}
+
+// Quantizes slider output in the binding instead of passing `step:` to Slider — stepped macOS
+// sliders render a tick mark per step, which draws a dense line of dots under the track.
+private func quantized(_ value: Double, step: Double) -> Double {
+    guard step > 0 else {
+        return value
+    }
+    return (value / step).rounded() * step
+}
+
+private enum SliderScale {
+    case linear
+    case logarithmic
 }
 
 private struct SliderRow: View {
@@ -1749,6 +1774,7 @@ private struct SliderRow: View {
     var range: ClosedRange<Double>
     var step: Double
     var suffix: String
+    var scale = SliderScale.linear
 
     var body: some View {
         HStack(spacing: 12) {
@@ -1756,15 +1782,46 @@ private struct SliderRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(width: 88, alignment: .leading)
-            Slider(value: $value, in: range, step: step)
+            Slider(value: sliderValue, in: sliderRange)
                 .frame(minWidth: 80)
                 .frame(maxWidth: 640)
                 .accessibilityLabel(Text(title))
                 .accessibilityValue(Text(label))
                 .accessibilityHint(Text(localized("Adjusts \(title.lowercased())")))
-            Text(label)
-                .font(.caption.monospacedDigit())
-                .frame(width: 64, alignment: .trailing)
+            EditableValueText(
+                title: title,
+                value: $value,
+                range: range,
+                step: step,
+                display: label
+            )
+        }
+    }
+
+    private var sliderValue: Binding<Double> {
+        switch scale {
+        case .linear:
+            Binding(
+                get: { value },
+                set: { value = quantized($0, step: step) }
+            )
+        case .logarithmic:
+            Binding(
+                get: { log10(min(max(value, range.lowerBound), range.upperBound)) },
+                set: {
+                    let restored = min(max(pow(10, $0), range.lowerBound), range.upperBound)
+                    value = quantized(restored, step: step)
+                }
+            )
+        }
+    }
+
+    private var sliderRange: ClosedRange<Double> {
+        switch scale {
+        case .linear:
+            range
+        case .logarithmic:
+            log10(range.lowerBound)...log10(range.upperBound)
         }
     }
 
@@ -1776,6 +1833,103 @@ private struct SliderRow: View {
             return value.dbLabel
         }
         return localizedDecimal(value, minimumFractionDigits: 2, maximumFractionDigits: 2)
+    }
+}
+
+// Value readout that becomes a text field on click, so exact values can be typed instead of
+// approximated by dragging the slider.
+private struct EditableValueText: View {
+    var title: String
+    @Binding var value: Double
+    var range: ClosedRange<Double>
+    var step: Double
+    var display: String
+    var width: CGFloat = 64
+
+    @State private var isEditing = false
+    @State private var editText = ""
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Group {
+            if isEditing {
+                TextField(title, text: $editText)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption.monospacedDigit())
+                    .multilineTextAlignment(.trailing)
+                    .focused($isFocused)
+                    .onAppear {
+                        isFocused = true
+                    }
+                    .onSubmit(commit)
+                    .onExitCommand {
+                        isEditing = false
+                    }
+                    .onChange(of: isFocused) { _, focused in
+                        if !focused {
+                            commit()
+                        }
+                    }
+            } else {
+                Button {
+                    editText = editableText
+                    isEditing = true
+                } label: {
+                    Text(display)
+                        .font(.caption.monospacedDigit())
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+                .help(localized("Click to type a value"))
+            }
+        }
+        .frame(width: width)
+        .accessibilityLabel(Text(localized("\(title) value")))
+        .accessibilityValue(Text(display))
+        .accessibilityHint(Text(localized("Edits \(title.lowercased()) as text")))
+    }
+
+    private var editableText: String {
+        let formatter = NumberFormatter()
+        formatter.locale = .autoupdatingCurrent
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = false
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = editFractionDigits
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private var editFractionDigits: Int {
+        guard step > 0, step < 1 else {
+            return 0
+        }
+        return step < 0.1 ? 2 : 1
+    }
+
+    private func commit() {
+        guard isEditing else {
+            return
+        }
+        isEditing = false
+        guard let parsed = parseNumber(editText) else {
+            return
+        }
+        value = min(max(parsed, range.lowerBound), range.upperBound)
+    }
+
+    private func parseNumber(_ text: String) -> Double? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+        let formatter = NumberFormatter()
+        formatter.locale = .autoupdatingCurrent
+        formatter.numberStyle = .decimal
+        if let number = formatter.number(from: trimmed) {
+            return number.doubleValue
+        }
+        return Double(trimmed.replacingOccurrences(of: ",", with: "."))
     }
 }
 

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -1969,12 +1969,7 @@ private struct EditableValueText: View {
                         isFocused = true
                     }
                     .onSubmit(commit)
-                    .onExitCommand {
-                        if let originalValue = editSession.cancel() {
-                            value = originalValue
-                        }
-                        isEditing = false
-                    }
+                    .onExitCommand(perform: cancel)
                     .onChange(of: editText) { _, text in
                         updateValue(from: text)
                     }
@@ -2020,18 +2015,30 @@ private struct EditableValueText: View {
         guard isEditing else {
             return
         }
-        updateValue(from: editText)
+        guard updateValue(from: editText) else {
+            cancel()
+            return
+        }
         editSession.finish()
         isEditing = false
     }
 
-    private func updateValue(from text: String) {
+    private func cancel() {
+        if let originalValue = editSession.cancel() {
+            value = originalValue
+        }
+        isEditing = false
+    }
+
+    @discardableResult
+    private func updateValue(from text: String) -> Bool {
         guard isEditing,
               let parsed = clampedEditableNumber(text, range: range) else {
-            return
+            return false
         }
         editSession.recordTextDrivenValue(parsed)
         value = parsed
+        return true
     }
 }
 

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -57,6 +57,34 @@ private func localizedDecimal(
     return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
 }
 
+func editableNumberText(_ value: Double, locale: Locale = .autoupdatingCurrent) -> String {
+    let formatter = NumberFormatter()
+    formatter.locale = locale
+    formatter.numberStyle = .decimal
+    formatter.usesGroupingSeparator = false
+    formatter.usesSignificantDigits = true
+    formatter.minimumSignificantDigits = 1
+    formatter.maximumSignificantDigits = 17
+    return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+}
+
+func parseEditableNumber(_ text: String, locale: Locale = .autoupdatingCurrent) -> Double? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        return nil
+    }
+
+    let formatter = NumberFormatter()
+    formatter.locale = locale
+    formatter.numberStyle = .decimal
+    let parsed = formatter.number(from: trimmed)?.doubleValue
+        ?? Double(trimmed.replacingOccurrences(of: ",", with: "."))
+    guard let parsed, parsed.isFinite else {
+        return nil
+    }
+    return parsed
+}
+
 private func localizedInteger(_ value: Int) -> String {
     value.formatted(.number.locale(.autoupdatingCurrent))
 }
@@ -1526,7 +1554,6 @@ private struct GraphicFilterEditor: View {
                         title: localized("Gain"),
                         value: $filter.gainDB,
                         range: -12...12,
-                        step: 0.1,
                         display: filter.gainDB.dbLabel,
                         width: 56
                     )
@@ -1792,7 +1819,6 @@ private struct SliderRow: View {
                 title: title,
                 value: $value,
                 range: range,
-                step: step,
                 display: label
             )
         }
@@ -1842,7 +1868,6 @@ private struct EditableValueText: View {
     var title: String
     @Binding var value: Double
     var range: ClosedRange<Double>
-    var step: Double
     var display: String
     var width: CGFloat = 64
 
@@ -1891,20 +1916,7 @@ private struct EditableValueText: View {
     }
 
     private var editableText: String {
-        let formatter = NumberFormatter()
-        formatter.locale = .autoupdatingCurrent
-        formatter.numberStyle = .decimal
-        formatter.usesGroupingSeparator = false
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = editFractionDigits
-        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
-    }
-
-    private var editFractionDigits: Int {
-        guard step > 0, step < 1 else {
-            return 0
-        }
-        return step < 0.1 ? 2 : 1
+        editableNumberText(value)
     }
 
     private func commit() {
@@ -1912,24 +1924,10 @@ private struct EditableValueText: View {
             return
         }
         isEditing = false
-        guard let parsed = parseNumber(editText) else {
+        guard let parsed = parseEditableNumber(editText) else {
             return
         }
         value = min(max(parsed, range.lowerBound), range.upperBound)
-    }
-
-    private func parseNumber(_ text: String) -> Double? {
-        let trimmed = text.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else {
-            return nil
-        }
-        let formatter = NumberFormatter()
-        formatter.locale = .autoupdatingCurrent
-        formatter.numberStyle = .decimal
-        if let number = formatter.number(from: trimmed) {
-            return number.doubleValue
-        }
-        return Double(trimmed.replacingOccurrences(of: ",", with: "."))
     }
 }
 

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -166,6 +166,25 @@ private func localizedFrameCount(_ value: UInt32) -> String {
     return value == 1 ? localized("\(number) frame") : localized("\(number) frames")
 }
 
+func settingsSnapshotPreservingLocalDraft(
+    current: SettingsSnapshot,
+    latest: SettingsSnapshot
+) -> SettingsSnapshot {
+    guard latest.profiles.contains(where: { $0.id == current.selectedProfileID }) else {
+        return latest
+    }
+
+    let selectedProfile = current.profiles.first(where: { $0.id == current.selectedProfileID })
+        ?? current.draftProfile
+    let hasUnsavedDraft = current.draftProfile != selectedProfile
+    var merged = latest
+    merged.selectedProfileID = current.selectedProfileID
+    merged.draftProfile = hasUnsavedDraft
+        ? current.draftProfile
+        : latest.profiles.first(where: { $0.id == current.selectedProfileID }) ?? current.draftProfile
+    return merged
+}
+
 private func localizedLatency(milliseconds: Double) -> String {
     let number = localizedDecimal(milliseconds, minimumFractionDigits: 2, maximumFractionDigits: 2)
     return localized("\(number) ms")
@@ -308,7 +327,7 @@ public struct SettingsView: View {
 
     private func importProfile(format: ImportFormat, name: String, text: String) async -> Bool {
         let response = await model.perform(.importProfile(format: format, name: name, text: text))
-        syncFromModel()
+        refreshSnapshotFromModel()
         return response?.importSucceeded ?? false
     }
 
@@ -356,29 +375,12 @@ public struct SettingsView: View {
         perform(.deleteProfile(snapshot.selectedProfileID))
     }
 
-    private func syncFromModel() {
-        snapshot = model.snapshot
-    }
-
     private func refreshMetricsFromModel() {
         snapshot.metrics = model.snapshot.metrics
     }
 
     private func refreshSnapshotFromModel() {
-        let latest = model.snapshot
-
-        guard latest.profiles.contains(where: { $0.id == snapshot.selectedProfileID }) else {
-            snapshot = latest
-            return
-        }
-
-        let selectedProfileID = snapshot.selectedProfileID
-        let draftProfile = hasUnsavedDraft
-            ? snapshot.draftProfile
-            : latest.profiles.first(where: { $0.id == selectedProfileID }) ?? snapshot.draftProfile
-        snapshot = latest
-        snapshot.selectedProfileID = selectedProfileID
-        snapshot.draftProfile = draftProfile
+        snapshot = settingsSnapshotPreservingLocalDraft(current: snapshot, latest: model.snapshot)
     }
 
     private func updateMetricsPolling() {
@@ -397,7 +399,7 @@ public struct SettingsView: View {
     private func perform(_ command: SettingsCommand) {
         Task { @MainActor in
             await model.perform(command)
-            syncFromModel()
+            refreshSnapshotFromModel()
         }
     }
 }

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -77,12 +77,42 @@ func parseEditableNumber(_ text: String, locale: Locale = .autoupdatingCurrent) 
     let formatter = NumberFormatter()
     formatter.locale = locale
     formatter.numberStyle = .decimal
-    let parsed = formatter.number(from: trimmed)?.doubleValue
-        ?? Double(trimmed.replacingOccurrences(of: ",", with: "."))
+    if let groupingSeparator = formatter.groupingSeparator,
+       !groupingSeparator.isEmpty,
+       groupingSeparator != formatter.decimalSeparator,
+       trimmed.contains(groupingSeparator) {
+        return nil
+    }
+
+    var normalized = trimmed
+    if let decimalSeparator = formatter.decimalSeparator,
+       decimalSeparator != "." {
+        normalized = normalized.replacingOccurrences(of: decimalSeparator, with: ".")
+    }
+    if let minusSign = formatter.minusSign,
+       minusSign != "-" {
+        normalized = normalized.replacingOccurrences(of: minusSign, with: "-")
+    }
+    if let plusSign = formatter.plusSign,
+       plusSign != "+" {
+        normalized = normalized.replacingOccurrences(of: plusSign, with: "+")
+    }
+    let parsed = Double(normalized)
     guard let parsed, parsed.isFinite else {
         return nil
     }
     return parsed
+}
+
+func clampedEditableNumber(
+    _ text: String,
+    range: ClosedRange<Double>,
+    locale: Locale = .autoupdatingCurrent
+) -> Double? {
+    guard let parsed = parseEditableNumber(text, locale: locale) else {
+        return nil
+    }
+    return min(max(parsed, range.lowerBound), range.upperBound)
 }
 
 private func localizedInteger(_ value: Int) -> String {
@@ -1783,11 +1813,12 @@ private struct ParametricFilterInspector: View {
 
 // Quantizes slider output in the binding instead of passing `step:` to Slider — stepped macOS
 // sliders render a tick mark per step, which draws a dense line of dots under the track.
-private func quantized(_ value: Double, step: Double) -> Double {
+func quantized(_ value: Double, step: Double) -> Double {
     guard step > 0 else {
         return value
     }
-    return (value / step).rounded() * step
+    let scale = 1 / step
+    return (value * scale).rounded() / scale
 }
 
 private enum SliderScale {
@@ -1890,6 +1921,9 @@ private struct EditableValueText: View {
                     .onExitCommand {
                         isEditing = false
                     }
+                    .onChange(of: editText) { _, text in
+                        updateValue(from: text)
+                    }
                     .onChange(of: isFocused) { _, focused in
                         if !focused {
                             commit()
@@ -1923,11 +1957,16 @@ private struct EditableValueText: View {
         guard isEditing else {
             return
         }
+        updateValue(from: editText)
         isEditing = false
-        guard let parsed = parseEditableNumber(editText) else {
+    }
+
+    private func updateValue(from text: String) {
+        guard isEditing,
+              let parsed = clampedEditableNumber(text, range: range) else {
             return
         }
-        value = min(max(parsed, range.lowerBound), range.upperBound)
+        value = parsed
     }
 }
 

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -7,6 +7,25 @@ import Testing
 
 @Suite
 struct SettingsIPCTests {
+    @Test(arguments: [0.707, 0.12345678901234567, 20_000.125])
+    func editableNumberTextRoundTripsTypedPrecision(_ value: Double) {
+        let locale = Locale(identifier: "en_US_POSIX")
+
+        let text = editableNumberText(value, locale: locale)
+
+        #expect(parseEditableNumber(text, locale: locale) == value)
+    }
+
+    @Test
+    func editableNumberParsingSupportsLocaleDecimalSeparator() {
+        #expect(parseEditableNumber("0,707", locale: Locale(identifier: "fi_FI")) == 0.707)
+    }
+
+    @Test(arguments: ["nan", "inf", "-inf", "infinity", "-infinity"])
+    func editableNumberParsingRejectsNonFiniteValues(_ text: String) {
+        #expect(parseEditableNumber(text, locale: Locale(identifier: "en_US_POSIX")) == nil)
+    }
+
     @Test
     func pipeMessageRoundTripsConnectRequest() throws {
         let message = SettingsPipeMessage.request(sessionToken: "token", id: "request-1", kind: .connect, command: nil)

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -56,6 +56,34 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func editableValueCancellationRestoresTheValueFromTheStartOfEditing() {
+        var session = EditableValueEditSession()
+        session.begin(value: -3)
+        session.recordTextDrivenValue(-6)
+
+        let textChangeWasExternal = session.valueChanged(-6)
+        let restoredValue = session.cancel()
+
+        #expect(!textChangeWasExternal)
+        #expect(restoredValue == -3)
+    }
+
+    @Test
+    func editableValueExternalChangesResetTheActiveSession() {
+        var session = EditableValueEditSession()
+        session.begin(value: -3)
+        session.recordTextDrivenValue(-6)
+
+        let textChangeWasExternal = session.valueChanged(-6)
+        let headroomChangeWasExternal = session.valueChanged(-12)
+        let restoredValue = session.cancel()
+
+        #expect(!textChangeWasExternal)
+        #expect(headroomChangeWasExternal)
+        #expect(restoredValue == nil)
+    }
+
+    @Test
     func sliderQuantizationDoesNotIntroduceDisplayNoise() {
         let locale = Locale(identifier: "en_US_POSIX")
 

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -22,6 +22,15 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func editableNumberParsingSupportsLocalizedDecimalDigits() {
+        let locale = Locale(identifier: "ar_EG")
+        let text = editableNumberText(-6.5, locale: locale)
+
+        #expect(parseEditableNumber(text, locale: locale) == -6.5)
+        #expect(parseEditableNumber("١٢٫٥", locale: locale) == 12.5)
+    }
+
+    @Test
     func editableNumberParsingRejectsLocaleGroupingSeparators() {
         #expect(parseEditableNumber("1.234", locale: Locale(identifier: "de_DE")) == nil)
         #expect(parseEditableNumber("1,234", locale: Locale(identifier: "de_DE")) == 1.234)

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -46,6 +46,16 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func editableNumberPreservesPersistableValuesOutsideSliderRanges() {
+        let locale = Locale(identifier: "en_US_POSIX")
+
+        #expect(clampedEditableNumber("24000", range: ProfilePersistence.frequencyRange, locale: locale) == 24_000)
+        #expect(clampedEditableNumber("120", range: ProfilePersistence.gainRange, locale: locale) == 120)
+        #expect(clampedEditableNumber("-30", range: ProfilePersistence.preampRange, locale: locale) == -30)
+        #expect(clampedEditableNumber("20", range: ProfilePersistence.qRange, locale: locale) == 20)
+    }
+
+    @Test
     func sliderQuantizationDoesNotIntroduceDisplayNoise() {
         let locale = Locale(identifier: "en_US_POSIX")
 

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -101,6 +101,28 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func delayedSnapshotPreservesNewerLocalDraftAndSelection() {
+        let first = EQProfile(name: "First", mode: .parametric, filters: [])
+        let second = EQProfile(name: "Second", mode: .parametric, filters: [])
+        var editedSecond = second
+        editedSecond.preampDB = -3.25
+        var current = SettingsSnapshotDTO.disconnected
+        current.profiles = [first, second]
+        current.selectedProfileID = second.id
+        current.draftProfile = editedSecond
+        var latest = current
+        latest.selectedProfileID = first.id
+        latest.draftProfile = first
+        latest.statusMessage = "Command completed"
+
+        let merged = settingsSnapshotPreservingLocalDraft(current: current, latest: latest)
+
+        #expect(merged.selectedProfileID == second.id)
+        #expect(merged.draftProfile == editedSecond)
+        #expect(merged.statusMessage == "Command completed")
+    }
+
+    @Test
     func sliderQuantizationDoesNotIntroduceDisplayNoise() {
         let locale = Locale(identifier: "en_US_POSIX")
 

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -69,6 +69,23 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func editableValueInvalidCommitRestoresTheValueFromTheStartOfEditing() {
+        var session = EditableValueEditSession()
+        session.begin(value: 10)
+        session.recordTextDrivenValue(2)
+        _ = session.valueChanged(2)
+
+        let finalValue: Double?
+        if let parsed = clampedEditableNumber("", range: 0...20) {
+            finalValue = parsed
+        } else {
+            finalValue = session.cancel()
+        }
+
+        #expect(finalValue == 10)
+    }
+
+    @Test
     func editableValueExternalChangesResetTheActiveSession() {
         var session = EditableValueEditSession()
         session.begin(value: -3)

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -123,6 +123,54 @@ struct SettingsIPCTests {
     }
 
     @Test
+    func commandSnapshotAdoptsIntentionalSelectionChangeWhenLocalDraftIsUnchanged() {
+        let original = EQProfile(name: "Original", mode: .parametric, filters: [])
+        let duplicate = EQProfile(name: "Duplicate", mode: .parametric, filters: [])
+        var dispatched = SettingsSnapshotDTO.disconnected
+        dispatched.profiles = [original]
+        dispatched.selectedProfileID = original.id
+        dispatched.draftProfile = original
+        var latest = dispatched
+        latest.profiles = [original, duplicate]
+        latest.selectedProfileID = duplicate.id
+        latest.draftProfile = duplicate
+
+        let merged = settingsSnapshotAfterCommand(
+            current: dispatched,
+            dispatched: dispatched,
+            latest: latest
+        )
+
+        #expect(merged.selectedProfileID == duplicate.id)
+        #expect(merged.draftProfile == duplicate)
+    }
+
+    @Test
+    func commandSnapshotPreservesEditsMadeWhileCommandWasPending() {
+        let first = EQProfile(name: "First", mode: .parametric, filters: [])
+        let second = EQProfile(name: "Second", mode: .parametric, filters: [])
+        var dispatched = SettingsSnapshotDTO.disconnected
+        dispatched.profiles = [first, second]
+        dispatched.selectedProfileID = first.id
+        dispatched.draftProfile = first
+        var current = dispatched
+        current.selectedProfileID = second.id
+        current.draftProfile = second
+        var latest = dispatched
+        latest.statusMessage = "Command completed"
+
+        let merged = settingsSnapshotAfterCommand(
+            current: current,
+            dispatched: dispatched,
+            latest: latest
+        )
+
+        #expect(merged.selectedProfileID == second.id)
+        #expect(merged.draftProfile == second)
+        #expect(merged.statusMessage == "Command completed")
+    }
+
+    @Test
     func sliderQuantizationDoesNotIntroduceDisplayNoise() {
         let locale = Locale(identifier: "en_US_POSIX")
 

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -21,6 +21,32 @@ struct SettingsIPCTests {
         #expect(parseEditableNumber("0,707", locale: Locale(identifier: "fi_FI")) == 0.707)
     }
 
+    @Test
+    func editableNumberParsingRejectsLocaleGroupingSeparators() {
+        #expect(parseEditableNumber("1.234", locale: Locale(identifier: "de_DE")) == nil)
+        #expect(parseEditableNumber("1,234", locale: Locale(identifier: "de_DE")) == 1.234)
+    }
+
+    @Test
+    func editableNumberUpdatesClampValidDraftText() {
+        let range = -24.0...24.0
+
+        #expect(clampedEditableNumber("-12.345", range: range, locale: Locale(identifier: "en_US_POSIX")) == -12.345)
+        #expect(clampedEditableNumber("30", range: range, locale: Locale(identifier: "en_US_POSIX")) == 24)
+        #expect(clampedEditableNumber("-", range: range, locale: Locale(identifier: "en_US_POSIX")) == nil)
+    }
+
+    @Test
+    func sliderQuantizationDoesNotIntroduceDisplayNoise() {
+        let locale = Locale(identifier: "en_US_POSIX")
+
+        for tenth in -240...240 {
+            let expected = Double(tenth) / 10
+            let value = quantized(expected, step: 0.1)
+            #expect(editableNumberText(value, locale: locale) == editableNumberText(expected, locale: locale))
+        }
+    }
+
     @Test(arguments: ["nan", "inf", "-inf", "infinity", "-infinity"])
     func editableNumberParsingRejectsNonFiniteValues(_ text: String) {
         #expect(parseEditableNumber(text, locale: Locale(identifier: "en_US_POSIX")) == nil)


### PR DESCRIPTION
- Slider-only EQ controls made it unnecessarily difficult to enter exact frequency, gain, Q, and preamp values.
- Add direct numeric entry while retaining the existing bounds, validation, and localized display behavior.
- Use a logarithmic frequency slider so low-frequency adjustments gain useful precision without sacrificing the full supported range.