### PR TITLE
chore(release): prepare alpha-0.9

### DIFF
--- a/Docs/Distribution.md
+++ b/Docs/Distribution.md
@@ -1,6 +1,6 @@
 # Distribution Notes
 
-GlassEQ alpha-0.8.1 is intended for ad hoc-signed distribution to technical testers. It is not Developer ID signed and is not notarized. A later non-alpha build will move to Developer ID distribution outside the Mac App Store.
+GlassEQ alpha-0.9 is intended for ad hoc-signed distribution to technical testers. It is not Developer ID signed and is not notarized. A later non-alpha build will move to Developer ID distribution outside the Mac App Store.
 
 ## Current Alpha Distribution
 
@@ -13,7 +13,7 @@ Build the alpha artifact:
 The script produces:
 
 - `.build/release-app/GlassEQ.app`
-- `.build/dist/GlassEQ-alpha-0.8.1-macos26-arm64.zip`
+- `.build/dist/GlassEQ-alpha-0.9-macos26-arm64.zip`
 
 The bundle is ad hoc-signed with `codesign --sign -`. It is not Developer ID signed and is not notarized, so this command should reject it:
 

--- a/Docs/ReleaseNotes-alpha-0.9.md
+++ b/Docs/ReleaseNotes-alpha-0.9.md
@@ -17,20 +17,6 @@ This build is ad hoc-signed, not Developer ID signed, and not notarized. macOS G
 - Exact EQ values can be typed directly, and the parametric frequency control now uses a logarithmic scale.
 - If the separate Settings helper cannot be launched, GlassEQ opens the same Settings interface inside the menu bar process.
 
-## Included
-
-- Menu bar app shell.
-- Core Audio system output tap.
-- Playback of processed audio to the current default output.
-- Parametric EQ, 10-band graphic EQ, and 31-band graphic EQ profiles.
-- AutoEQ / EqualizerAPO and REW text import.
-- Per-output profile mappings by Core Audio device UID.
-- Profile persistence under the GlassEQ sandbox container, with migration from legacy `~/Library/Application Support/GlassEQ` data.
-- Settings helper app and local IPC for editing profiles from the menu bar app, with an in-process fallback.
-- Audio route recovery after system sleep, screen wake, session unlock, and Bluetooth route teardown while the screen is locked.
-- Route-specific playback buffering, clock correction, and local calibration history.
-- Callback, frame-loss, occupancy, clock-correction, and latency diagnostics.
-
 ## Supported Alpha Target
 
 - macOS 26.0 or newer.

--- a/Docs/ReleaseNotes-alpha-0.9.md
+++ b/Docs/ReleaseNotes-alpha-0.9.md
@@ -1,0 +1,57 @@
+# GlassEQ alpha-0.9 Release Notes
+
+This is a technical alpha for Apple Silicon Macs running macOS 26.
+
+## Distribution Warning
+
+This build is ad hoc-signed, not Developer ID signed, and not notarized. macOS Gatekeeper will reject it by default. Install only if you are comfortable testing ad hoc-signed macOS software and granting system audio capture permission.
+
+## Changes Since alpha-0.8.1
+
+- Playback now continuously corrects for independent capture and output clocks instead of eventually dropping or duplicating frames when nominal sample rates match but hardware clocks drift.
+- GlassEQ learns a stable callback size and playback target for each output route. The Settings diagnostics show the active correction and allow the current device's calibration to be reset.
+- Bidirectional Bluetooth headset modes retain their device-owned 24 or 16 kHz sample rate and use realtime sample-rate conversion with anti-alias filtering.
+- Filters above a low-rate output's usable frequency ceiling are disabled in the realtime processor and identified in the editor.
+- Multi-channel output devices play the stereo signal through their configured preferred stereo pair while leaving unrelated channels silent.
+- Ring-buffer contention is retried within a bounded realtime budget, and capture-side dropped frames are now reported by diagnostics.
+- Exact EQ values can be typed directly, and the parametric frequency control now uses a logarithmic scale.
+- If the separate Settings helper cannot be launched, GlassEQ opens the same Settings interface inside the menu bar process.
+
+## Included
+
+- Menu bar app shell.
+- Core Audio system output tap.
+- Playback of processed audio to the current default output.
+- Parametric EQ, 10-band graphic EQ, and 31-band graphic EQ profiles.
+- AutoEQ / EqualizerAPO and REW text import.
+- Per-output profile mappings by Core Audio device UID.
+- Profile persistence under the GlassEQ sandbox container, with migration from legacy `~/Library/Application Support/GlassEQ` data.
+- Settings helper app and local IPC for editing profiles from the menu bar app, with an in-process fallback.
+- Audio route recovery after system sleep, screen wake, session unlock, and Bluetooth route teardown while the screen is locked.
+- Route-specific playback buffering, clock correction, and local calibration history.
+- Callback, frame-loss, occupancy, clock-correction, and latency diagnostics.
+
+## Supported Alpha Target
+
+- macOS 26.0 or newer.
+- Apple Silicon / arm64 only.
+
+## Known Issues
+
+- Gatekeeper rejection is expected because the app is not notarized.
+- System audio capture permission may require manual cleanup or retrying on test machines.
+- Bluetooth and AirPods routes may still expose macOS Core Audio edge cases; report device model, macOS version, and steps to reproduce.
+- AirPlay outputs are not yet supported.
+- No automatic updates.
+- No crash reporting.
+- No notarized Developer ID build yet.
+- No x86_64 build.
+
+## Build Artifact
+
+The release script writes:
+
+```sh
+.build/dist/GlassEQ-alpha-0.9-macos26-arm64.zip
+.build/dist/GlassEQ-alpha-0.9-macos26-arm64.zip.sha256
+```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GlassEQ takes a different route. It uses **Core Audio process taps**, Apple's mo
 
 ## Download & install
 
-Grab `GlassEQ-alpha-0.8.1-macos26-arm64.zip` from the [alpha-0.8.1 release](https://github.com/juhokoskela/GlassEQ/releases/tag/alpha-0.8.1), then:
+Grab `GlassEQ-alpha-0.9-macos26-arm64.zip` from the [alpha-0.9 release](https://github.com/juhokoskela/GlassEQ/releases/tag/alpha-0.9), then:
 
 1. Unzip it.
 2. Move `GlassEQ.app` to `/Applications`.
@@ -37,7 +37,7 @@ On first run GlassEQ asks for **system audio capture permission** — that's wha
 
 ### About this alpha
 
-GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no automatic updates or crash reporting yet. Expect the occasional rough edge, and please report any hardware-specific audio issues you run into. See [Docs/AlphaTesting.md](Docs/AlphaTesting.md), [Docs/Distribution.md](Docs/Distribution.md), and [Docs/ReleaseNotes-alpha-0.8.1.md](Docs/ReleaseNotes-alpha-0.8.1.md) before installing a build.
+GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no automatic updates or crash reporting yet. Expect the occasional rough edge, and please report any hardware-specific audio issues you run into. See [Docs/AlphaTesting.md](Docs/AlphaTesting.md), [Docs/Distribution.md](Docs/Distribution.md), and [Docs/ReleaseNotes-alpha-0.9.md](Docs/ReleaseNotes-alpha-0.9.md) before installing a build.
 
 ## How it works
 
@@ -58,7 +58,7 @@ The result is low, predictable latency. The built-in diagnostics report it direc
 - **Profile import** from AutoEQ / EqualizerAPO and REW text, allowing you to paste a headphone-correction curve straight in.
 - **Per-output profile mapping** by Core Audio device UID, with a fallback profile for unmapped devices.
 - **Soft-clip saturation** that tames overshoot instead of hard-clipping.
-- **Built-in diagnostics** (captured/played frames, underruns, buffer occupancy, latency).
+- **Built-in diagnostics** for frame loss, underruns, adaptive buffer occupancy, clock correction, and latency.
 
 ![GlassEQ settings — Editor tab, with the frequency-response graph and parametric filters](Docs/Screenshots/editor.png)
 

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -100,8 +100,8 @@ private enum AppBuildInfo {
            !releaseLabel.isEmpty {
             return releaseLabel
         }
-        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.8.1"
-        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "11"
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.9.0"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "12"
         return "v\(version) (\(build))"
     }
 }

--- a/Sources/GlassEQApp/Info.plist
+++ b/Sources/GlassEQApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-    <string>0.8.1</string>
+    <string>0.9.0</string>
 	<key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
 	<key>GlassEQReleaseLabel</key>
-    <string>alpha-0.8.1</string>
+    <string>alpha-0.9</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/GlassEQSettings/Info.plist
+++ b/Sources/GlassEQSettings/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.1</string>
+    <string>0.9.0</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
- Alpha 0.9 packages clock correction, route-adaptive buffering, low-rate headset conversion, frame-loss diagnostics, precise EQ controls, and the in-process Settings fallback for technical testers.
- Bump the app and helper to version 0.9.0 build 12 and align the distribution artifact, download links, and release notes.
- The release remains an ad hoc-signed, Apple Silicon build targeting macOS 26.