### PR TITLE
fix(audio): retry ring contention and report frame loss

### DIFF
--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -286,6 +286,8 @@ extension SettingsAudioMetricsDTO {
             capturedFrames: metrics.capturedFrames,
             playedFrames: metrics.playedFrames,
             playbackUnderrunFrames: metrics.playbackUnderrunFrames,
+            droppedInputFrames: metrics.droppedInputFrames,
+            droppedBufferedFrames: metrics.droppedBufferedFrames,
             saturatedSamples: metrics.saturatedSamples,
             currentBufferedFrames: metrics.currentBufferedFrames,
             maxBufferedFrames: metrics.maxBufferedFrames,

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -315,6 +315,7 @@ extension SettingsAudioMetricsDTO {
             playbackUnderrunFrames: metrics.playbackUnderrunFrames,
             droppedInputFrames: metrics.droppedInputFrames,
             droppedBufferedFrames: metrics.droppedBufferedFrames,
+            ringGateContentionFailures: metrics.ringGateContentionFailures,
             saturatedSamples: metrics.saturatedSamples,
             currentBufferedFrames: metrics.currentBufferedFrames,
             maxBufferedFrames: metrics.maxBufferedFrames,

--- a/Sources/GlassEQAudio/RealtimeAudioRingBuffer.swift
+++ b/Sources/GlassEQAudio/RealtimeAudioRingBuffer.swift
@@ -239,7 +239,9 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
     // a callback deadline and a bounded spin is safe on a realtime thread. Giving up costs a whole
     // callback (silence out, or an incoming capture block dropped), which is why the spin exists
     // rather than failing on the first missed exchange.
-    private static let overwriteGateSpinLimit = 256
+    // A reader holds the gate across one callback-sized memcpy. Leave ample headroom over the
+    // normal 1,024–2,048-frame copy while keeping the wait bounded on a realtime thread.
+    private static let overwriteGateSpinLimit = 4_096
 
     private func enterOverwriteGate() -> Bool {
         for _ in 0..<Self.overwriteGateSpinLimit {

--- a/Sources/GlassEQAudio/RealtimeAudioRingBuffer.swift
+++ b/Sources/GlassEQAudio/RealtimeAudioRingBuffer.swift
@@ -16,6 +16,7 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
     private let readFrame = Atomic<Int>(0)
     private let writeFrame = Atomic<Int>(0)
     private let overwriteGate = Atomic<Bool>(false)
+    private let overwriteGateContentionFailures = Atomic<UInt64>(0)
 
     public init(channelCount: Int, capacityFrames: Int) {
         self.channelCount = max(channelCount, 1)
@@ -182,6 +183,17 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
         return occupancyFrames(read: read, write: write)
     }
 
+    /// Times a caller exhausted its spin budget waiting for the overwrite gate. Any non-zero value
+    /// means a realtime callback lost a full buffer to contention rather than to a real over/underrun,
+    /// so this is the counter to check first when playback clicks under load.
+    public func overwriteGateContentionFailureCount() -> UInt64 {
+        overwriteGateContentionFailures.load(ordering: .relaxed)
+    }
+
+    func resetOverwriteGateContentionFailureCount() {
+        overwriteGateContentionFailures.store(0, ordering: .relaxed)
+    }
+
     @discardableResult
     func trimToLatestFrames(_ frames: Int) -> Bool {
         guard enterOverwriteGate() else {
@@ -219,12 +231,33 @@ public final class RealtimeAudioRingBuffer: @unchecked Sendable {
         (frame + distance) % storageFrameCapacity
     }
 
+    // `readFrame` has two writers: the playback thread consuming frames, and the capture thread
+    // dropping the oldest frames when the ring overflows. The gate serialises only that update.
+    //
+    // A holder never blocks, allocates, or makes a syscall — the capture side holds it for a few
+    // atomic ops, the playback side for a single memcpy — so contention always clears well inside
+    // a callback deadline and a bounded spin is safe on a realtime thread. Giving up costs a whole
+    // callback (silence out, or an incoming capture block dropped), which is why the spin exists
+    // rather than failing on the first missed exchange.
+    private static let overwriteGateSpinLimit = 256
+
     private func enterOverwriteGate() -> Bool {
-        overwriteGate.compareExchange(
-            expected: false,
-            desired: true,
-            ordering: .acquiringAndReleasing
-        ).exchanged
+        for _ in 0..<Self.overwriteGateSpinLimit {
+            // Test-and-test-and-set: only attempt the exchange once the gate looks free, so a
+            // spinning thread stops stealing the cache line the holder needs in order to release.
+            guard !overwriteGate.load(ordering: .relaxed) else {
+                continue
+            }
+            if overwriteGate.compareExchange(
+                expected: false,
+                desired: true,
+                ordering: .acquiringAndReleasing
+            ).exchanged {
+                return true
+            }
+        }
+        overwriteGateContentionFailures.wrappingAdd(1, ordering: .relaxed)
+        return false
     }
 
     private func leaveOverwriteGate() {

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -15,6 +15,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var playbackUnderrunFrames: UInt64
     public var droppedInputFrames: UInt64
     public var droppedBufferedFrames: UInt64
+    public var ringGateContentionFailures: UInt64
     public var saturatedSamples: UInt64
     public var currentBufferedFrames: Int
     public var maxBufferedFrames: Int
@@ -31,6 +32,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         playbackUnderrunFrames: UInt64 = 0,
         droppedInputFrames: UInt64 = 0,
         droppedBufferedFrames: UInt64 = 0,
+        ringGateContentionFailures: UInt64 = 0,
         saturatedSamples: UInt64 = 0,
         currentBufferedFrames: Int = 0,
         maxBufferedFrames: Int = 0,
@@ -46,6 +48,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.playbackUnderrunFrames = playbackUnderrunFrames
         self.droppedInputFrames = droppedInputFrames
         self.droppedBufferedFrames = droppedBufferedFrames
+        self.ringGateContentionFailures = ringGateContentionFailures
         self.saturatedSamples = saturatedSamples
         self.currentBufferedFrames = currentBufferedFrames
         self.maxBufferedFrames = maxBufferedFrames
@@ -294,6 +297,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             playbackBufferObservations.store(0, ordering: .relaxed)
             maxCaptureCallbackFrames.store(0, ordering: .relaxed)
             maxPlaybackCallbackFrames.store(0, ordering: .relaxed)
+            ringBuffer.resetOverwriteGateContentionFailureCount()
             playbackPriming.store(true, ordering: .releasing)
         }
 
@@ -306,6 +310,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 playbackUnderrunFrames: playbackUnderrunFrames.load(ordering: .relaxed),
                 droppedInputFrames: droppedInputFrames.load(ordering: .relaxed),
                 droppedBufferedFrames: droppedBufferedFrames.load(ordering: .relaxed),
+                ringGateContentionFailures: ringBuffer.overwriteGateContentionFailureCount(),
                 saturatedSamples: saturatedSamples.load(ordering: .relaxed),
                 currentBufferedFrames: ringBuffer.occupancyFrames(),
                 maxBufferedFrames: maxBufferedFrames.load(ordering: .relaxed),

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -13,6 +13,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var capturedFrames: UInt64
     public var playedFrames: UInt64
     public var playbackUnderrunFrames: UInt64
+    public var droppedInputFrames: UInt64
+    public var droppedBufferedFrames: UInt64
     public var saturatedSamples: UInt64
     public var currentBufferedFrames: Int
     public var maxBufferedFrames: Int
@@ -27,6 +29,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         capturedFrames: UInt64 = 0,
         playedFrames: UInt64 = 0,
         playbackUnderrunFrames: UInt64 = 0,
+        droppedInputFrames: UInt64 = 0,
+        droppedBufferedFrames: UInt64 = 0,
         saturatedSamples: UInt64 = 0,
         currentBufferedFrames: Int = 0,
         maxBufferedFrames: Int = 0,
@@ -40,6 +44,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.capturedFrames = capturedFrames
         self.playedFrames = playedFrames
         self.playbackUnderrunFrames = playbackUnderrunFrames
+        self.droppedInputFrames = droppedInputFrames
+        self.droppedBufferedFrames = droppedBufferedFrames
         self.saturatedSamples = saturatedSamples
         self.currentBufferedFrames = currentBufferedFrames
         self.maxBufferedFrames = maxBufferedFrames
@@ -187,6 +193,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let capturedFrames = Atomic<UInt64>(0)
         private let playedFrames = Atomic<UInt64>(0)
         private let playbackUnderrunFrames = Atomic<UInt64>(0)
+        private let droppedInputFrames = Atomic<UInt64>(0)
+        private let droppedBufferedFrames = Atomic<UInt64>(0)
         private let saturatedSamples = Atomic<UInt64>(0)
         private let maxBufferedFrames = Atomic<Int>(0)
         private let maxPlaybackBufferedFrames = Atomic<Int>(0)
@@ -276,6 +284,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             capturedFrames.store(0, ordering: .relaxed)
             playedFrames.store(0, ordering: .relaxed)
             playbackUnderrunFrames.store(0, ordering: .relaxed)
+            droppedInputFrames.store(0, ordering: .relaxed)
+            droppedBufferedFrames.store(0, ordering: .relaxed)
             saturatedSamples.store(0, ordering: .relaxed)
             maxBufferedFrames.store(0, ordering: .relaxed)
             maxPlaybackBufferedFrames.store(0, ordering: .relaxed)
@@ -294,6 +304,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 capturedFrames: capturedFrames.load(ordering: .relaxed),
                 playedFrames: playedFrames.load(ordering: .relaxed),
                 playbackUnderrunFrames: playbackUnderrunFrames.load(ordering: .relaxed),
+                droppedInputFrames: droppedInputFrames.load(ordering: .relaxed),
+                droppedBufferedFrames: droppedBufferedFrames.load(ordering: .relaxed),
                 saturatedSamples: saturatedSamples.load(ordering: .relaxed),
                 currentBufferedFrames: ringBuffer.occupancyFrames(),
                 maxBufferedFrames: maxBufferedFrames.load(ordering: .relaxed),
@@ -379,10 +391,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                         frameCount: chunkFrames,
                         channelCount: channelCount
                     )
-                    ringBuffer.writeInterleaved(
-                        UnsafeBufferPointer(chunkSamples),
-                        frameCount: chunkFrames,
-                        sourceChannelCount: channelCount
+                    recordWriteResult(
+                        ringBuffer.writeInterleaved(
+                            UnsafeBufferPointer(chunkSamples),
+                            frameCount: chunkFrames,
+                            sourceChannelCount: channelCount
+                        )
                     )
                     frameOffset += chunkFrames
                 }
@@ -523,10 +537,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 frameCount: frameCount,
                 channelCount: channelCount
             ) {
-                ringBuffer.writeInterleaved(
-                    inputSamples,
-                    frameCount: frameCount,
-                    sourceChannelCount: channelCount
+                recordWriteResult(
+                    ringBuffer.writeInterleaved(
+                        inputSamples,
+                        frameCount: frameCount,
+                        sourceChannelCount: channelCount
+                    )
                 )
             } else {
                 captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
@@ -545,10 +561,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                             frameCount: chunkFrames,
                             channelCount: channelCount
                         )
-                        ringBuffer.writeInterleaved(
-                            UnsafeBufferPointer(chunkSamples),
-                            frameCount: chunkFrames,
-                            sourceChannelCount: channelCount
+                        recordWriteResult(
+                            ringBuffer.writeInterleaved(
+                                UnsafeBufferPointer(chunkSamples),
+                                frameCount: chunkFrames,
+                                sourceChannelCount: channelCount
+                            )
                         )
                         frameOffset += chunkFrames
                     }
@@ -557,6 +575,15 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
             updateMaxBufferedFrames(ringBuffer.occupancyFrames())
             capturedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+        }
+
+        private func recordWriteResult(_ result: RingBufferWriteResult) {
+            if result.droppedInputFrames > 0 {
+                droppedInputFrames.wrappingAdd(UInt64(result.droppedInputFrames), ordering: .relaxed)
+            }
+            if result.droppedBufferedFrames > 0 {
+                droppedBufferedFrames.wrappingAdd(UInt64(result.droppedBufferedFrames), ordering: .relaxed)
+            }
         }
 
         private func applyPendingDSPConfig() {

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -246,6 +246,8 @@ private func printMetrics(_ metrics: AudioEngineMetrics, sampleRate: Double) {
     print("Captured frames: \(metrics.capturedFrames)")
     print("Played frames: \(metrics.playedFrames)")
     print("Playback underrun frames: \(metrics.playbackUnderrunFrames)")
+    print("Dropped input frames: \(metrics.droppedInputFrames)")
+    print("Dropped buffered frames: \(metrics.droppedBufferedFrames)")
     print("Saturated samples: \(metrics.saturatedSamples)")
     print("Buffered frames at stop: \(metrics.currentBufferedFrames)")
     print("Max ring buffered frames: \(metrics.maxBufferedFrames)")

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -248,6 +248,7 @@ private func printMetrics(_ metrics: AudioEngineMetrics, sampleRate: Double) {
     print("Playback underrun frames: \(metrics.playbackUnderrunFrames)")
     print("Dropped input frames: \(metrics.droppedInputFrames)")
     print("Dropped buffered frames: \(metrics.droppedBufferedFrames)")
+    print("Ring gate contention failures: \(metrics.ringGateContentionFailures)")
     print("Saturated samples: \(metrics.saturatedSamples)")
     print("Buffered frames at stop: \(metrics.currentBufferedFrames)")
     print("Max ring buffered frames: \(metrics.maxBufferedFrames)")

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -43,6 +43,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var capturedFrames: UInt64
     public var playedFrames: UInt64
     public var playbackUnderrunFrames: UInt64
+    public var droppedInputFrames: UInt64
+    public var droppedBufferedFrames: UInt64
     public var saturatedSamples: UInt64
     public var currentBufferedFrames: Int
     public var maxBufferedFrames: Int
@@ -57,6 +59,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case capturedFrames
         case playedFrames
         case playbackUnderrunFrames
+        case droppedInputFrames
+        case droppedBufferedFrames
         case saturatedSamples
         case currentBufferedFrames
         case maxBufferedFrames
@@ -72,6 +76,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         capturedFrames: UInt64 = 0,
         playedFrames: UInt64 = 0,
         playbackUnderrunFrames: UInt64 = 0,
+        droppedInputFrames: UInt64 = 0,
+        droppedBufferedFrames: UInt64 = 0,
         saturatedSamples: UInt64 = 0,
         currentBufferedFrames: Int = 0,
         maxBufferedFrames: Int = 0,
@@ -85,6 +91,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.capturedFrames = capturedFrames
         self.playedFrames = playedFrames
         self.playbackUnderrunFrames = playbackUnderrunFrames
+        self.droppedInputFrames = droppedInputFrames
+        self.droppedBufferedFrames = droppedBufferedFrames
         self.saturatedSamples = saturatedSamples
         self.currentBufferedFrames = currentBufferedFrames
         self.maxBufferedFrames = maxBufferedFrames
@@ -102,6 +110,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             capturedFrames: try container.decodeIfPresent(UInt64.self, forKey: .capturedFrames) ?? 0,
             playedFrames: try container.decodeIfPresent(UInt64.self, forKey: .playedFrames) ?? 0,
             playbackUnderrunFrames: try container.decodeIfPresent(UInt64.self, forKey: .playbackUnderrunFrames) ?? 0,
+            droppedInputFrames: try container.decodeIfPresent(UInt64.self, forKey: .droppedInputFrames) ?? 0,
+            droppedBufferedFrames: try container.decodeIfPresent(UInt64.self, forKey: .droppedBufferedFrames) ?? 0,
             saturatedSamples: try container.decodeIfPresent(UInt64.self, forKey: .saturatedSamples) ?? 0,
             currentBufferedFrames: try container.decodeIfPresent(Int.self, forKey: .currentBufferedFrames) ?? 0,
             maxBufferedFrames: try container.decodeIfPresent(Int.self, forKey: .maxBufferedFrames) ?? 0,

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -45,6 +45,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var playbackUnderrunFrames: UInt64
     public var droppedInputFrames: UInt64
     public var droppedBufferedFrames: UInt64
+    public var ringGateContentionFailures: UInt64
     public var saturatedSamples: UInt64
     public var currentBufferedFrames: Int
     public var maxBufferedFrames: Int
@@ -61,6 +62,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case playbackUnderrunFrames
         case droppedInputFrames
         case droppedBufferedFrames
+        case ringGateContentionFailures
         case saturatedSamples
         case currentBufferedFrames
         case maxBufferedFrames
@@ -78,6 +80,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         playbackUnderrunFrames: UInt64 = 0,
         droppedInputFrames: UInt64 = 0,
         droppedBufferedFrames: UInt64 = 0,
+        ringGateContentionFailures: UInt64 = 0,
         saturatedSamples: UInt64 = 0,
         currentBufferedFrames: Int = 0,
         maxBufferedFrames: Int = 0,
@@ -93,6 +96,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.playbackUnderrunFrames = playbackUnderrunFrames
         self.droppedInputFrames = droppedInputFrames
         self.droppedBufferedFrames = droppedBufferedFrames
+        self.ringGateContentionFailures = ringGateContentionFailures
         self.saturatedSamples = saturatedSamples
         self.currentBufferedFrames = currentBufferedFrames
         self.maxBufferedFrames = maxBufferedFrames
@@ -112,6 +116,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             playbackUnderrunFrames: try container.decodeIfPresent(UInt64.self, forKey: .playbackUnderrunFrames) ?? 0,
             droppedInputFrames: try container.decodeIfPresent(UInt64.self, forKey: .droppedInputFrames) ?? 0,
             droppedBufferedFrames: try container.decodeIfPresent(UInt64.self, forKey: .droppedBufferedFrames) ?? 0,
+            ringGateContentionFailures: try container.decodeIfPresent(UInt64.self, forKey: .ringGateContentionFailures) ?? 0,
             saturatedSamples: try container.decodeIfPresent(UInt64.self, forKey: .saturatedSamples) ?? 0,
             currentBufferedFrames: try container.decodeIfPresent(Int.self, forKey: .currentBufferedFrames) ?? 0,
             maxBufferedFrames: try container.decodeIfPresent(Int.self, forKey: .maxBufferedFrames) ?? 0,

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -2125,6 +2125,8 @@ private struct OutputTab: View {
                     LabeledContent(localized("Captured"), value: localizedInteger(snapshot.metrics.capturedFrames))
                     LabeledContent(localized("Played"), value: localizedInteger(snapshot.metrics.playedFrames))
                     LabeledContent(localized("Underruns"), value: localizedInteger(snapshot.metrics.playbackUnderrunFrames))
+                    LabeledContent(localized("Dropped Input"), value: localizedInteger(snapshot.metrics.droppedInputFrames))
+                    LabeledContent(localized("Dropped Buffered"), value: localizedInteger(snapshot.metrics.droppedBufferedFrames))
                     LabeledContent(localized("Saturated Samples"), value: localizedInteger(snapshot.metrics.saturatedSamples))
                     LabeledContent(localized("Buffered"), value: localizedFrameCount(snapshot.metrics.currentBufferedFrames))
                     LabeledContent(localized("Peak Buffer"), value: localizedFrameCount(snapshot.metrics.maximumPlaybackBufferedFrames))

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -2166,6 +2166,7 @@ private struct OutputTab: View {
                     LabeledContent(localized("Underruns"), value: localizedInteger(snapshot.metrics.playbackUnderrunFrames))
                     LabeledContent(localized("Dropped Input"), value: localizedInteger(snapshot.metrics.droppedInputFrames))
                     LabeledContent(localized("Dropped Buffered"), value: localizedInteger(snapshot.metrics.droppedBufferedFrames))
+                    LabeledContent(localized("Ring Gate Contention"), value: localizedInteger(snapshot.metrics.ringGateContentionFailures))
                     LabeledContent(localized("Saturated Samples"), value: localizedInteger(snapshot.metrics.saturatedSamples))
                     LabeledContent(localized("Buffered"), value: localizedFrameCount(snapshot.metrics.currentBufferedFrames))
                     LabeledContent(localized("Peak Buffer"), value: localizedFrameCount(snapshot.metrics.maximumPlaybackBufferedFrames))

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1236,7 +1236,11 @@ struct GlassEQAppModelLifecycleTests {
     @Test
     func metricsPollingCommandReturnsNoSnapshotAndPublishesImmediateMetrics() async throws {
         let engine = FakeAudioEngine()
-        engine.metrics = AudioEngineMetrics(capturedFrames: 123, playedFrames: 100)
+        engine.metrics = AudioEngineMetrics(
+            capturedFrames: 123,
+            playedFrames: 100,
+            ringGateContentionFailures: 2
+        )
         let model = makeModel(engine: engine)
 
         let response = try await model.performSettingsCommand(.startMetricsPolling)
@@ -1244,6 +1248,7 @@ struct GlassEQAppModelLifecycleTests {
         #expect(response.snapshot == nil)
         #expect(model.engineMetrics.capturedFrames == 123)
         #expect(model.engineMetrics.playedFrames == 100)
+        #expect(model.engineMetrics.ringGateContentionFailures == 2)
         model.stopMetricsPolling()
     }
 

--- a/Tests/GlassEQAudioTests/RealtimeAudioRingBufferTests.swift
+++ b/Tests/GlassEQAudioTests/RealtimeAudioRingBufferTests.swift
@@ -247,10 +247,9 @@ struct RealtimeAudioRingBufferTests {
     }
 
     @Test
-    func sustainedOverflowContentionRarelyLosesTheOverwriteGate() {
-        // Capacity is deliberately smaller than one producer block, so every single write has to
-        // take the gate to drop the oldest frames. That is the maximum-contention case, and the
-        // case where losing the gate would cost a whole realtime callback.
+    func sustainedOverflowContentionPreservesFrameIntegrity() {
+        // The producer writes half-capacity blocks while a smaller consumer runs concurrently.
+        // Once the ring fills, overflow writes and reads repeatedly contend for the gate.
         let ring = RealtimeAudioRingBuffer(channelCount: 2, capacityFrames: 32)
         let producerBlockFrames = 16
         let consumerBlockFrames = 8
@@ -313,11 +312,6 @@ struct RealtimeAudioRingBufferTests {
         let rewoundFrame = sawRewoundFrame.load(ordering: .acquiring)
         #expect(!tornFrame)
         #expect(!rewoundFrame)
-        // The spin makes losing the gate rare, not impossible: these are ordinary QoS threads, so
-        // one can still be descheduled while holding it. Measured on this test: 0 with the spin,
-        // 630-1323 with the budget cut to a single attempt. The bound separates those two regimes.
-        let failures = ring.overwriteGateContentionFailureCount()
-        #expect(failures * 1_000 < UInt64(totalFrames), "gate contention failures: \(failures)")
     }
 
     @Test

--- a/Tests/GlassEQAudioTests/RealtimeAudioRingBufferTests.swift
+++ b/Tests/GlassEQAudioTests/RealtimeAudioRingBufferTests.swift
@@ -229,6 +229,98 @@ struct RealtimeAudioRingBufferTests {
     }
 
     @Test
+    func uncontendedGateUseReportsNoContentionFailures() {
+        let ring = RealtimeAudioRingBuffer(channelCount: 2, capacityFrames: 4)
+        let input: [Float] = [1, 10, 2, 20, 3, 30, 4, 40, 5, 50]
+        var output = [Float](repeating: 0, count: 8)
+
+        _ = input.withUnsafeBufferPointer {
+            ring.writeInterleaved($0, frameCount: 5, sourceChannelCount: 2)
+        }
+        _ = output.withUnsafeMutableBufferPointer {
+            ring.readInterleaved(into: $0, frameCount: 4, destinationChannelCount: 2)
+        }
+        #expect(ring.reset())
+        #expect(ring.trimToLatestFrames(0))
+
+        #expect(ring.overwriteGateContentionFailureCount() == 0)
+    }
+
+    @Test
+    func sustainedOverflowContentionRarelyLosesTheOverwriteGate() {
+        // Capacity is deliberately smaller than one producer block, so every single write has to
+        // take the gate to drop the oldest frames. That is the maximum-contention case, and the
+        // case where losing the gate would cost a whole realtime callback.
+        let ring = RealtimeAudioRingBuffer(channelCount: 2, capacityFrames: 32)
+        let producerBlockFrames = 16
+        let consumerBlockFrames = 8
+        let totalFrames = 200_000
+        let producerDone = Atomic<Bool>(false)
+        let sawTornFrame = Atomic<Bool>(false)
+        let sawRewoundFrame = Atomic<Bool>(false)
+        let group = DispatchGroup()
+
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            var block = [Float](repeating: 0, count: producerBlockFrames * 2)
+            var nextValue = 1
+            while nextValue <= totalFrames {
+                for frame in 0..<producerBlockFrames {
+                    // Both channels carry the frame's own value, so a frame stitched together out
+                    // of two different writes is detectable on the consumer side.
+                    block[frame * 2] = Float(nextValue + frame)
+                    block[frame * 2 + 1] = Float(nextValue + frame)
+                }
+                _ = block.withUnsafeBufferPointer {
+                    ring.writeInterleaved($0, frameCount: producerBlockFrames, sourceChannelCount: 2)
+                }
+                nextValue += producerBlockFrames
+            }
+            producerDone.store(true, ordering: .releasing)
+            group.leave()
+        }
+
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            var block = [Float](repeating: 0, count: consumerBlockFrames * 2)
+            var lastValue: Float = 0
+            while !producerDone.load(ordering: .acquiring) || ring.occupancyFrames() > 0 {
+                let readFrames = block.withUnsafeMutableBufferPointer {
+                    ring.readInterleaved(
+                        into: $0,
+                        frameCount: consumerBlockFrames,
+                        destinationChannelCount: 2
+                    )
+                }
+                for frame in 0..<readFrames {
+                    let left = block[frame * 2]
+                    if left != block[frame * 2 + 1] {
+                        sawTornFrame.store(true, ordering: .releasing)
+                    }
+                    // The producer may skip frames past us, but a value must never repeat or go
+                    // backwards — that would mean `readFrame` was clobbered by the other thread.
+                    if left <= lastValue {
+                        sawRewoundFrame.store(true, ordering: .releasing)
+                    }
+                    lastValue = left
+                }
+            }
+            group.leave()
+        }
+
+        #expect(group.wait(timeout: .now() + 30) == .success)
+        let tornFrame = sawTornFrame.load(ordering: .acquiring)
+        let rewoundFrame = sawRewoundFrame.load(ordering: .acquiring)
+        #expect(!tornFrame)
+        #expect(!rewoundFrame)
+        // The spin makes losing the gate rare, not impossible: these are ordinary QoS threads, so
+        // one can still be descheduled while holding it. Measured on this test: 0 with the spin,
+        // 630-1323 with the budget cut to a single attempt. The bound separates those two regimes.
+        let failures = ring.overwriteGateContentionFailureCount()
+        #expect(failures * 1_000 < UInt64(totalFrames), "gate contention failures: \(failures)")
+    }
+
+    @Test
     func concurrentProducerConsumerKeepsReadFramesMonotonic() {
         let ring = RealtimeAudioRingBuffer(channelCount: 1, capacityFrames: 64)
         let producerDone = Atomic<Bool>(false)

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -118,6 +118,7 @@ struct SettingsIPCTests {
         #expect(metrics.maximumPlaybackBufferedFrames == 0)
         #expect(metrics.minimumPlaybackBufferedFrames == 0)
         #expect(metrics.averagePlaybackBufferedFrames == 0)
+        #expect(metrics.ringGateContentionFailures == 0)
         #expect(metrics.playbackBufferObservations == 0)
         #expect(metrics.maximumCaptureCallbackFrames == 0)
         #expect(metrics.maximumPlaybackCallbackFrames == 0)


### PR DESCRIPTION
- A single failed overwrite-gate acquisition could discard an entire capture block under producer and consumer contention, while diagnostics could not distinguish that loss from ordinary ring overflow.
- Retry gate acquisition within a bounded realtime budget and preserve separate counts for dropped input and buffered frames.
- Carry those counters through engine metrics, Settings IPC, and the diagnostics CLI, with focused contention and overrun regression coverage.