### PR TITLE
feat(audio): adopt aggregate-clock output architecture

### DIFF
--- a/Docs/AggregateSafetyOffsetInvestigation.md
+++ b/Docs/AggregateSafetyOffsetInvestigation.md
@@ -1,0 +1,242 @@
+# Where the 74-frame input safety offset comes from
+
+This is a follow-up to [Aggregate clock experiment: findings](AggregateClockExperiment.md). It answers one question: can a sandboxed application remove the 74-frame input-scoped safety offset that the private combined aggregate inherits from a USB output device, while keeping the physical output as clock source and output target?
+
+Measured on macOS 26.6 (build 25G81), Xcode 26.6 SDK, all devices at 48 kHz.
+
+## Verdict
+
+Effectively device-defined and unbeatable from an application. The value is published by Apple's USB audio driver stack, it is read-only in every scope, and the aggregate device copies it verbatim from whichever subdevice owns its timeline. Every aggregate composition key that touches latency is additive and clamps at zero, so nothing can subtract. The only supported way to change the number is to change which device supplies the aggregate's timebase, and the only device GlassEQ could supply is one it wrote itself, which means a driver.
+
+I do not think the 74 frames are worth chasing. Reasoning is in the last section.
+
+## What I measured
+
+Two read-only probes plus a private-aggregate matrix. No taps were created, no IO was started, and no property on any physical device was written. Every aggregate was private and destroyed immediately. Source is in the appendix.
+
+### Physical devices on this machine
+
+| Device | Transport | In streams | Out streams | Safety in | Safety out | Latency in | Latency out | ZTS period |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Topping D10s | usb | 0 | 1 | 74 | 14 | 74 | 14 | 12000 |
+| Scarlett Solo | usb | 1 | 1 | 74 | 14 | 74 | 14 | 12000 |
+| ThinkPad Dock (engine 1) | usb | 1 | 0 | 74 | 50 | 74 | 50 | 12000 |
+| ThinkPad Dock (engine 2) | usb | 0 | 1 | 74 | 50 | 74 | 50 | 12000 |
+| MacBook Pro Speakers | bltn | 0 | 1 | 36 | 48 | 21 | 60 | 15840 |
+| MacBook Pro Microphone | bltn | 1 | 0 | 36 | 24 | 14 | 1 | 15840 |
+| LEN Y27q-20 | dprt | 0 | 1 | 0 | 320 | 0 | 88 | 12288 |
+| iPhone Microphone | ccwd | 1 | 0 | 100 | 0 | 6000 | 0 | 12480 |
+| Teams loopback | virt | 1 | 1 | 0 | 0 | 0 | 0 | 40960 |
+| rekordbox Aggregate | grup | 0 | 1 | 36 | 48 | 21 | 60 | 0 |
+
+Three facts fall out of this table.
+
+Every device publishes a safety offset in both scopes no matter what streams it has. Four of the devices listed are one-directional, and all four still answer the opposite scope. `kAudioDevicePropertySafetyOffset` is absent in global scope and read-only in input and output scope on every device.
+
+All three USB devices report exactly 74 frames of input safety, while their output safety differs (14, 14, 50, 50). The input number does not vary with the endpoint, so it is a constant of the USB audio driver, not a measurement of any hardware path. On USB the driver also sets `kAudioDevicePropertyLatency` equal to the safety offset in both directions. The built-in and DisplayPort devices keep the two properties distinct, which is why GlassEQ's earlier speaker measurement showed 21 and 60 frames of latency alongside 36 and 48 frames of safety.
+
+The `rekordbox Aggregate Device` is the accidental control experiment. Its composition names `BuiltInSpeakerDevice` as `master`, and it republishes the speakers' input safety (36), output safety (48), device latency (21 and 60), and even the speakers' 690-frame output stream latency. Its other subdevice is a USB controller, which would contribute 74 if anything about the USB device leaked in. Nothing does. The aggregate is a mirror of its main subdevice.
+
+### The aggregate mirror rule
+
+One subdevice, no taps, IO never started. Requested value on the left, aggregate readback on the right.
+
+| Composition | Aggregate safety in | Aggregate safety out |
+| --- | ---: | ---: |
+| `[Scarlett]` master=Scarlett | 74 | 14 |
+| `[Scarlett]` no `master` key | 74 | 14 |
+| `[Scarlett]` `channels-in: 0` | 74 | 14 |
+| `[Dock engine 2]` | 74 | 50 |
+| `[Speakers]` | 36 | 48 |
+| `[Built-in mic]` | 36 | 24 |
+| `[DisplayPort]` | 0 | 320 |
+| `[Teams loopback]` | 0 | 0 |
+| no subdevices at all | 0 | 0 |
+
+Six devices, six exact matches in both scopes. The aggregate also mirrors the main subdevice's `kAudioDevicePropertyLatency`. Note that the aggregate's own zero-timestamp period is 0, on both my probe aggregates and rekordbox's. An aggregate has no ring buffer and no timeline of its own, so it has nothing to declare and nothing to compute a margin from. It borrows both from the subdevice that owns its timebase.
+
+`channels-in: 0` is worth calling out. HAL accepts the key, then overrides it: the composition readback comes back as `channels-in=2`. That is the mechanism behind the Scarlett microphone channels appearing in the aggregate despite the request in `SystemTapAudioEngine.createCombinedAggregateDevice`. `IsStackedKey: 1` does suppress the phantom input channels (input channel count goes to 0), but the input safety offset stays at 74, so it buys nothing for latency.
+
+### Adding subdevices only makes it worse
+
+| Composition | master | Safety in | Safety out |
+| --- | --- | ---: | ---: |
+| `[Scarlett, Speakers]` | Scarlett | 74 | 94 |
+| `[Scarlett, Speakers]` | Speakers | 127 | 48 |
+| `[Speakers, Scarlett]` | Speakers | 127 | 48 |
+| `[Scarlett, DisplayPort]` | Scarlett | 74 | 394 |
+| `[Scarlett, DisplayPort]` | DisplayPort | 148 | 320 |
+
+The scope owned by the main subdevice keeps the main subdevice's value. The other scope goes up, sometimes a lot. Adding the DisplayPort monitor to a Scarlett-clocked aggregate takes output safety from 14 to 394 frames. Nothing here ever produced a number below the main subdevice's own value, and list order makes no difference (rows two and three are the same composition in the opposite order).
+
+The practical consequence: you cannot dilute the 74 by adding a device with a lower input safety offset. There is no configuration in which the Scarlett or the D10s is present and the aggregate's input safety drops below 74.
+
+### The clock device makes it worse too
+
+`kAudioAggregateDeviceClockDeviceKey` with one of this machine's two TimeSync clock devices, on an otherwise identical single-Scarlett aggregate:
+
+| Composition | Safety in | Safety out | Latency in | Latency out |
+| --- | ---: | ---: | ---: | ---: |
+| `[Scarlett]` master=Scarlett | 74 | 14 | 74 | 14 |
+| `[Scarlett]` master=Scarlett, clock=TimeSync | 148 | 28 | 0 | 0 |
+| `[Scarlett]` clock=TimeSync, no master | 148 | 28 | 0 | 0 |
+
+Both offsets double and the reported latency collapses to zero. This is what the header warns about. `kAudioAggregateDevicePropertyClockDevice` says "Setting this property will enable drift correction for all subdevices in the aggregate device" (`AudioHardware.h:1673`). Once the physical device is no longer the timebase, it is a drift-corrected member and pays double its own margin, plus a resampler on the output path.
+
+There is also a structural reason a clock device can never help. In AudioDriverKit, `IOUserAudioDevice` is a subclass of `IOUserAudioClockDevice` (`IOUserAudioDevice.iig:51`). The clock base class owns `SetZeroTimeStampPeriod`, `SetInputLatency`, `SetOutputLatency`, `SetClockDomain`, `SetClockAlgorithm` and `SetClockIsStable`. The safety offset setters, `SetInputSafetyOffset` and `SetOutputSafetyOffset`, exist only on the device subclass (`IOUserAudioDevice.iig:401,434`). A clock device has no safety offset to donate. Timebase and IO margin are separate concepts in Apple's own driver model, so separating the clock declaration from the main subdevice declaration cannot move the IO margin.
+
+### A device-scoped tap resolves to its backing device
+
+The newer `AudioHardwareAggregateDevice` API exposes `setClockSource(_:)` with an `AudioHardwareObject`, and Apple documents the corresponding `clockSource` as a device, clock, or tap. That is a real supported degree of freedom which the first investigation missed.
+
+`GlassEQDiagnostics --clock-source-probe` tested it on both the Scarlett and D10s. Each probe used one device-and-stream-scoped, non-mixdown tap and the physical USB output. The live cells briefly started silent IO and disabled the physical input stream for their IOProc.
+
+| Construction | Requested source | Published source | Safety in | Safety out |
+| --- | --- | --- | ---: | ---: |
+| Physical output plus tap | Physical device | Physical device | 74 | 14 |
+| Physical output plus tap | Tap, before IO | Physical device | 74 | 14 |
+| Physical output plus tap | Tap, during IO | Physical device | 74 | 14 |
+| Tap first, physical output added later | Tap | Physical device | 74 | 14 |
+| Tap UID stored as aggregate `master` | Tap | Physical device | 74 | 14 |
+| Tap only | Tap | None | 74 | 14 |
+
+The `master` composition is the most revealing case. HAL accepts and round-trips the tap UID, but `clockSource` still reports the physical device that backs the device-scoped tap, including while IO is running. A device-scoped tap therefore does not supply an independent timeline on either tested USB device. Its aggregate inherits the backing device's `74 / 14` margins even when the aggregate has no physical subdevice.
+
+There are two tap object identities during live IO. Passing the original `AudioHardwareTap` to `setClockSource(_:)` returns successfully but does not change `clockSource`. The aggregate also publishes a distinct object through `activeSubtaps`; passing that object is rejected with `kAudioHardwareBadObjectError` (`'!obj'`). The active-subtap list was nonempty during these attempts, so the negative result is not explained by a dormant tap.
+
+The explicit-clock control was unavailable. Calling `AudioHardwareDevice.clock` on both USB devices returned Core Audio's `clock not found` error, so neither exposes a separate `AudioHardwareClock` object to select. The system TimeSync objects remain the only explicit clock objects tested here, and those doubled the margins.
+
+### The latency keys are additive and clamp at zero
+
+`kAudioSubDeviceExtraInputLatencyKey` ("latency-in") on the Scarlett subdevice. This turned out to be the only key that moves the number at all, and it moves it the wrong way.
+
+| latency-in | Aggregate safety in |
+| ---: | ---: |
+| -1000 | 74 |
+| -148 | 74 |
+| -74 | 74 |
+| -74.0 (Float64) | 74 |
+| -14 | 74 |
+| -1 | 74 |
+| 0 | 74 |
+| +1 | 75 |
+| +14 | 88 |
+| +74 | 148 |
+| +1000 | 1074 |
+
+`latency-out` behaves the same way: -14 leaves output safety at 14, +1 gives 15, +100 gives 114.
+
+So the sub-device extra latency lands on the aggregate's **safety offset**, not on its reported latency, which explains why earlier experiments looked like the metadata was being ignored. It was not ignored. The negative side is clamped at zero, and the clamp is exact: -1 does nothing, +1 works. Passing the value as a Float64 rather than an integer changes nothing, so it is not a signedness accident in how CFNumber is read.
+
+The header wording matches. `kAudioSubDeviceExtraInputLatencyKey` says "the total number of frames of additional latency that will be **added** to the input side" (`AudioHardware.h:1783`). The runtime property `kAudioSubDevicePropertyExtraLatency` is documented more loosely as "a Float64 indicating the number of sample frames to add to or subtract from the latency compensation" (`AudioHardware.h:1826`), so I checked whether the runtime object accepts what the composition key refuses. It does not, because the object is not reachable: `kAudioAggregateDevicePropertyActiveSubDeviceList` returns objects whose `kAudioObjectPropertyClass` is `'adev'`, the real device, not `'asub'`. Setting `'xltc'` on it returns `kAudioHardwareUnknownPropertyError` (`'who?'`) in global, input and output scope. There is no AudioSubDevice instance for a client to talk to.
+
+Writing `kAudioDevicePropertySafetyOffset` on the aggregate returns `kAudioHardwareIllegalOperationError` (`'nope'`).
+
+### Everything else that does nothing
+
+Aggregate buffer frame size at 16, 512 and 4096 frames: safety offsets unchanged at 74 and 14 in all three cases. Confirms the earlier finding from the running app. The aggregate's buffer frame size range is 15 to 4096, which is where the 16-frame floor comes from.
+
+While chasing composition keys I found five undocumented ones in the HAL's string table, three of them next to `HALS_MetaDeviceDescription.cpp` and two next to `HALS_MetaSubTap.cpp`: `LDCM`, `isolated use case`, `dsp input settings override`, `don't pad` and `drift algorithm`. The last two show up in rekordbox's real aggregate composition, so third-party tools do carry them. HAL accepts all five and round-trips them in the composition readback. None of them changed the safety offsets at any value I tried. They are private, undocumented and unsupported, and I would not ship any of them.
+
+## Answers to the ten questions
+
+**1. What does an input-scoped safety offset mean on an output-only device?** It is a property of the device object, not of its stream topology. The driver sets it unconditionally for both directions. `IOUserAudioDevice::SetInputSafetyOffset` takes a plain `uint32_t` and is documented as "the number for frames behind the current hardware position that is safe to do IO" (`IOUserAudioDevice.iig:386`). Nothing in that contract asks the driver whether it has input streams. Apple's USB audio driver publishes 74 for every engine it creates, and my three USB devices confirm it, two of which are output-only.
+
+**2. Which layer supplies it?** The device driver. On this machine USB audio is served by `/System/Library/Audio/Plug-Ins/HAL/usbaudiodxpc.driver`, an AudioServerPlugIn matching `AppleUSBAudioControlNub` and talking to the `com.apple.usbaudiod` Mach service, with `com.apple.driver.AppleUSBAudio` (850.5) loaded in the kernel. The HAL republishes the value. The aggregate plug-in copies it from the timebase subdevice. Nothing in the chain is client-writable.
+
+**3. Why does the aggregate inherit it?** Because the aggregate has no timeline of its own. Its zero-timestamp period is 0, it has no ring buffer, and the host drives IO from `GetZeroTimeStamp()` on the device that owns the timebase (`AudioServerPlugIn.h:80`). Both of its safe-to-read and safe-to-write margins therefore come from that device. Verified against six devices with pairwise-distinct values, and against a third-party aggregate that mirrors the built-in speakers down to the 690-frame stream latency. The process taps do not lower this. They can only raise it, which is exactly what the global and mixdown taps did when they pushed both scopes to 1024 frames.
+
+**4. Is there a topology that keeps the physical output as clock and output but avoids its input safety offset?** No. Single-subdevice aggregates mirror. Multi-subdevice aggregates never go below the main subdevice's value in its own scope, and raise the other one. A clock device doubles both. The extra-latency keys clamp at zero. I could not construct a composition that reports less than 74 with the Scarlett in it.
+
+**5. Semantics of the individual properties.** `kAudioDevicePropertySafetyOffset` ('saft') is per-scope, driver-declared, read-only, and it is the value that governs the aggregate's IO cycle. `kAudioDevicePropertyLatency` ('ltnc') is separate and, as GlassEQ already measured, is not added to the tap-to-output timestamp interval. `kAudioDevicePropertyZeroTimeStampPeriod` ('ring') is declared in `AudioServerPlugIn.h`, not in the client umbrella header, with a documented minimum of 10923 frames; it sets how often the driver anchors sample time to host time and has nothing to do with IO margin. `kAudioDevicePropertyClockDomain` is decorative here: the value on this machine is `'main'` (1835100526) for the Scarlett, the monitor, the built-in devices and the rekordbox aggregate alike, and 0 for the D10s. `AudioHardwareAggregateDevice.setClockSource(_:)` accepts a device, clock, or tap, but a device-scoped tap resolves to its backing device in this topology. `kAudioAggregateDeviceClockDeviceKey` selects an explicit clock object and forces drift correction on everything. `kAudioAggregateDevicePropertyFullSubDeviceList` order controls stream order only; flipping it left the offsets identical. `kAudioAggregateDeviceTapAutoStartKey` gates when `AudioDeviceStart` returns and does not touch the offsets. Tap ordering determines input channel offsets, which GlassEQ already reads back from the composition. `CATapDescription` scoping is the one lever that genuinely matters, and GlassEQ is already on its fastest setting: a device and stream scoped tap with `isMixdown` false.
+
+**6. Can the aggregate use the physical output clock without naming the whole device as `master`?** It can name the device-scoped tap instead, but this changes only the composition string. `clockSource` still resolves to the physical device and the offsets stay at 74 and 14. A separate `AudioHardwareClock` was not available from either tested USB device. Handing the timebase to a TimeSync clock doubled the physical device's offsets.
+
+**7. Is mutability controlled by the device plug-in?** Yes. `AudioObjectIsPropertySettable` returns false for `kAudioDevicePropertySafetyOffset` on every device here, and setting it on an aggregate returns `'nope'`. The only code that can call `SetInputSafetyOffset` is the driver that owns the device.
+
+**8. Untested supported mechanisms?** The tap clock source was the missing supported mechanism. It is now tested and leaves the offsets unchanged. The two undocumented sub-device keys and three undocumented aggregate keys are inert for this purpose, and I would not ship them anyway. `latency-in` is real and supported, but it only adds.
+
+**9. Would separating clock declaration from main subdevice help?** No. A device-scoped tap still resolves to the backing physical device and reports 74 and 14. A TimeSync clock produces 148 and 28 because it makes the physical device a drift-corrected member.
+
+**10. If it cannot be removed, where is the limit?** In `AppleUSBAudio` and its `usbaudiodxpc` AudioServerPlugIn. The value is a driver-family constant of 74 frames applied to the input direction of every USB audio engine regardless of topology. GlassEQ pays it because the aggregate's timeline is that device's timeline. A route whose driver declares a smaller value already costs less, which is why the DisplayPort output measured an input age of 15.6 frames against its declared input safety of 0.
+
+## The tap-only experiment
+
+The device-scoped, non-mixdown tap in a tap-only private aggregate reported the same 74-frame input and 14-frame output safety offsets on both the Scarlett and D10s. It published no clock source, even during a short IO run, but retained the backing device's margins. This nails down the mechanism: the safety offsets travel with the device-scoped tap, not merely with the physical device's membership in the aggregate.
+
+Two smaller cells if you are in there anyway. Confirm that positive `kAudioSubTapExtraInputLatencyKey` raises the aggregate's input safety offset the way the sub-device key does; the earlier test only checked callback timing, and the sub-device key taught us that the value lands on the safety offset rather than the latency. And check whether 74 is a frame count or a fixed time by reading a USB device's input safety offset at 44.1 and 96 kHz. If it scales, it is roughly 1.54 ms of driver policy; if it stays 74, it is a raw frame constant. That one does require changing the device's nominal rate, so do it on a device nothing else is using.
+
+## Risks, if someone tries anyway
+
+The only remaining lever is a virtual device or custom driver, and it fails GlassEQ's constraints on its own terms. A driver's device would become the aggregate's main subdevice, which means it would supply the timeline, which means the physical output becomes a drift-corrected member at double its own safety offset plus a resampler, exactly as the clock device test showed. That is a second clock domain wearing a disguise, and it is slower than what GlassEQ has today. It also brings a system extension, user approval, an installer, and the whole class of failures GlassEQ avoids by owning nothing outside its own process. I would not present that as an app-level fix, because it is not one.
+
+The supported knobs carry their own risks worth recording. `stacked` changes what output streams mean and is untested with taps. The private composition keys are undocumented and could change or start being rejected in any macOS update. Positive `latency-in` is safe and supported, but it buys tap-read slack, not deadline slack, so it will not help with the lateness failures behind the adaptive buffer ladder. The observed `SafetyViolationOccurred` with `lateness: 14` was the client thread missing its deadline, and moving the tap read point earlier does not extend that deadline.
+
+## Recommendation
+
+Leave it. Here is the arithmetic I would weigh it against.
+
+The prize is 74 frames, 1.542 ms at 48 kHz, taking the USB routes from 120 frames to 46. Against that, the adaptive ladder's full 16-to-64-frame span changes the callback contribution by 96 frames. The buffer policy already accepts a larger latency range for reliability and tunes it per route. The observed timeline disturbances are larger still. The uncontaminated probe record advanced both timelines by 608 frames in one callback, which is 12.667 ms, roughly eight times the prize.
+
+There is also no path to collect it. Not "no path we have found yet", but no path that survives the constraint list: every supported mechanism either mirrors the driver's value, raises it, or clamps at zero, and the unsupported ones do nothing. The only thing that would work is a driver, which trades 1.542 ms for a second clock domain, a resampler on the output, and a system extension.
+
+I would close this line of investigation and record the model instead. GlassEQ's tap-to-output latency is
+
+    input safety offset + one callback + output safety offset + one callback
+
+where both safety offsets belong to the physical output device and are not negotiable. GlassEQ controls exactly one of those four terms, the callback size, and the adaptive policy already tunes it as far down as each route tolerates. That is the whole design space.
+
+## Appendix: reproducing the measurements
+
+The original aggregate-metadata probes are read-only apart from creating and destroying private aggregates. The clock-source probe additionally starts short silent IO cycles and disables physical input streams for combined-aggregate IOProcs. Sketch of the original aggregate matrix:
+
+```swift
+func probe(_ label: String, _ subDeviceExtras: [String: Any] = [:], clock: String? = nil) {
+    var description: [String: Any] = [
+        kAudioAggregateDeviceUIDKey: "com.glasseq.probe.\(UUID().uuidString)",
+        kAudioAggregateDeviceIsPrivateKey: 1,
+        kAudioAggregateDeviceNameKey: "GlassEQ Probe",
+        kAudioAggregateDeviceMainSubDeviceKey: outputUID,
+        kAudioAggregateDeviceSubDeviceListKey: [
+            [kAudioSubDeviceUIDKey: outputUID,
+             kAudioSubDeviceDriftCompensationKey: 0].merging(subDeviceExtras) { _, b in b }
+        ]
+    ]
+    if let clock { description[kAudioAggregateDeviceClockDeviceKey] = clock }
+
+    var deviceID = AudioObjectID(kAudioObjectUnknown)
+    guard AudioHardwareCreateAggregateDevice(description as CFDictionary, &deviceID) == noErr else { return }
+    defer { AudioHardwareDestroyAggregateDevice(deviceID) }
+
+    // Poll kAudioDevicePropertyDeviceIsAlive before reading, then read
+    // kAudioDevicePropertySafetyOffset and kAudioDevicePropertyLatency in
+    // kAudioObjectPropertyScopeInput and kAudioObjectPropertyScopeOutput.
+    // kAudioAggregateDevicePropertyComposition shows what HAL kept or overrode.
+}
+```
+
+`kAudioDevicePropertyZeroTimeStampPeriod` is declared in `AudioServerPlugIn.h`, which the CoreAudio umbrella header does not include, so Swift needs the raw selector `0x72696E67` to read it from a client.
+
+## Primary sources
+
+SDK headers, `MacOSX26.5.sdk` under Xcode 26.6:
+
+- `CoreAudio/AudioHardwareBase.h:705,746` safety offset semantics and the `'saft'` selector; `:666` clock domain; `:820-828` AudioClockDevice properties.
+- `CoreAudio/AudioHardware.h:1586-1602` `master` and `clock` composition keys; `:1655-1695` aggregate properties, including the drift-correction warning on `kAudioAggregateDevicePropertyClockDevice`; `:1783-1798` sub-device extra latency keys; `:1826-1842` sub-device runtime properties; `:1869-1928` sub-tap keys and properties; `:1635-1645` `tapautostart`.
+- `CoreAudio/AudioServerPlugIn.h:80-82` the host drives timing from `GetZeroTimeStamp()`; `:432-449` `kAudioDevicePropertyZeroTimeStampPeriod`, `kAudioDevicePropertyClockAlgorithm`, `kAudioDevicePropertyClockIsStable`.
+- `CoreAudio/CATapDescription.h` device and stream scoping, `mixdown`, and the macOS 26 additions `bundleIDs` and `processRestoreEnabled`.
+- `CoreAudio/AudioHardwareTapping.h` tap creation, macOS 14.2.
+- [`AudioHardwareAggregateDevice`](https://developer.apple.com/documentation/coreaudio/audiohardwareaggregatedevice), including `clockSource` and `setClockSource(_:)`, macOS 26.
+- [`AudioHardwareDevice.clock`](https://developer.apple.com/documentation/coreaudio/audiohardwaredevice/clock), which returned `clock not found` on the Scarlett and D10s.
+
+DriverKit SDK, `AudioDriverKit.framework`:
+
+- `IOUserAudioDevice.iig:51` `IOUserAudioDevice` is a subclass of `IOUserAudioClockDevice`; `:386-449` `SetInputSafetyOffset` and `SetOutputSafetyOffset`.
+- `IOUserAudioClockDevice.iig` `SetZeroTimeStampPeriod`, `SetInputLatency`, `SetOutputLatency`, `SetClockDomain`, `SetClockAlgorithm`, `SetClockIsStable`, and no safety offset.
+
+System:
+
+- `/System/Library/Audio/Plug-Ins/HAL/usbaudiodxpc.driver/Contents/Info.plist`, `AudioServerPlugIn_LoadingConditions` matching `AppleUSBAudioControlNub`, `AudioServerPlugIn_MachServices` naming `com.apple.usbaudiod`.
+- `kmutil showloaded`, `com.apple.driver.AppleUSBAudio` 850.5.
+
+The five undocumented composition keys came from the HAL string table in the dyld shared cache, adjacent to `HALS_MetaDeviceDescription.cpp` and `HALS_MetaSubTap.cpp`. That is inference from a closed binary, not documentation, and all five are inert here in any case.

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -4,15 +4,18 @@
 
 macOS owns output switching. GlassEQ observes the default output device and follows it. The app never asks the user to choose a physical output inside GlassEQ.
 
-The runtime flow is:
+The normal-rate runtime flow is:
 
 1. Discover current default output device and UID.
 2. Load the mapped profile for that output UID.
-3. Build a private Core Audio system tap that excludes GlassEQ itself.
-4. Mute tapped dry output while the tap is active.
-5. Process tap buffers through the active EQ configuration.
-6. Replay processed audio to the current default output device.
-7. Tear down and rebuild the graph when macOS changes the default output.
+3. Build a private Core Audio tap for the selected physical output stream. The tap excludes GlassEQ itself and mutes the tapped dry output.
+4. Build one private aggregate device containing the tap and physical output.
+5. Use the physical output as the aggregate clock source and enable Core Audio drift compensation for the tap.
+6. Disable every aggregate input stream except the tap stream for GlassEQ's I/O callback.
+7. Process tap buffers and write the result to the physical output in one aggregate-device callback.
+8. Rebuild the tap and aggregate when macOS changes the selected output device or stream.
+
+Bluetooth routes at 24 kHz or below initially use a separate-clock compatibility backend. The tap runs in a tap-only aggregate, the physical output has its own HAL callback, and a bounded ring buffer, occupancy servo, and realtime sample-rate converter bridge the two clocks. After the route settles and its physical clock advances at the advertised rate, GlassEQ attempts to replace the bridge with the normal combined aggregate. A failed promotion or later paired timestamp discontinuity returns the route to compatibility mode for the remainder of that output transition.
 
 ## Real-Time Rules
 
@@ -20,13 +23,23 @@ The audio render path must not allocate, lock, touch disk, log, parse text, muta
 
 ## Current Implementation Status
 
-This repository contains the SwiftPM project, DSP engine, importers, profile persistence, menu bar shell, Core Audio tap capture, a preallocated stereo ring buffer, and playback to the current default output device. The Core Audio bridge is intentionally isolated under `GlassEQAudio` so device-format support and hardware QA can be hardened without disturbing UI/profile code.
+This repository contains the SwiftPM project, DSP engine, importers, profile persistence, menu bar shell, the combined Core Audio tap/output fast path, and the transitional separate-clock Bluetooth headset backend. The Core Audio bridge is intentionally isolated under `GlassEQAudio` so device-format support and hardware QA can be hardened without disturbing UI/profile code.
 
-## Adaptive Playback Buffering
+## Clocking And Routing
 
-Normal-rate outputs start at the lowest callback-size step GlassEQ supports. Each device UID and sample-rate pair learns its hardware callback size plus a separate stable servo target for every callback size it has exercised. An underrun adds one 64-frame capture period to the current target, up to three capture periods beyond the callback; only another underrun at that ceiling increases the hardware callback. Excessive backlog is trimmed during reprime and does not modify the device calibration. An output timestamp discontinuity increases the hardware callback immediately because more queued audio cannot repair a missed device deadline. A callback increase starts from the target already learned for that quantum, or from one callback plus one capture period when the quantum is new, instead of carrying forward the previous quantum's reservoir. A candidate operating point must run for 60 seconds without another instability before it becomes stable. On a later engine session, a stable target may probe one 64-frame step lower; a failed lower target is remembered and is not retried until the device calibration is reset. Hardware callbacks never decrease automatically. The bounded local history records stabilization and meaningful instability transitions; repeated unresolved instability at the same operating point is deduplicated in memory without rereading or rewriting the calibration file. No calibration data leaves the Mac. Existing learned scalar targets migrate to the operating point for their callback size. Diagnostics can clear every learned sample-rate variant for the current device UID and immediately restart its calibration without affecting other outputs.
+On normal-rate routes, the selected physical output is the aggregate's main subdevice and therefore owns the render clock. The process tap captures the device stream containing the output's preferred stereo pair and is an aggregate subtap with high-quality Core Audio drift compensation enabled. The engine has one `AudioDeviceIOProcID`: each callback receives the tapped system mix, runs the biquad cascade, and writes directly to the physical output buffers. There is no application-level queue or asynchronous sample-rate converter on this path.
 
-Every route runs the occupancy servo and four-point Hermite resampler. Matching the tap and output's nominal sample rates does not guarantee that their hardware clocks advance identically, so the servo applies a small continuous rate correction instead of eventually dropping or duplicating frames. Output timestamp discontinuities and occupancy jumps beyond four callback periods re-prime directly to the route target while preserving the learned correction; step backlogs are never left for the ppm-scale servo to drain. Bidirectional Bluetooth headset modes retain their device-owned 24 or 16 kHz rate and add Audio Toolbox's realtime-safe PCM converter after the Hermite stage; returning to a normal-rate route disposes that converter and resets the clock pair. Low-sample-rate routes keep conservative fixed callback buffering instead of running the calibration ladder. EQ coefficients remain calculated at the tap's processing rate, while filters above the output route's usable-frequency ceiling receive identity coefficients so runtime behavior matches the editor warning.
+GlassEQ measures tap-to-output latency as the host-time difference between the first tapped input frame acquired for an I/O cycle and the first rendered output frame scheduled for hardware. Diagnostics report the observed average and range. This does not include latency before the system tap or after the output reaches the hardware.
+
+On duplex interfaces, Core Audio exposes the physical input channels before the process-tap channels in the aggregate input layout. GlassEQ requires the tap to occupy complete input streams, disables every physical input stream for its I/O callback, and verifies the applied stream-usage mask before starting. The callback still understands the aggregate channel offsets because disabled streams remain present as null buffers. GlassEQ fails startup if Core Audio cannot isolate the tap this way.
+
+The device-scoped tap deliberately follows one output stream rather than all system routes. Audio explicitly routed to another device, including a distinct system-alert output, is outside GlassEQ's processing path. The low-latency path currently requires the preferred pair to occupy one native mono or stereo hardware stream. A pair that spans streams cannot be captured by one device tap, while asking Core Audio to mix down a multichannel stream reintroduces the deep input latency this design avoids. Output switching also requires recreating the muted tap after macOS reports the new route; switch handoff behavior remains a hardware soak-test requirement.
+
+AirPods headset transitions exposed periodic, matching input and output timestamp discontinuities in the combined aggregate at 24 kHz. A timestamp probe showed that HAL could advertise 24 kHz while advancing `mSampleTime` on the old 48 kHz scale, then reset the timeline after several seconds. A combined aggregate created after the headset route had settled ran cleanly, but larger aggregate buffers, drift-compensation changes, and tap mixdown did not make the transition safe. For Bluetooth routes at 24 kHz or below, GlassEQ first uses a tap-only aggregate and drives the physical output separately. A preallocated ring buffer carries processed samples between callbacks, an occupancy servo corrects clock drift, and the realtime converter handles the tap and device sample-rate difference. After six seconds, GlassEQ measures the physical device's sample-time slope for 500 ms. If it agrees with the nominal rate, GlassEQ tries the combined path and rejects it if a paired timestamp discontinuity appears during a 750 ms validation window. One later qualifying paired jump also returns the route to the bridge, with no second promotion attempt until the output changes. Returning to a normal-rate route disposes either headset backend and restores the combined fast path.
+
+See [Aggregate clock experiment: findings](AggregateClockExperiment.md) for the measurements and experiments behind this design.
+
+GlassEQ requests a 16-frame callback only from the private combined aggregate and leaves the physical output's shared buffer-frame property unchanged. While the separate-clock headset backend is active, Core Audio owns the physical output's low-rate callback size while tap capture uses its own aggregate quantum. EQ coefficients use the active processing rate; filters above the output route's usable-frequency ceiling receive identity coefficients so runtime behavior matches the editor warning.
 
 ## Diagnostics
 
@@ -41,6 +54,12 @@ The command prints output device metadata and post-run callback metrics:
 - Captured frames from the private Core Audio tap.
 - Played frames written to the default output device.
 - Playback underrun frames.
+- Input frames dropped because a callback exposed more input than output capacity.
+- Peak capture and output callback sizes.
+- Average and range of tap-to-output latency from Core Audio's I/O timestamps.
+- Samples that reached the soft clipper.
+
+The separate-clock fallback reports its additional bridge diagnostics instead: buffered frames, occupancy-derived bridge latency, clock correction, output timing gaps, sample-rate conversion, and reservoir target. Its bridge-latency number is not the same measurement as the combined path's timestamp-derived tap-to-output latency.
 
 The diagnostic follows the current macOS output device and does not switch outputs itself.
 
@@ -55,3 +74,7 @@ swift run GlassEQDiagnostics 2
 ## Profile Storage And Settings Helper
 
 Profile data belongs to the main app sandbox and is migrated by the main app through `container-migration.plist`. The settings helper does not share profile storage and does not need an app-group entitlement; it receives snapshots and sends commands over the private stdin/stdout IPC session launched by GlassEQ.
+
+## Backlog
+
+- Support preferred stereo pairs inside native output streams wider than two channels without enabling Core Audio tap mixdown. The first version should still process only the preferred pair, preserve the device-scoped native stream format, map the tapped channels and aggregate buffers explicitly, keep physical inputs disabled, and verify that the wider stream does not restore the 43.5 ms mixdown latency.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ GlassEQ is an early alpha: Apple Silicon only, tested on macOS 26, with no autom
 
 ## How it works
 
-1. GlassEQ opens a **private, muted global process tap** that excludes itself, pulling the dry system mix out of the output without creating a feedback loop.
-2. Tapped audio runs through the active EQ profile in real time.
-3. The processed audio is replayed to the current default output device with a tiny occupancy-driven asynchronous rate correction to absorb clock drift. Bidirectional Bluetooth headset modes are converted to their lower device-owned sample rate with realtime-safe anti-alias filtering.
-4. When you change outputs, the tap stays alive and only the output stage is rebuilt, so dry audio never leaks to the new device during the handoff.
+1. GlassEQ opens a **private, muted process tap** for the current physical output stream. The tap excludes GlassEQ itself, pulling the dry system mix out of that route without creating a feedback loop.
+2. On normal-rate routes, GlassEQ places that tap and the physical output in one private aggregate device. One Core Audio callback applies EQ and writes directly to the output on the same clock.
+3. Low-rate Bluetooth headset modes begin on a separate-clock compatibility path with a bounded ring buffer, drift servo, and realtime sample-rate conversion. Once the route's clock settles, GlassEQ tests the normal low-latency aggregate and returns to compatibility mode if its timing becomes unstable.
+4. GlassEQ switches backend automatically when the output device, stream, or headset sample rate changes.
 
-The result is low, predictable latency. The built-in diagnostics report it directly (about **2,9 ms added latency** on a 48 kHz / 128-frame route, with no underruns or clipped samples):
+The normal fast path has low, predictable latency without a separate playback queue. The built-in diagnostics report tap-to-output latency from Core Audio's I/O timestamps alongside frame delivery, callback sizes, underruns, dropped input, and saturation. Headset mode reports its bridge occupancy, clock correction, sample-rate conversion, and output timing separately.
+
+The current low-latency path requires the output's preferred pair to occupy one native mono or stereo hardware stream. Audio routed to a different device or a distinct system-alert output is outside that tap.
 
 ![GlassEQ settings — Output tab, showing current output, profile mapping, engine status, and live diagnostics](Docs/Screenshots/output.png)
 
@@ -60,7 +62,7 @@ The result is low, predictable latency. The built-in diagnostics report it direc
 - **Profile import** from AutoEQ / EqualizerAPO and REW text, allowing you to paste a headphone-correction curve straight in.
 - **Per-output profile mapping** by Core Audio device UID, with a fallback profile for unmapped devices.
 - **Soft-clip saturation** that tames overshoot instead of hard-clipping.
-- **Built-in diagnostics** for frame loss, underruns, adaptive buffer occupancy, clock correction, and latency.
+- **Built-in diagnostics** for frame delivery, underruns, dropped input, callback sizes, saturation, latency, clock correction, and fallback buffering.
 
 ![GlassEQ settings — Editor tab, with the frequency-response graph and parametric filters](Docs/Screenshots/editor.png)
 
@@ -78,7 +80,7 @@ During normal listening GlassEQ is just a menu bar app and the audio engine, con
 
 - **AirPlay outputs are not yet supported.** The DSP engine currently fails to start on AirPlay receivers and GlassEQ stops processing that route; macOS keeps routing normal system audio to the AirPlay device. Switching to any other output (built-in, USB, Bluetooth, HDMI) restores processing cleanly.
 - **Stereo processing.** GlassEQ processes a stereo stream. On multi-channel interfaces it plays to the device's preferred stereo pair (configurable in Audio MIDI Setup → Configure Speakers) and writes silence to the remaining channels — the same routing macOS uses for system audio. There is no surround/per-channel EQ, and preferred-pair changes apply on the next output switch.
-- **Bluetooth** routes can still surface Core Audio edge cases, please report device model, macOS version, and steps to reproduce.
+- **Bluetooth** headset modes initially use a higher-latency separate-clock compatibility path to avoid periodic combined-aggregate timestamp faults while the route settles. Promotion to the low-latency path is experimental; please report the device model, macOS version, and steps if a route still produces jitter.
 - No automatic updates, no crash reporting, no x86_64 build.
 
 <a id="supported-target"></a>
@@ -139,7 +141,7 @@ The entitlements output should include `com.apple.security.app-sandbox` and `com
 
 ## Architecture
 
-macOS owns output switching, GlassEQ follows it. A persistent muted tap forms the capture half of the engine and survives output changes, while the output half is rebuilt per device. The render path stays free of allocation, locks, disk, logging, and SwiftUI state. The Core Audio bridge is isolated under `GlassEQAudio` so device-format and hardware work can be hardened without disturbing the UI and profile code.
+macOS owns output switching, GlassEQ follows it. Normal-rate routes use a muted device-scoped tap and physical output in one aggregate callback and clock. Bluetooth routes at 24 kHz or below start on a separate capture/playback clock bridge, then attempt the combined path after the device clock settles; a timing failure returns them to the bridge for that output transition. GlassEQ disables unused physical input streams and never records the microphone. The render path stays free of allocation, locks, disk, logging, and SwiftUI state. The Core Audio bridge is isolated under `GlassEQAudio` so device-format and hardware work can be hardened without disturbing the UI and profile code.
 
 See [Docs/Architecture.md](Docs/Architecture.md) for the full ownership model and runtime flow.
 

--- a/Sources/GlassEQApp/AggregateBufferNotifier.swift
+++ b/Sources/GlassEQApp/AggregateBufferNotifier.swift
@@ -1,0 +1,128 @@
+import Foundation
+@preconcurrency import UserNotifications
+
+private extension Notification.Name {
+    static let glassEQOpenOutputSettings = Notification.Name(
+        "com.glasseq.openOutputSettings"
+    )
+}
+
+@MainActor
+protocol AggregateBufferChangeNotifying: AnyObject {
+    func notifyBufferIncrease(
+        outputName: String,
+        previousFrameSize: UInt32,
+        newFrameSize: UInt32
+    )
+}
+
+@MainActor
+final class AggregateBufferNotifier: NSObject,
+    AggregateBufferChangeNotifying,
+    UNUserNotificationCenterDelegate {
+    static let shared = AggregateBufferNotifier()
+
+    private nonisolated static let categoryIdentifier = "GLASSEQ_BUFFER_RELIABILITY"
+    private nonisolated static let openActionIdentifier = "GLASSEQ_OPEN_OUTPUT_SETTINGS"
+
+    func start() {
+        guard Self.canUseUserNotifications() else {
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.setNotificationCategories([Self.notificationCategory()])
+        Task {
+            let settings = await center.notificationSettings()
+            if settings.authorizationStatus == .notDetermined {
+                _ = try? await center.requestAuthorization(options: [.alert])
+            }
+        }
+    }
+
+    static func canUseUserNotifications(bundleURL: URL = Bundle.main.bundleURL) -> Bool {
+        bundleURL.pathExtension == "app"
+    }
+
+    static func notificationCategory() -> UNNotificationCategory {
+        let openAction = UNNotificationAction(
+            identifier: Self.openActionIdentifier,
+            title: localized("Open Output Settings"),
+            options: []
+        )
+        return UNNotificationCategory(
+            identifier: Self.categoryIdentifier,
+            actions: [openAction],
+            intentIdentifiers: []
+        )
+    }
+
+    func notifyBufferIncrease(
+        outputName: String,
+        previousFrameSize: UInt32,
+        newFrameSize: UInt32
+    ) {
+        guard Self.canUseUserNotifications() else {
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        Task {
+            let settings = await center.notificationSettings()
+            guard settings.authorizationStatus == .authorized
+                    || settings.authorizationStatus == .provisional else {
+                return
+            }
+            let content = UNMutableNotificationContent()
+            content.title = localized("GlassEQ increased the audio buffer")
+            content.body = localized(
+                "GlassEQ detected a timing interruption while \(outputName) was using \(previousFrameSize)-frame buffers. It switched this route to \(newFrameSize) frames for more reliable playback."
+            )
+            content.categoryIdentifier = Self.categoryIdentifier
+            try? await center.add(
+                UNNotificationRequest(
+                    identifier: "glasseq-buffer-reliability-\(UUID().uuidString)",
+                    content: content,
+                    trigger: nil
+                )
+            )
+        }
+    }
+
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        willPresent _: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .list]
+    }
+
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        guard response.actionIdentifier == UNNotificationDefaultActionIdentifier
+                || response.actionIdentifier == Self.openActionIdentifier else {
+            return
+        }
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: .glassEQOpenOutputSettings,
+                object: nil
+            )
+        }
+    }
+}
+
+@MainActor
+final class NoopAggregateBufferNotifier: AggregateBufferChangeNotifying {
+    func notifyBufferIncrease(
+        outputName _: String,
+        previousFrameSize _: UInt32,
+        newFrameSize _: UInt32
+    ) {}
+}
+
+extension Notification.Name {
+    static var glassEQOpenOutputSettingsRequest: Notification.Name {
+        .glassEQOpenOutputSettings
+    }
+}

--- a/Sources/GlassEQApp/AggregateBufferPolicy.swift
+++ b/Sources/GlassEQApp/AggregateBufferPolicy.swift
@@ -1,0 +1,327 @@
+import Foundation
+import GlassEQAudio
+import GlassEQSettingsIPC
+
+struct AggregateBufferSelection: Equatable, Sendable {
+    var mode: SettingsAggregateBufferMode
+    var frameSize: UInt32
+    var automaticFrameSize: UInt32
+}
+
+@MainActor
+final class AggregateBufferPolicyStore {
+    private struct Record: Codable, Equatable {
+        var route: AggregateAudioRouteFingerprint
+        var mode: SettingsAggregateBufferMode
+        var automaticFrameSize: UInt32
+        var failureWindowStartedAt: Date?
+        var failureCount: Int
+        var cleanSessionCount: Int
+
+        init(
+            route: AggregateAudioRouteFingerprint,
+            mode: SettingsAggregateBufferMode,
+            automaticFrameSize: UInt32,
+            failureWindowStartedAt: Date? = nil,
+            failureCount: Int = 0,
+            cleanSessionCount: Int = 0
+        ) {
+            self.route = route
+            self.mode = mode
+            self.automaticFrameSize = automaticFrameSize
+            self.failureWindowStartedAt = failureWindowStartedAt
+            self.failureCount = failureCount
+            self.cleanSessionCount = cleanSessionCount
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case route
+            case mode
+            case automaticFrameSize
+            case failureWindowStartedAt
+            case failureCount
+            case cleanSessionCount
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            route = try container.decode(
+                AggregateAudioRouteFingerprint.self,
+                forKey: .route
+            )
+            mode = try container.decode(SettingsAggregateBufferMode.self, forKey: .mode)
+            automaticFrameSize = try container.decode(UInt32.self, forKey: .automaticFrameSize)
+            failureWindowStartedAt = try container.decodeIfPresent(
+                Date.self,
+                forKey: .failureWindowStartedAt
+            )
+            failureCount = try container.decodeIfPresent(Int.self, forKey: .failureCount) ?? 0
+            cleanSessionCount = try container.decodeIfPresent(
+                Int.self,
+                forKey: .cleanSessionCount
+            ) ?? 0
+        }
+    }
+
+    private struct Document: Codable {
+        static let schemaVersion = 2
+
+        var schemaVersion: Int
+        var records: [Record]
+    }
+
+    private let url: URL
+    private var records: [Record]
+
+    static let failureWindow: TimeInterval = 5 * 60
+    static let cleanSessionsBeforeRetry = 3
+
+    init(url: URL) {
+        self.url = url
+        self.records = Self.load(from: url)
+    }
+
+    static func defaultURL() -> URL {
+        let baseURL = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.temporaryDirectory
+        return baseURL
+            .appendingPathComponent("GlassEQ", isDirectory: true)
+            .appendingPathComponent("aggregate-buffer-policy.json")
+    }
+
+    func selection(for route: AggregateAudioRouteFingerprint) -> AggregateBufferSelection {
+        let record = record(for: route)
+        let mode = record?.mode ?? .automatic
+        let automaticFrameSize = Self.validatedAutomaticFrameSize(
+            record?.automaticFrameSize ?? 16
+        )
+        let frameSize: UInt32 = switch mode {
+        case .automatic:
+            automaticFrameSize
+        case .frames16:
+            16
+        case .frames32:
+            32
+        case .frames64:
+            64
+        }
+        return AggregateBufferSelection(
+            mode: mode,
+            frameSize: frameSize,
+            automaticFrameSize: automaticFrameSize
+        )
+    }
+
+    func setMode(
+        _ mode: SettingsAggregateBufferMode,
+        for route: AggregateAudioRouteFingerprint
+    ) throws {
+        try update(route: route) { record in
+            guard record.mode != mode else {
+                return
+            }
+            record.mode = mode
+            record.failureWindowStartedAt = nil
+            record.failureCount = 0
+            record.cleanSessionCount = 0
+        }
+    }
+
+    @discardableResult
+    func recordAutomaticFailure(
+        for route: AggregateAudioRouteFingerprint,
+        occurrences: UInt64 = 1,
+        at now: Date = Date()
+    ) throws -> UInt32? {
+        guard occurrences > 0,
+              selection(for: route).mode == .automatic else {
+            return nil
+        }
+        var resultingFrameSize: UInt32?
+        try update(route: route) { record in
+            let windowAge = record.failureWindowStartedAt.map {
+                now.timeIntervalSince($0)
+            }
+            if let windowAge,
+               windowAge >= 0,
+               windowAge <= Self.failureWindow {
+                record.failureCount += Int(clamping: occurrences)
+            } else {
+                record.failureWindowStartedAt = now
+                record.failureCount = Int(clamping: occurrences)
+            }
+            record.cleanSessionCount = 0
+
+            guard record.failureCount >= 2 else {
+                return
+            }
+            record.failureWindowStartedAt = nil
+            record.failureCount = 0
+            guard let nextFrameSize = Self.nextAutomaticFrameSize(
+                after: record.automaticFrameSize
+            ) else {
+                return
+            }
+            record.automaticFrameSize = nextFrameSize
+            resultingFrameSize = nextFrameSize
+        }
+        return resultingFrameSize
+    }
+
+    @discardableResult
+    func recordCleanAutomaticSession(
+        for route: AggregateAudioRouteFingerprint
+    ) throws -> UInt32? {
+        let selection = selection(for: route)
+        guard selection.mode == .automatic,
+              selection.automaticFrameSize > 16 else {
+            return nil
+        }
+        var resultingFrameSize: UInt32?
+        try update(route: route) { record in
+            record.failureWindowStartedAt = nil
+            record.failureCount = 0
+            record.cleanSessionCount += 1
+            guard record.cleanSessionCount >= Self.cleanSessionsBeforeRetry,
+                  let previousFrameSize = Self.previousAutomaticFrameSize(
+                      before: record.automaticFrameSize
+                  ) else {
+                return
+            }
+            record.automaticFrameSize = previousFrameSize
+            record.cleanSessionCount = 0
+            resultingFrameSize = previousFrameSize
+        }
+        return resultingFrameSize
+    }
+
+    func retryAutomaticBuffer(for route: AggregateAudioRouteFingerprint) throws {
+        try update(route: route) { record in
+            record.mode = .automatic
+            record.automaticFrameSize = 16
+            record.failureWindowStartedAt = nil
+            record.failureCount = 0
+            record.cleanSessionCount = 0
+        }
+    }
+
+    private func record(for route: AggregateAudioRouteFingerprint) -> Record? {
+        records.first { $0.route == route }
+    }
+
+    private func update(
+        route: AggregateAudioRouteFingerprint,
+        _ update: (inout Record) -> Void
+    ) throws {
+        guard route.isValid else {
+            return
+        }
+        let index: Int
+        let inserted: Bool
+        if let existingIndex = records.firstIndex(where: { $0.route == route }) {
+            index = existingIndex
+            inserted = false
+        } else {
+            records.append(Record(
+                route: route,
+                mode: .automatic,
+                automaticFrameSize: 16
+            ))
+            index = records.index(before: records.endIndex)
+            inserted = true
+        }
+
+        let previous = records[index]
+        update(&records[index])
+        guard records[index] != previous else {
+            return
+        }
+        do {
+            try write()
+        } catch {
+            if inserted {
+                records.remove(at: index)
+            } else {
+                records[index] = previous
+            }
+            throw error
+        }
+    }
+
+    private func write() throws {
+        let document = Document(
+            schemaVersion: Document.schemaVersion,
+            records: records.sorted {
+                if $0.route.outputDeviceUID != $1.route.outputDeviceUID {
+                    return $0.route.outputDeviceUID < $1.route.outputDeviceUID
+                }
+                if $0.route.nativeOutputStreamIndex != $1.route.nativeOutputStreamIndex {
+                    return $0.route.nativeOutputStreamIndex < $1.route.nativeOutputStreamIndex
+                }
+                return $0.route.nominalSampleRate < $1.route.nominalSampleRate
+            }
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(document)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func load(from url: URL) -> [Record] {
+        guard let data = try? Data(contentsOf: url),
+              let document = try? JSONDecoder().decode(Document.self, from: data),
+              [1, Document.schemaVersion].contains(document.schemaVersion) else {
+            return []
+        }
+        return document.records.compactMap { record in
+            guard record.route.isValid,
+                  [16, 32, 64].contains(record.automaticFrameSize) else {
+                return nil
+            }
+            var record = record
+            if document.schemaVersion == 1 {
+                // Schema 1 raised a route after one event, so its learned rung cannot satisfy
+                // the new two-event policy. Preserve explicit fixed modes but relearn Automatic.
+                record.automaticFrameSize = 16
+            }
+            record.failureCount = min(max(record.failureCount, 0), 1)
+            record.cleanSessionCount = min(
+                max(record.cleanSessionCount, 0),
+                Self.cleanSessionsBeforeRetry - 1
+            )
+            return record
+        }
+    }
+
+    private static func validatedAutomaticFrameSize(_ frameSize: UInt32) -> UInt32 {
+        [16, 32, 64].contains(frameSize) ? frameSize : 16
+    }
+
+    private static func nextAutomaticFrameSize(after frameSize: UInt32) -> UInt32? {
+        switch frameSize {
+        case ..<32:
+            32
+        case 32..<64:
+            64
+        default:
+            nil
+        }
+    }
+
+    private static func previousAutomaticFrameSize(before frameSize: UInt32) -> UInt32? {
+        switch frameSize {
+        case 64...:
+            32
+        case 32..<64:
+            16
+        default:
+            nil
+        }
+    }
+}

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -4,7 +4,6 @@ import GlassEQCore
 import GlassEQSettingsIPC
 import GlassEQSettingsUI
 import SwiftUI
-import UserNotifications
 
 private enum GlassEQWindowID {
     static let inProcessSettings = "in-process-settings"
@@ -130,8 +129,8 @@ private enum AppBuildInfo {
            !releaseLabel.isEmpty {
             return releaseLabel
         }
-        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.9.0"
-        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "12"
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.9.1"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "13"
         return "v\(version) (\(build))"
     }
 }
@@ -231,11 +230,6 @@ private func localizedFrameCount(_ value: UInt32) -> String {
     return value == 1 ? localized("\(number) frame") : localized("\(number) frames")
 }
 
-private func localizedLatency(milliseconds: Double) -> String {
-    let number = localizedDecimal(milliseconds, minimumFractionDigits: 2, maximumFractionDigits: 2)
-    return localized("\(number) ms")
-}
-
 private var noOutputName: String {
     localized("No output")
 }
@@ -250,8 +244,16 @@ enum GlassEQAppLifecycleState: Equatable {
 
 protocol AudioEngineControlling: AnyObject, Sendable {
     var state: AudioEngineState { get }
+    var isUsingTransitionalHeadsetBackend: Bool { get }
+    var isUsingPromotedHeadsetAggregate: Bool { get }
 
     func start(output: AudioOutputDevice, profile: EQProfile) throws
+    func attemptHeadsetAggregatePromotion() throws -> HeadsetAggregatePromotionResult
+    func rejectHeadsetAggregatePromotion()
+    func aggregateRouteFingerprint(
+        for output: AudioOutputDevice
+    ) throws -> AggregateAudioRouteFingerprint?
+    func setPreferredAggregateBufferFrameSize(_ frameSize: UInt32)
     func update(profile: EQProfile) throws
     @discardableResult func updateDSP(profile: EQProfile) -> Bool
     func setBypassed(_ isBypassed: Bool)
@@ -259,18 +261,13 @@ protocol AudioEngineControlling: AnyObject, Sendable {
     func stop()
     func snapshotMetrics() -> AudioEngineMetrics
     func resetDiagnostics()
-    func resetPlaybackBufferCalibration(forOutputUID outputUID: String) throws
-    func setPlaybackBufferRenegotiationHandler(
-        _ handler: (@Sendable (PlaybackBufferRenegotiation) -> Void)?
-    )
     func setRuntimeFailureHandler(_ handler: (@Sendable (AudioEngineFailure) -> Void)?)
 }
 
 extension AudioEngineControlling {
-    func setPlaybackBufferRenegotiationHandler(
-        _ handler: (@Sendable (PlaybackBufferRenegotiation) -> Void)?
+    func setRuntimeFailureHandler(
+        _: (@Sendable (AudioEngineFailure) -> Void)?
     ) {}
-    func setRuntimeFailureHandler(_ handler: (@Sendable (AudioEngineFailure) -> Void)?) {}
 }
 
 extension SystemTapAudioEngine: AudioEngineControlling {}
@@ -323,88 +320,6 @@ protocol WorkspaceOpening {
 
 extension NSWorkspace: WorkspaceOpening {}
 
-@MainActor
-protocol PlaybackBufferRenegotiationNotifying {
-    func prepare()
-    func notify(_ renegotiation: PlaybackBufferRenegotiation)
-}
-
-extension PlaybackBufferRenegotiationNotifying {
-    func prepare() {}
-}
-
-private final class GlassEQUserNotificationDelegate: NSObject, UNUserNotificationCenterDelegate, @unchecked Sendable {
-    static let shared = GlassEQUserNotificationDelegate()
-
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification
-    ) async -> UNNotificationPresentationOptions {
-        [.banner, .sound]
-    }
-}
-
-@MainActor
-struct SystemPlaybackBufferRenegotiationNotifier: PlaybackBufferRenegotiationNotifying {
-    func prepare() {
-        guard Bundle.main.bundleURL.pathExtension == "app" else {
-            return
-        }
-        let center = UNUserNotificationCenter.current()
-        center.delegate = GlassEQUserNotificationDelegate.shared
-        Task {
-            let settings = await center.notificationSettings()
-            if settings.authorizationStatus == .notDetermined {
-                _ = try? await center.requestAuthorization(options: [.alert, .sound])
-            }
-        }
-    }
-
-    func notify(_ renegotiation: PlaybackBufferRenegotiation) {
-        guard Bundle.main.bundleURL.pathExtension == "app" else {
-            return
-        }
-        let reason = switch renegotiation.reason {
-        case .underrun:
-            localized("an audio underrun")
-        case .outputTimestampDiscontinuity:
-            localized("an output timing discontinuity")
-        case .excessiveBacklog:
-            localized("an excessive playback backlog")
-        case .adaptiveRenderFailure:
-            localized("an adaptive playback render failure")
-        }
-        let targetLatency = renegotiation.sampleRate > 0
-            ? localizedLatency(milliseconds: Double(renegotiation.playbackTargetFrames) / renegotiation.sampleRate * 1_000)
-            : localizedFrameCount(renegotiation.playbackTargetFrames)
-        let title = localized("GlassEQ increased the audio buffer")
-        let body = localized(
-            "\(renegotiation.outputName): \(renegotiation.previousFrameSize) to \(renegotiation.frameSize) callback frames after \(reason). Target latency is now \(targetLatency)."
-        )
-
-        Task {
-            let center = UNUserNotificationCenter.current()
-            center.delegate = GlassEQUserNotificationDelegate.shared
-            let settings = await center.notificationSettings()
-            guard settings.authorizationStatus == .authorized
-                    || settings.authorizationStatus == .provisional else {
-                return
-            }
-
-            let content = UNMutableNotificationContent()
-            content.title = title
-            content.body = body
-            content.sound = .default
-            let request = UNNotificationRequest(
-                identifier: "playback-buffer-\(renegotiation.outputUID)-\(renegotiation.frameSize)-\(UUID().uuidString)",
-                content: content,
-                trigger: nil
-            )
-            try? await center.add(request)
-        }
-    }
-}
-
 extension SettingsAudioMetricsDTO {
     init(_ metrics: AudioEngineMetrics) {
         self.init(
@@ -421,6 +336,8 @@ extension SettingsAudioMetricsDTO {
             minimumPlaybackBufferedFrames: metrics.minimumPlaybackBufferedFrames,
             averagePlaybackBufferedFrames: metrics.averagePlaybackBufferedFrames,
             playbackBufferObservations: metrics.playbackBufferObservations,
+            inputTimestampDiscontinuities: metrics.inputTimestampDiscontinuities,
+            outputTimestampDiscontinuities: metrics.outputTimestampDiscontinuities,
             maximumCaptureCallbackFrames: metrics.maximumCaptureCallbackFrames,
             maximumPlaybackCallbackFrames: metrics.maximumPlaybackCallbackFrames,
             playbackTimestampDiscontinuities: metrics.playbackTimestampDiscontinuities,
@@ -431,7 +348,11 @@ extension SettingsAudioMetricsDTO {
             playbackOccupancyTargetFrames: metrics.playbackOccupancyTargetFrames,
             filteredPlaybackOccupancyFrames: metrics.filteredPlaybackOccupancyFrames,
             playbackBufferSampleRate: metrics.playbackBufferSampleRate,
-            playbackSampleRateConversionActive: metrics.playbackSampleRateConversionActive
+            playbackSampleRateConversionActive: metrics.playbackSampleRateConversionActive,
+            tapToOutputLatencyObservations: metrics.tapToOutputLatencyObservations,
+            minimumTapToOutputLatencyNanoseconds: metrics.minimumTapToOutputLatencyNanoseconds,
+            maximumTapToOutputLatencyNanoseconds: metrics.maximumTapToOutputLatencyNanoseconds,
+            averageTapToOutputLatencyNanoseconds: metrics.averageTapToOutputLatencyNanoseconds
         )
     }
 }
@@ -509,13 +430,14 @@ final class GlassEQAppModel {
     private let defaultOutputLookup: any DefaultOutputLookingUp
     private let observerFactory: any DefaultOutputObservingMaking
     private let workspaceOpener: any WorkspaceOpening
-    private let playbackBufferRenegotiationNotifier: any PlaybackBufferRenegotiationNotifying
     private let profileImportOperation: @Sendable (ImportFormat, String, String) async -> Result<EQProfile, any Error>
     private let outputChangeSettlingDelayOverride: Duration?
     private let wakeReconnectDelayOverride: Duration?
     private let saveDebounceDelay: Duration
     private var observer: (any DefaultOutputObserving)?
     private var metricsTask: Task<Void, Never>?
+    private var aggregateStabilityTask: Task<Void, Never>?
+    private var headsetAggregatePromotionTask: Task<Void, Never>?
     private var outputChangeTask: Task<Void, Never>?
     private var engineStartTask: Task<Void, Never>?
     private var activeSettingsCommandCount = 0
@@ -529,7 +451,14 @@ final class GlassEQAppModel {
     private var outputChangeGeneration = 0
     private var engineStartGeneration = 0
     private var pendingEngineStartOutput: AudioOutputDevice?
-    private var playbackBufferCalibrationResetCount = 0
+    private var activeAggregateRoute: AggregateAudioRouteFingerprint?
+    private let aggregateBufferPolicyStore: AggregateBufferPolicyStore
+    private let aggregateStabilitySettlingDelay: Duration
+    private let aggregateCleanSessionDuration: Duration
+    private let headsetAggregatePromotionDelay: Duration
+    private var headsetPromotionAttemptedOutputGeneration: Int?
+    private let aggregateBufferNotifier: any AggregateBufferChangeNotifying
+    private var pendingAggregateBufferIncrease: PendingAggregateBufferIncrease?
     private let storeWriter: ProfileStoreWriter
     private var profilePersistenceMode: ProfilePersistenceMode = .normal
     @ObservationIgnored private let engineWorkExecutor = EngineWorkExecutor()
@@ -558,6 +487,13 @@ final class GlassEQAppModel {
         var selectedProfileID: UUID
         var draftProfile: EQProfile
         var previewReturnProfile: EQProfile?
+    }
+
+    private struct PendingAggregateBufferIncrease: Sendable {
+        var route: AggregateAudioRouteFingerprint
+        var outputName: String
+        var previousFrameSize: UInt32
+        var newFrameSize: UInt32
     }
 
     private struct EngineProfileConfirmation: Sendable {
@@ -705,19 +641,24 @@ final class GlassEQAppModel {
     }
 
     private enum EngineWork: Sendable {
-        case start(output: AudioOutputDevice, profile: EQProfile, rollback: ProfileRollback?)
+        case start(
+            output: AudioOutputDevice,
+            profile: EQProfile,
+            rollback: ProfileRollback?,
+            aggregateBufferFrameSize: UInt32
+        )
         case restart(profile: EQProfile, rollback: ProfileRollback?)
 
         var profile: EQProfile {
             switch self {
-            case .start(_, let profile, _), .restart(let profile, _):
+            case .start(_, let profile, _, _), .restart(let profile, _):
                 return profile
             }
         }
 
         var rollback: ProfileRollback? {
             switch self {
-            case .start(_, _, let rollback), .restart(_, let rollback):
+            case .start(_, _, let rollback, _), .restart(_, let rollback):
                 return rollback
             }
         }
@@ -730,9 +671,9 @@ final class GlassEQAppModel {
         case cancelled
     }
 
-    private enum PlaybackBufferCalibrationResetResult: Sendable {
-        case success(AudioEngineState)
-        case failure(any Error, AudioEngineState)
+    private enum HeadsetPromotionWorkResult: Sendable {
+        case success(HeadsetAggregatePromotionResult)
+        case failure(String)
     }
 
     private struct EngineWorkFailure: Error, LocalizedError, Sendable {
@@ -753,11 +694,15 @@ final class GlassEQAppModel {
         installLifecycleObservers shouldInstallLifecycleObservers: Bool = true,
         registerAppDelegate: Bool = true,
         workspaceOpener: any WorkspaceOpening = NSWorkspace.shared,
-        playbackBufferRenegotiationNotifier: any PlaybackBufferRenegotiationNotifying = SystemPlaybackBufferRenegotiationNotifier(),
         profileImportOperation: (@Sendable (ImportFormat, String, String) async -> Result<EQProfile, any Error>)? = nil,
         saveDebounceDelay: Duration = .milliseconds(250),
         outputChangeSettlingDelayOverride: Duration? = nil,
-        wakeReconnectDelayOverride: Duration? = nil
+        wakeReconnectDelayOverride: Duration? = nil,
+        aggregateBufferPolicyURL: URL? = nil,
+        aggregateStabilitySettlingDelay: Duration = .seconds(2),
+        aggregateCleanSessionDuration: Duration = .seconds(5 * 60),
+        headsetAggregatePromotionDelay: Duration = .seconds(6),
+        aggregateBufferNotifier: (any AggregateBufferChangeNotifying)? = nil
     ) {
         let loadResult: ProfileStoreLoadResult?
         let loadedStore: ProfileStore
@@ -784,7 +729,6 @@ final class GlassEQAppModel {
         self.defaultOutputLookup = defaultOutputLookup
         self.observerFactory = observerFactory
         self.workspaceOpener = workspaceOpener
-        self.playbackBufferRenegotiationNotifier = playbackBufferRenegotiationNotifier
         self.profileImportOperation = profileImportOperation ?? { format, name, text in
             await Task.detached(priority: .userInitiated) {
                 Result<EQProfile, Error> {
@@ -801,6 +745,16 @@ final class GlassEQAppModel {
         self.outputChangeSettlingDelayOverride = outputChangeSettlingDelayOverride
         self.wakeReconnectDelayOverride = wakeReconnectDelayOverride
         self.storeWriter = ProfileStoreWriter(url: storeURL)
+        self.aggregateBufferPolicyStore = AggregateBufferPolicyStore(
+            url: aggregateBufferPolicyURL ?? AggregateBufferPolicyStore.defaultURL()
+        )
+        self.aggregateStabilitySettlingDelay = aggregateStabilitySettlingDelay
+        self.aggregateCleanSessionDuration = aggregateCleanSessionDuration
+        self.headsetAggregatePromotionDelay = headsetAggregatePromotionDelay
+        self.aggregateBufferNotifier = aggregateBufferNotifier
+            ?? (registerAppDelegate
+                ? AggregateBufferNotifier.shared
+                : NoopAggregateBufferNotifier())
         self.profilePersistenceMode = persistenceMode
         engine.setRuntimeFailureHandler { [weak self] failure in
             Task { @MainActor in
@@ -809,6 +763,18 @@ final class GlassEQAppModel {
         }
         if registerAppDelegate {
             GlassEQAppDelegate.model = self
+            AggregateBufferNotifier.shared.start()
+            lifecycleObserverTokens.append(
+                NotificationCenter.default.addObserver(
+                    forName: .glassEQOpenOutputSettingsRequest,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    Task { @MainActor in
+                        self?.openAggregateBufferSettings()
+                    }
+                }
+            )
         }
         if shouldInstallLifecycleObservers {
             installLifecycleObservers()
@@ -830,12 +796,6 @@ final class GlassEQAppModel {
                 self?.start()
             }
         }
-        engine.setPlaybackBufferRenegotiationHandler { [weak self] renegotiation in
-            Task { @MainActor [weak self] in
-                self?.processPlaybackBufferRenegotiation(renegotiation)
-            }
-        }
-        playbackBufferRenegotiationNotifier.prepare()
     }
 
     var hasUnsavedDraft: Bool {
@@ -870,6 +830,7 @@ final class GlassEQAppModel {
             currentOutputChannelCount: currentOutputChannelCount,
             currentOutputBufferFrameSize: currentOutputBufferFrameSize,
             currentOutputMappedProfileID: currentOutputMappedProfileID,
+            aggregateBuffer: aggregateBufferSnapshot(),
             fallbackProfileID: profileStore.fallbackProfileID,
             statusMessage: statusMessage,
             metrics: SettingsAudioMetricsDTO(engineMetrics),
@@ -877,6 +838,28 @@ final class GlassEQAppModel {
             isPreviewing: previewReturnProfile != nil,
             profileStoreProtection: profileStoreProtectionSnapshot()
         )
+    }
+
+    private func aggregateBufferSnapshot() -> SettingsAggregateBufferDTO {
+        guard let activeAggregateRoute else {
+            return SettingsAggregateBufferDTO()
+        }
+        let selection = aggregateBufferPolicyStore.selection(for: activeAggregateRoute)
+        return SettingsAggregateBufferDTO(
+            mode: selection.mode,
+            automaticFrameSize: selection.automaticFrameSize,
+            isAvailable: lifecycleState == .running
+                && isRunning
+                && engineStartTask == nil
+                && engineIsRunning
+        )
+    }
+
+    private var engineIsRunning: Bool {
+        if case .running = engine.state {
+            return true
+        }
+        return false
     }
 
     private func profileStoreProtectionSnapshot() -> SettingsProfileStoreProtectionDTO {
@@ -1260,82 +1243,6 @@ final class GlassEQAppModel {
         notifyModelDidChange()
     }
 
-    func resetPlaybackBufferCalibrationForCurrentOutput() async throws {
-        guard lifecycleState == .running else {
-            throw SettingsCommandFailure(
-                message: localized("Buffer calibration can only be reset while audio processing is running.")
-            )
-        }
-        guard !currentOutputUID.isEmpty else {
-            throw SettingsCommandFailure(message: localized("No output is available to recalibrate."))
-        }
-        let generation = engineStartGeneration
-        let outputUID = currentOutputUID
-        let outputName = currentOutputName
-        playbackBufferCalibrationResetCount += 1
-        defer {
-            playbackBufferCalibrationResetCount -= 1
-        }
-        statusMessage = localized("Recalibrating the audio buffer for \(outputName)...")
-        notifyModelDidChange()
-
-        let engine = engine
-        let resetTask = engineWorkExecutor.enqueue(priority: .userInitiated) {
-            do {
-                try engine.resetPlaybackBufferCalibration(forOutputUID: outputUID)
-                return PlaybackBufferCalibrationResetResult.success(engine.state)
-            } catch {
-                return PlaybackBufferCalibrationResetResult.failure(error, engine.state)
-            }
-        }
-
-        let result = await resetTask.value
-        guard generation == engineStartGeneration else {
-            if case .failure(let error, _) = result {
-                throw error
-            }
-            return
-        }
-
-        switch result {
-        case .success(let state):
-            switch state {
-            case .running(let output):
-                refreshCurrentOutputMetadata(from: output)
-                lifecycleState = .running
-                isRunning = true
-                statusMessage = processingStatus(outputName: output.name, profileName: activeProfile.name)
-            case .stopped:
-                lifecycleState = .stopped
-                isRunning = false
-                statusMessage = localized("Buffer calibration reset for \(outputName)")
-            case .failed(let message):
-                lifecycleState = .stopped
-                isRunning = false
-                statusMessage = message
-            }
-        case .failure(let error, let state):
-            switch state {
-            case .running(let output):
-                refreshCurrentOutputMetadata(from: output)
-                lifecycleState = .running
-                isRunning = true
-                statusMessage = localized("Buffer calibration reset failed: \(error.localizedDescription)")
-            case .stopped:
-                lifecycleState = .stopped
-                isRunning = false
-                statusMessage = localized("Buffer calibration reset failed: \(error.localizedDescription)")
-            case .failed(let message):
-                lifecycleState = .stopped
-                isRunning = false
-                statusMessage = message
-            }
-            notifyModelDidChange()
-            throw error
-        }
-        notifyModelDidChange()
-    }
-
     @discardableResult
     private func addProfile(_ profile: EQProfile, name: String, status: String? = nil) throws -> EQProfile {
         try ensureProfileStoreWritable()
@@ -1571,7 +1478,7 @@ final class GlassEQAppModel {
             if activeProfile.isBypassed {
                 disableActiveProfileProcessing(updateMetrics: false)
             } else {
-                scheduleEngineWork(.start(output: output, profile: activeProfile, rollback: rollback))
+                scheduleEngineStart(output: output, profile: activeProfile, rollback: rollback)
             }
         case .failure(let error):
             if lifecycleState == .waking {
@@ -1595,9 +1502,13 @@ final class GlassEQAppModel {
 
         engineStartGeneration += 1
         let generation = engineStartGeneration
+        aggregateStabilityTask?.cancel()
+        aggregateStabilityTask = nil
+        headsetAggregatePromotionTask?.cancel()
+        headsetAggregatePromotionTask = nil
         engineStartTask?.cancel()
         switch work {
-        case .start(let output, _, _):
+        case .start(let output, _, _, _):
             pendingEngineStartOutput = output
         case .restart:
             pendingEngineStartOutput = nil
@@ -1637,6 +1548,24 @@ final class GlassEQAppModel {
             }
             self?.completeEngineWork(result, generation: generation)
         }
+    }
+
+    private func scheduleEngineStart(
+        output: AudioOutputDevice,
+        profile: EQProfile,
+        rollback: ProfileRollback?,
+        aggregateBufferFrameSize requestedFrameSize: UInt32? = nil
+    ) {
+        let route = try? engine.aggregateRouteFingerprint(for: output)
+        let frameSize = requestedFrameSize
+            ?? route.map { aggregateBufferPolicyStore.selection(for: $0).frameSize }
+            ?? 16
+        scheduleEngineWork(.start(
+            output: output,
+            profile: profile,
+            rollback: rollback,
+            aggregateBufferFrameSize: frameSize
+        ))
     }
 
     private func synchronizeActiveProfileProcessing(rollback: ProfileRollback? = nil) {
@@ -1745,13 +1674,19 @@ final class GlassEQAppModel {
         do {
             let output: AudioOutputDevice
             switch work {
-            case .start(let requestedOutput, let profile, let rollback):
+            case .start(
+                let requestedOutput,
+                let profile,
+                let rollback,
+                let aggregateBufferFrameSize
+            ):
                 guard !Task.isCancelled else {
                     confirmedState.recordCancelledAttempt(failedAttempt)
                     return .cancelled
                 }
                 attemptedOutput = requestedOutput
                 do {
+                    engine.setPreferredAggregateBufferFrameSize(aggregateBufferFrameSize)
                     try engine.start(output: requestedOutput, profile: profile)
                 } catch {
                     if case .running(let activeOutput) = engine.state {
@@ -1862,13 +1797,28 @@ final class GlassEQAppModel {
         switch result {
         case .success(let output):
             refreshCurrentOutputMetadata(from: output)
+            activeAggregateRoute = try? engine.aggregateRouteFingerprint(for: output)
             lifecycleState = .running
             isRunning = true
             wakeReconnectAttempts = 0
             wasRunningBeforeSleep = false
-            statusMessage = processingStatus(outputName: output.name, profileName: activeProfile.name)
+            if engine.isUsingTransitionalHeadsetBackend,
+               headsetPromotionAttemptedOutputGeneration == outputChangeGeneration {
+                statusMessage = localized(
+                    "Processing \(output.name) with \(activeProfile.name) in compatibility mode"
+                )
+            } else {
+                statusMessage = processingStatus(
+                    outputName: output.name,
+                    profileName: activeProfile.name
+                )
+            }
+            completePendingAggregateBufferIncreaseIfNeeded(output: output)
+            startAggregateStabilityMonitoring()
+            startHeadsetAggregatePromotionIfNeeded()
         case .profileChangeNotApplied(_, let output, let reconciliation):
             refreshCurrentOutputMetadata(from: output)
+            activeAggregateRoute = try? engine.aggregateRouteFingerprint(for: output)
             if let reconciliation {
                 restoreEngineProfileReconciliation(reconciliation, persist: true)
                 confirmedEngineProfileState.acknowledge(reconciliation)
@@ -1880,6 +1830,9 @@ final class GlassEQAppModel {
             isRunning = true
             wakeReconnectAttempts = 0
             wasRunningBeforeSleep = false
+            pendingAggregateBufferIncrease = nil
+            startAggregateStabilityMonitoring()
+            startHeadsetAggregatePromotionIfNeeded()
         case .failure(let error, let attemptedOutput):
             if let attemptedOutput {
                 refreshCurrentOutputMetadata(from: attemptedOutput)
@@ -1890,11 +1843,298 @@ final class GlassEQAppModel {
             }
             lifecycleState = .stopped
             isRunning = false
+            activeAggregateRoute = nil
+            pendingAggregateBufferIncrease = nil
             statusMessage = audioEngineStatusMessage(error)
         case .cancelled:
             return
         }
         notifyModelDidChange()
+    }
+
+    private func startAggregateStabilityMonitoring() {
+        aggregateStabilityTask?.cancel()
+        aggregateStabilityTask = nil
+        guard let route = activeAggregateRoute else {
+            return
+        }
+        let selection = aggregateBufferPolicyStore.selection(for: route)
+        guard selection.mode == .automatic else {
+            return
+        }
+        let engineGeneration = engineStartGeneration
+        let outputGeneration = outputChangeGeneration
+        let settlingDelay = aggregateStabilitySettlingDelay
+        let cleanSessionDuration = aggregateCleanSessionDuration
+        aggregateStabilityTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: settlingDelay)
+            guard let self,
+                  !Task.isCancelled,
+                  self.aggregateRouteIsSettled(
+                      route,
+                      engineGeneration: engineGeneration,
+                      outputGeneration: outputGeneration
+                  ) else {
+                return
+            }
+            var qualifyingBaseline = self.engine.snapshotMetrics()
+                .qualifyingPairedTimestampDiscontinuities
+            var sessionHadQualifyingInterruption = false
+            var cleanSessionRecorded = false
+            let cleanSessionDeadline = ContinuousClock.now.advanced(
+                by: cleanSessionDuration
+            )
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(250))
+                guard !Task.isCancelled,
+                      self.aggregateRouteIsSettled(
+                          route,
+                          engineGeneration: engineGeneration,
+                          outputGeneration: outputGeneration
+                      ) else {
+                    return
+                }
+                let nextCount = self.engine.snapshotMetrics()
+                    .qualifyingPairedTimestampDiscontinuities
+                if nextCount > qualifyingBaseline {
+                    let occurrenceCount = nextCount - qualifyingBaseline
+                    qualifyingBaseline = nextCount
+                    sessionHadQualifyingInterruption = true
+                    if self.handleQualifyingAggregateInterruption(
+                        on: route,
+                        occurrences: occurrenceCount
+                    ) {
+                        return
+                    }
+                } else if nextCount < qualifyingBaseline {
+                    qualifyingBaseline = nextCount
+                }
+
+                if !cleanSessionRecorded,
+                   !sessionHadQualifyingInterruption,
+                   ContinuousClock.now >= cleanSessionDeadline {
+                    cleanSessionRecorded = true
+                    if self.handleCleanAggregateSession(on: route) {
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    private func startHeadsetAggregatePromotionIfNeeded() {
+        headsetAggregatePromotionTask?.cancel()
+        headsetAggregatePromotionTask = nil
+        guard engine.isUsingTransitionalHeadsetBackend,
+              headsetPromotionAttemptedOutputGeneration != outputChangeGeneration else {
+            return
+        }
+        headsetPromotionAttemptedOutputGeneration = outputChangeGeneration
+        let engineGeneration = engineStartGeneration
+        let outputGeneration = outputChangeGeneration
+        let delay = headsetAggregatePromotionDelay
+        statusMessage = localized(
+            "Processing \(currentOutputName) in compatibility mode while its clock settles..."
+        )
+        headsetAggregatePromotionTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self,
+                  !Task.isCancelled,
+                  self.lifecycleState == .running,
+                  self.isRunning,
+                  self.engineStartGeneration == engineGeneration,
+                  self.outputChangeGeneration == outputGeneration,
+                  self.engine.isUsingTransitionalHeadsetBackend else {
+                return
+            }
+            self.statusMessage = localized("Testing the low-latency headset path...")
+            self.notifyModelDidChange()
+            let engine = self.engine
+            let work = self.engineWorkExecutor.enqueue(priority: .userInitiated) {
+                do {
+                    return HeadsetPromotionWorkResult.success(
+                        try engine.attemptHeadsetAggregatePromotion()
+                    )
+                } catch {
+                    return HeadsetPromotionWorkResult.failure(error.localizedDescription)
+                }
+            }
+            let result = await work.value
+            guard !Task.isCancelled,
+                  self.lifecycleState == .running,
+                  self.engineStartGeneration == engineGeneration,
+                  self.outputChangeGeneration == outputGeneration else {
+                return
+            }
+            self.headsetAggregatePromotionTask = nil
+            self.completeHeadsetAggregatePromotion(result)
+        }
+    }
+
+    private func completeHeadsetAggregatePromotion(
+        _ workResult: HeadsetPromotionWorkResult
+    ) {
+        switch workResult {
+        case .success(.promoted(let output)):
+            refreshCurrentOutputMetadata(from: output)
+            activeAggregateRoute = try? engine.aggregateRouteFingerprint(for: output)
+            engineMetrics = engine.snapshotMetrics()
+            statusMessage = localized(
+                "Processing \(output.name) with \(activeProfile.name) on the low-latency headset path"
+            )
+            startAggregateStabilityMonitoring()
+        case .success(.clockUnstable):
+            statusMessage = localized(
+                "The headset clock is still settling; compatibility mode remains active."
+            )
+        case .success(.aggregateUnstable):
+            activeAggregateRoute = nil
+            statusMessage = localized(
+                "The headset aggregate was still unstable; compatibility mode remains active."
+            )
+        case .success(.notApplicable):
+            statusMessage = processingStatus(
+                outputName: currentOutputName,
+                profileName: activeProfile.name
+            )
+        case .failure(let message):
+            activeAggregateRoute = nil
+            if case .running = engine.state {
+                statusMessage = localized(
+                    "Could not test the low-latency headset path; compatibility mode remains active: \(message)"
+                )
+            } else {
+                lifecycleState = .stopped
+                isRunning = false
+                statusMessage = localized("Audio engine failed: \(message)")
+            }
+        }
+        notifyModelDidChange()
+    }
+
+    private func aggregateRouteIsSettled(
+        _ route: AggregateAudioRouteFingerprint,
+        engineGeneration: Int,
+        outputGeneration: Int
+    ) -> Bool {
+        lifecycleState == .running
+            && isRunning
+            && engineStartTask == nil
+            && engineStartGeneration == engineGeneration
+            && outputChangeGeneration == outputGeneration
+            && activeAggregateRoute == route
+            && currentOutputUID == route.outputDeviceUID
+            && Int64(currentOutputSampleRate.rounded()) == route.nominalSampleRate
+    }
+
+    private func handleQualifyingAggregateInterruption(
+        on route: AggregateAudioRouteFingerprint,
+        occurrences: UInt64
+    ) -> Bool {
+        guard activeAggregateRoute == route,
+              lifecycleState == .running,
+              engineStartTask == nil,
+              case .running(let output) = engine.state else {
+            return false
+        }
+        if engine.isUsingPromotedHeadsetAggregate {
+            engine.rejectHeadsetAggregatePromotion()
+            pendingAggregateBufferIncrease = nil
+            statusMessage = localized(
+                "Headset timing became unstable; returning to compatibility mode..."
+            )
+            notifyModelDidChange()
+            scheduleEngineStart(
+                output: output,
+                profile: activeProfile,
+                rollback: nil
+            )
+            return true
+        }
+        let previousFrameSize = aggregateBufferPolicyStore.selection(for: route).frameSize
+        do {
+            guard let nextFrameSize = try aggregateBufferPolicyStore
+                .recordAutomaticFailure(
+                    for: route,
+                    occurrences: occurrences
+                ) else {
+                return false
+            }
+            pendingAggregateBufferIncrease = PendingAggregateBufferIncrease(
+                route: route,
+                outputName: output.name,
+                previousFrameSize: previousFrameSize,
+                newFrameSize: nextFrameSize
+            )
+            statusMessage = localized(
+                "Timing interruption detected; switching \(output.name) to \(nextFrameSize)-frame buffers..."
+            )
+            notifyModelDidChange()
+            scheduleEngineStart(
+                output: output,
+                profile: activeProfile,
+                rollback: nil,
+                aggregateBufferFrameSize: nextFrameSize
+            )
+            return true
+        } catch {
+            statusMessage = localized(
+                "Could not save the safer audio buffer setting: \(error.localizedDescription)"
+            )
+            notifyModelDidChange()
+            return false
+        }
+    }
+
+    private func handleCleanAggregateSession(
+        on route: AggregateAudioRouteFingerprint
+    ) -> Bool {
+        guard activeAggregateRoute == route,
+              lifecycleState == .running,
+              engineStartTask == nil,
+              case .running(let output) = engine.state else {
+            return false
+        }
+        do {
+            guard let nextFrameSize = try aggregateBufferPolicyStore
+                .recordCleanAutomaticSession(for: route) else {
+                return false
+            }
+            pendingAggregateBufferIncrease = nil
+            statusMessage = localized(
+                "Revalidating \(output.name) with \(nextFrameSize)-frame buffers..."
+            )
+            notifyModelDidChange()
+            scheduleEngineStart(
+                output: output,
+                profile: activeProfile,
+                rollback: nil,
+                aggregateBufferFrameSize: nextFrameSize
+            )
+            return true
+        } catch {
+            statusMessage = localized(
+                "Could not save the lower audio buffer setting: \(error.localizedDescription)"
+            )
+            notifyModelDidChange()
+            return false
+        }
+    }
+
+    private func completePendingAggregateBufferIncreaseIfNeeded(
+        output: AudioOutputDevice
+    ) {
+        guard let pendingAggregateBufferIncrease,
+              activeAggregateRoute == pendingAggregateBufferIncrease.route,
+              output.bufferFrameSize == pendingAggregateBufferIncrease.newFrameSize else {
+            return
+        }
+        self.pendingAggregateBufferIncrease = nil
+        aggregateBufferNotifier.notifyBufferIncrease(
+            outputName: pendingAggregateBufferIncrease.outputName,
+            previousFrameSize: pendingAggregateBufferIncrease.previousFrameSize,
+            newFrameSize: pendingAggregateBufferIncrease.newFrameSize
+        )
     }
 
     private func restoreProfileRollback(_ rollback: ProfileRollback, persist: Bool) {
@@ -1988,14 +2228,14 @@ final class GlassEQAppModel {
             return
         }
         if let output = pendingEngineStartOutput {
-            scheduleEngineWork(.start(output: output, profile: activeProfile, rollback: rollback))
+            scheduleEngineStart(output: output, profile: activeProfile, rollback: rollback)
         } else {
             scheduleEngineWork(.restart(profile: activeProfile, rollback: rollback))
         }
     }
 
     private var hasPendingProfileReplacingEngineWork: Bool {
-        engineStartTask != nil || playbackBufferCalibrationResetCount > 0
+        engineStartTask != nil
     }
 
     private func scheduleWakeReconnectRetry(status: String) {
@@ -2159,6 +2399,55 @@ final class GlassEQAppModel {
         restartEngineWithActiveProfile()
     }
 
+    func setAggregateBufferMode(_ mode: SettingsAggregateBufferMode) throws {
+        guard let activeAggregateRoute,
+              lifecycleState == .running,
+              isRunning,
+              engineStartTask == nil,
+              case .running(let output) = engine.state else {
+            throw SettingsCommandFailure(
+                message: localized("Automatic buffer tuning is unavailable on this output route.")
+            )
+        }
+        try aggregateBufferPolicyStore.setMode(mode, for: activeAggregateRoute)
+        let selection = aggregateBufferPolicyStore.selection(for: activeAggregateRoute)
+        pendingAggregateBufferIncrease = nil
+        statusMessage = localized(
+            "Rebuilding \(output.name) with \(selection.frameSize)-frame buffers..."
+        )
+        notifyModelDidChange()
+        scheduleEngineStart(
+            output: output,
+            profile: activeProfile,
+            rollback: nil,
+            aggregateBufferFrameSize: selection.frameSize
+        )
+    }
+
+    func retryAutomaticAggregateBuffer() throws {
+        guard let activeAggregateRoute,
+              lifecycleState == .running,
+              isRunning,
+              engineStartTask == nil,
+              case .running(let output) = engine.state else {
+            throw SettingsCommandFailure(
+                message: localized("Automatic buffer tuning is unavailable on this output route.")
+            )
+        }
+        try aggregateBufferPolicyStore.retryAutomaticBuffer(for: activeAggregateRoute)
+        pendingAggregateBufferIncrease = nil
+        statusMessage = localized(
+            "Retrying 16-frame buffers on \(output.name)..."
+        )
+        notifyModelDidChange()
+        scheduleEngineStart(
+            output: output,
+            profile: activeProfile,
+            rollback: nil,
+            aggregateBufferFrameSize: 16
+        )
+    }
+
     func openPrivacySettings() throws {
         let urls = [
             URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"),
@@ -2213,14 +2502,6 @@ final class GlassEQAppModel {
         }
     }
 
-    func processPlaybackBufferRenegotiation(_ renegotiation: PlaybackBufferRenegotiation) {
-        if renegotiation.outputUID == currentOutputUID {
-            currentOutputBufferFrameSize = renegotiation.frameSize
-        }
-        playbackBufferRenegotiationNotifier.notify(renegotiation)
-        notifyModelDidChange()
-    }
-
     func stopMetricsPolling() {
         metricsTask?.cancel()
         metricsTask = nil
@@ -2255,9 +2536,15 @@ final class GlassEQAppModel {
 
     private func invalidatePendingEngineStart() {
         engineStartGeneration += 1
+        aggregateStabilityTask?.cancel()
+        aggregateStabilityTask = nil
+        headsetAggregatePromotionTask?.cancel()
+        headsetAggregatePromotionTask = nil
         engineStartTask?.cancel()
         engineStartTask = nil
         pendingEngineStartOutput = nil
+        activeAggregateRoute = nil
+        pendingAggregateBufferIncrease = nil
     }
 
     private func installLifecycleObservers() {
@@ -2407,7 +2694,6 @@ final class GlassEQAppModel {
             return false
         }
         lifecycleState = .terminating
-        engine.setPlaybackBufferRenegotiationHandler(nil)
         acceptsSettingsCommands = false
         wasRunningBeforeSleep = false
         invalidatePendingOutputChange()
@@ -2431,8 +2717,7 @@ final class GlassEQAppModel {
         if let availabilityError = error as? AudioDeviceAvailabilityError {
             switch availabilityError {
             case .unsupportedOutputChannelCount,
-                 .unsupportedOutputBufferFrameSize,
-                 .unsupportedPlaybackConversionBuffer:
+                 .unsupportedOutputBufferFrameSize:
                 return localized("Output format unsupported: \(availabilityError.description)")
             default:
                 return localized("Default output unavailable: \(availabilityError.description)")

--- a/Sources/GlassEQApp/Info.plist
+++ b/Sources/GlassEQApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-    <string>0.9.0</string>
+    <string>0.9.1</string>
 	<key>CFBundleVersion</key>
-    <string>12</string>
+    <string>13</string>
 	<key>GlassEQReleaseLabel</key>
-    <string>alpha-0.9</string>
+    <string>alpha-0.9.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -96,6 +96,7 @@ final class SettingsCoordinator: NSObject {
     private var settingsConnected = false
     private var readyAcknowledgmentPending = false
     private var pendingFocusRequest = false
+    private var pendingSectionRequest: SettingsSection?
     private var suppressedModelChangeDepth = 0
     private var lastSentSnapshot: SettingsSnapshot?
 
@@ -113,12 +114,17 @@ final class SettingsCoordinator: NSObject {
     }
 
     @discardableResult
-    func openSettings() -> SettingsOpenDisposition {
+    func openSettings(section: SettingsSection? = nil) -> SettingsOpenDisposition {
         if let helperProcess, helperProcess.isRunning {
             if settingsConnected {
-                send(.focusRequested)
+                if let section {
+                    send(.sectionRequested(section))
+                } else {
+                    send(.focusRequested)
+                }
             } else {
                 pendingFocusRequest = true
+                pendingSectionRequest = section
             }
             focusSettings()
             return .helper
@@ -127,6 +133,7 @@ final class SettingsCoordinator: NSObject {
         do {
             let token = try prepareSession()
             pendingFocusRequest = true
+            pendingSectionRequest = section
             try launchHelper(token: token)
             return .helper
         } catch {
@@ -135,6 +142,10 @@ final class SettingsCoordinator: NSObject {
             cleanupSession(terminateHelper: true)
             return .inProcessFallback(reason: reason)
         }
+    }
+
+    var hasRunningSettingsHelper: Bool {
+        helperProcess?.isRunning == true
     }
 
     func shutdown() {
@@ -177,6 +188,7 @@ final class SettingsCoordinator: NSObject {
         settingsConnected = false
         readyAcknowledgmentPending = false
         pendingFocusRequest = false
+        pendingSectionRequest = nil
         suppressedModelChangeDepth = 0
         lastSentSnapshot = nil
         return token
@@ -414,7 +426,12 @@ final class SettingsCoordinator: NSObject {
             }
             if pendingFocusRequest {
                 pendingFocusRequest = false
-                send(.focusRequested)
+                if let pendingSectionRequest {
+                    self.pendingSectionRequest = nil
+                    send(.sectionRequested(pendingSectionRequest))
+                } else {
+                    send(.focusRequested)
+                }
             }
         }
     }
@@ -516,6 +533,10 @@ final class SettingsCoordinator: NSObject {
             } else {
                 patch.currentOutputMappedProfileID = .clear
             }
+            didPatch = true
+        }
+        if previous.aggregateBuffer != snapshot.aggregateBuffer {
+            patch.aggregateBuffer = snapshot.aggregateBuffer
             didPatch = true
         }
         if previous.profileStoreProtection != snapshot.profileStoreProtection {
@@ -629,6 +650,7 @@ final class SettingsCoordinator: NSObject {
         pipeWriter = nil
         launchToken = nil
         pendingFocusRequest = false
+        pendingSectionRequest = nil
         suppressedModelChangeDepth = 0
         lastSentSnapshot = nil
         runningApplication = nil
@@ -914,15 +936,30 @@ struct SecuritySettingsCodeSigningValidator: SettingsCodeSigningValidating {
 }
 
 extension GlassEQAppModel {
+    func openAggregateBufferSettings() {
+        if settingsCoordinator.hasRunningSettingsHelper {
+            openSettings(section: .output)
+            return
+        }
+        SettingsWindowFocus.request(section: .output)
+        requestInProcessSettingsPresentation()
+    }
+
     @discardableResult
-    func openSettings() -> SettingsOpenDisposition {
+    func openSettings(section: SettingsSection? = nil) -> SettingsOpenDisposition {
         guard !inProcessSettingsIsPresented,
               !inProcessSettingsPresentationIsPending else {
+            if let section {
+                SettingsWindowFocus.request(section: section)
+            }
             requestInProcessSettingsPresentation()
             return .activeInProcessFallback
         }
-        let disposition = settingsCoordinator.openSettings()
+        let disposition = settingsCoordinator.openSettings(section: section)
         if case .inProcessFallback(let reason) = disposition {
+            if let section {
+                SettingsWindowFocus.request(section: section)
+            }
             requestInProcessSettingsPresentation(
                 statusMessage: localized("Settings helper unavailable: \(reason). Opened Settings in GlassEQ instead.")
             )
@@ -1026,8 +1063,12 @@ extension GlassEQAppModel {
             resetDiagnostics()
             return SettingsCommandResponse(snapshot: settingsSnapshot())
 
-        case .resetPlaybackBufferCalibration:
-            try await resetPlaybackBufferCalibrationForCurrentOutput()
+        case .setAggregateBufferMode(let mode):
+            try setAggregateBufferMode(mode)
+            return SettingsCommandResponse(snapshot: settingsSnapshot())
+
+        case .retryAutomaticAggregateBuffer:
+            try retryAutomaticAggregateBuffer()
             return SettingsCommandResponse(snapshot: settingsSnapshot())
 
         case .retryAudioEngine:

--- a/Sources/GlassEQAudio/AdaptivePlaybackBuffer.swift
+++ b/Sources/GlassEQAudio/AdaptivePlaybackBuffer.swift
@@ -3,9 +3,12 @@ import Foundation
 
 public enum PlaybackBufferInstabilityReason: UInt8, Codable, Equatable, Sendable {
     case underrun = 1
-    case outputTimestampDiscontinuity = 2
-    case excessiveBacklog = 3
     case adaptiveRenderFailure = 4
+}
+
+public enum PlaybackBufferRenegotiationCause: Equatable, Sendable {
+    case instability(PlaybackBufferInstabilityReason)
+    case stableDecay
 }
 
 public struct PlaybackBufferRenegotiation: Equatable, Sendable {
@@ -16,7 +19,7 @@ public struct PlaybackBufferRenegotiation: Equatable, Sendable {
     public var frameSize: UInt32
     public var previousPlaybackTargetFrames: Int
     public var playbackTargetFrames: Int
-    public var reason: PlaybackBufferInstabilityReason
+    public var cause: PlaybackBufferRenegotiationCause
 
     public init(
         outputName: String,
@@ -26,7 +29,7 @@ public struct PlaybackBufferRenegotiation: Equatable, Sendable {
         frameSize: UInt32,
         previousPlaybackTargetFrames: Int? = nil,
         playbackTargetFrames: Int,
-        reason: PlaybackBufferInstabilityReason
+        cause: PlaybackBufferRenegotiationCause
     ) {
         self.outputName = outputName
         self.outputUID = outputUID
@@ -35,7 +38,7 @@ public struct PlaybackBufferRenegotiation: Equatable, Sendable {
         self.frameSize = frameSize
         self.previousPlaybackTargetFrames = previousPlaybackTargetFrames ?? playbackTargetFrames
         self.playbackTargetFrames = playbackTargetFrames
-        self.reason = reason
+        self.cause = cause
     }
 }
 
@@ -112,7 +115,7 @@ private struct LegacyPersistedPlaybackBufferSize: Codable {
 }
 
 private struct PersistedPlaybackBufferCalibrationDocument: Codable {
-    static let currentSchemaVersion = 2
+    static let currentSchemaVersion = 3
 
     var schemaVersion: Int
     var calibrations: [PersistedPlaybackBufferCalibration]
@@ -146,6 +149,100 @@ struct PlaybackBufferCalibrationProbe: Equatable, Sendable {
         duration: Duration = PlaybackBufferCalibrationPolicy.probationDuration
     ) -> Bool {
         startedAt.duration(to: now) >= duration
+    }
+}
+
+struct PlaybackBufferUnderrunEvidence: Sendable {
+    // Reprime separates underrun signals into episodes, so the controller can corroborate them
+    // from generation deltas without adding counters to the realtime callback.
+    private var count = 0
+    private var startedAt: ContinuousClock.Instant?
+
+    mutating func record(
+        eventCount: UInt64,
+        at now: ContinuousClock.Instant,
+        requiredCount: Int = PlaybackBufferAdaptationPolicy.requiredUnderrunCount,
+        window: Duration = PlaybackBufferAdaptationPolicy.underrunWindow
+    ) -> Bool {
+        guard eventCount > 0, requiredCount > 0 else {
+            return false
+        }
+        if let startedAt,
+           startedAt.duration(to: now) > window {
+            reset()
+        }
+        if startedAt == nil {
+            startedAt = now
+        }
+        count += Int(min(eventCount, UInt64(requiredCount)))
+        guard count >= requiredCount else {
+            return false
+        }
+        reset()
+        return true
+    }
+
+    mutating func reset() {
+        count = 0
+        startedAt = nil
+    }
+}
+
+struct PlaybackBufferAdaptationEvidenceObservation: Equatable, Sendable {
+    var observedDisturbance = false
+    var escalationReason: PlaybackBufferInstabilityReason?
+}
+
+struct PlaybackBufferAdaptationEvidence: Sendable {
+    private var handledInstabilityGeneration: UInt64 = 0
+    private var handledTimestampDiscontinuities: UInt64 = 0
+    private var underruns = PlaybackBufferUnderrunEvidence()
+
+    mutating func reset(
+        instabilityGeneration: UInt64,
+        timestampDiscontinuities: UInt64
+    ) {
+        handledInstabilityGeneration = instabilityGeneration
+        handledTimestampDiscontinuities = timestampDiscontinuities
+        underruns.reset()
+    }
+
+    mutating func resetUnderrunEpisodes() {
+        underruns.reset()
+    }
+
+    mutating func observe(
+        instabilityGeneration: UInt64,
+        reason: PlaybackBufferInstabilityReason,
+        timestampDiscontinuities: UInt64,
+        at now: ContinuousClock.Instant
+    ) -> PlaybackBufferAdaptationEvidenceObservation {
+        var observation = PlaybackBufferAdaptationEvidenceObservation()
+
+        if timestampDiscontinuities < handledTimestampDiscontinuities {
+            handledTimestampDiscontinuities = timestampDiscontinuities
+        } else if timestampDiscontinuities != handledTimestampDiscontinuities {
+            handledTimestampDiscontinuities = timestampDiscontinuities
+            observation.observedDisturbance = true
+        }
+
+        guard instabilityGeneration != handledInstabilityGeneration else {
+            return observation
+        }
+        let eventCount = instabilityGeneration &- handledInstabilityGeneration
+        handledInstabilityGeneration = instabilityGeneration
+        observation.observedDisturbance = true
+
+        switch reason {
+        case .underrun:
+            if underruns.record(eventCount: eventCount, at: now) {
+                observation.escalationReason = .underrun
+            }
+        case .adaptiveRenderFailure:
+            underruns.reset()
+            observation.escalationReason = .adaptiveRenderFailure
+        }
+        return observation
     }
 }
 
@@ -215,6 +312,12 @@ enum PlaybackBufferCalibrationPolicy {
     }
 }
 
+enum PlaybackBufferAdaptationPolicy {
+    static let requiredUnderrunCount = 3
+    static let underrunWindow: Duration = .seconds(2)
+    static let decayDelay: Duration = .seconds(5 * 60)
+}
+
 enum PersistedPlaybackBufferCalibrationStore {
     static func defaultURL(nextTo restorationStoreURL: URL) -> URL {
         restorationStoreURL.deletingLastPathComponent()
@@ -233,6 +336,8 @@ enum PersistedPlaybackBufferCalibrationStore {
             return normalized(document.calibrations)
         }
 
+        // Schema 2 persisted callback growth caused by timestamp reanchors. Do not migrate that
+        // contaminated evidence; legacy and schema 1 records predate that escalation path.
         if let document = try? decoder.decode(PersistedPlaybackBufferCalibrationDocumentV1.self, from: data),
            document.schemaVersion == 1 {
             return normalized(document.calibrations.map(migrateV1Calibration))
@@ -334,9 +439,7 @@ enum PersistedPlaybackBufferCalibrationStore {
               previousTargetFrames > 0, resultingTargetFrames > 0 else {
             return
         }
-        guard reason != .excessiveBacklog
-                || previousFrameSize != resultingFrameSize
-                || previousTargetFrames != resultingTargetFrames else {
+        guard reason == .underrun else {
             return
         }
         try updateCalibration(
@@ -358,17 +461,15 @@ enum PersistedPlaybackBufferCalibrationStore {
             if calibration.stableFrameSize == nil {
                 calibration.probingFrameSize = resultingFrameSize
             }
-            if reason == .underrun {
-                calibration.updateOperatingPoint(for: previousFrameSize) { operatingPoint in
-                    if operatingPoint.stableTargetFrames == previousTarget {
-                        operatingPoint.stableTargetFrames = nil
-                    }
-                    operatingPoint.probingTargetFrames = nil
-                    operatingPoint.unstableThroughTargetFrames = max(
-                        operatingPoint.unstableThroughTargetFrames ?? 0,
-                        previousTarget
-                    )
+            calibration.updateOperatingPoint(for: previousFrameSize) { operatingPoint in
+                if operatingPoint.stableTargetFrames == previousTarget {
+                    operatingPoint.stableTargetFrames = nil
                 }
+                operatingPoint.probingTargetFrames = nil
+                operatingPoint.unstableThroughTargetFrames = max(
+                    operatingPoint.unstableThroughTargetFrames ?? 0,
+                    previousTarget
+                )
             }
             calibration.updateOperatingPoint(for: resultingFrameSize) { operatingPoint in
                 operatingPoint.probingTargetFrames = UInt32(clamping: resultingTargetFrames)
@@ -656,22 +757,11 @@ struct AdaptivePlaybackBufferPolicy {
     static func startupFrameSize(
         preferredFrameSize: UInt32,
         calibration: PersistedPlaybackBufferCalibration?,
-        supportedRange: AudioBufferFrameSizeRange,
-        allowsDownwardProbe: Bool
+        supportedRange: AudioBufferFrameSizeRange
     ) -> UInt32 {
-        let calibratedFrameSize: UInt32
-        if let probingFrameSize = calibration?.probingFrameSize {
-            calibratedFrameSize = probingFrameSize
-        } else if allowsDownwardProbe,
-                  let stableFrameSize = calibration?.stableFrameSize,
-                  let downProbe = previousFrameSize(
-                      before: stableFrameSize,
-                      supportedRange: supportedRange
-                  ) {
-            calibratedFrameSize = downProbe
-        } else {
-            calibratedFrameSize = calibration?.stableFrameSize ?? 0
-        }
+        let calibratedFrameSize = calibration?.probingFrameSize
+            ?? calibration?.stableFrameSize
+            ?? 0
         return min(
             max(max(preferredFrameSize, calibratedFrameSize), supportedRange.minimum),
             supportedRange.maximum
@@ -679,16 +769,10 @@ struct AdaptivePlaybackBufferPolicy {
     }
 
     static func nextTargetFrames(
-        for reason: PlaybackBufferInstabilityReason,
         callbackFrames: UInt32,
         after currentTargetFrames: Int,
         maximumReservoirFrames: Int = maximumReservoirFrames
     ) -> Int? {
-        // Reservoir protects against missing input. Backlog is trimmed during reprime and does
-        // not become safer when both the prime and target move upward together.
-        guard reason == .underrun else {
-            return nil
-        }
         let callbackFrames = max(Int(callbackFrames), 1)
         let maximumTargetFrames = callbackFrames + max(maximumReservoirFrames, reservoirStepFrames)
         let nextTargetFrames = max(
@@ -698,23 +782,22 @@ struct AdaptivePlaybackBufferPolicy {
         return nextTargetFrames <= maximumTargetFrames ? nextTargetFrames : nil
     }
 
-    static func shouldIncreaseCallback(for reason: PlaybackBufferInstabilityReason) -> Bool {
-        // Timestamp gaps implicate callback scheduling, while repeated underruns reach this point
-        // only after the reservoir ladder is exhausted. Backlog is neither signal.
-        reason != .excessiveBacklog
-    }
-
     static func minimumTargetFrames(callbackFrames: UInt32) -> Int {
         max(Int(callbackFrames) + reservoirStepFrames, reservoirStepFrames * 2)
     }
 
-    static func nextSessionTargetProbe(
+    static func nextDecayTargetFrames(
         callbackFrames: UInt32,
         stableTargetFrames: Int,
-        unstableThroughTargetFrames: UInt32?
+        unstableThroughTargetFrames: UInt32?,
+        baselineTargetFrames: Int = 0
     ) -> Int? {
         let candidate = stableTargetFrames - reservoirStepFrames
-        guard candidate >= minimumTargetFrames(callbackFrames: callbackFrames),
+        let minimum = max(
+            minimumTargetFrames(callbackFrames: callbackFrames),
+            baselineTargetFrames
+        )
+        guard candidate >= minimum,
               candidate > Int(unstableThroughTargetFrames ?? 0) else {
             return nil
         }
@@ -722,25 +805,14 @@ struct AdaptivePlaybackBufferPolicy {
     }
 
     static func startupTargetFrames(
-        callbackFrames: UInt32,
         baselineTargetFrames: Int,
-        operatingPoint: PersistedPlaybackBufferOperatingPoint?,
-        allowsDownwardProbe: Bool
+        operatingPoint: PersistedPlaybackBufferOperatingPoint?
     ) -> Int {
         guard let operatingPoint else {
             return baselineTargetFrames
         }
         if let probingTargetFrames = operatingPoint.probingTargetFrames {
             return max(baselineTargetFrames, Int(probingTargetFrames))
-        }
-        if allowsDownwardProbe,
-           let stableTargetFrames = operatingPoint.stableTargetFrames,
-           let downProbe = nextSessionTargetProbe(
-               callbackFrames: callbackFrames,
-               stableTargetFrames: Int(stableTargetFrames),
-               unstableThroughTargetFrames: operatingPoint.unstableThroughTargetFrames
-           ) {
-            return max(baselineTargetFrames, downProbe)
         }
         return max(baselineTargetFrames, Int(operatingPoint.stableTargetFrames ?? 0))
     }

--- a/Sources/GlassEQAudio/AdaptivePlaybackRate.swift
+++ b/Sources/GlassEQAudio/AdaptivePlaybackRate.swift
@@ -64,6 +64,10 @@ struct PlaybackRateServo: Sendable {
         correction * 1_000_000
     }
 
+    var learnedCorrectionPartsPerMillion: Double {
+        correctionBias * 1_000_000
+    }
+
     mutating func reset(targetFrames: Int) {
         self.targetFrames = Double(max(targetFrames, 1))
         filteredOccupancyFrames = self.targetFrames
@@ -74,16 +78,13 @@ struct PlaybackRateServo: Sendable {
     }
 
     mutating func beginPriming() {
-        if !isPriming {
-            // Re-centring occupancy must not erase the rate learned for the same clock pair.
-            correctionBias = correction
-        }
+        // Keep the integral's clock-rate estimate. The current correction may also contain a
+        // transient proportional response, which must not become learned bias during a reprime.
         filteredOccupancyFrames = targetFrames
         isPriming = true
     }
 
     mutating func retarget(_ targetFrames: Int) {
-        correctionBias = correction
         self.targetFrames = Double(max(targetFrames, 1))
         filteredOccupancyFrames = self.targetFrames
         isPriming = true

--- a/Sources/GlassEQAudio/AudioDevice.swift
+++ b/Sources/GlassEQAudio/AudioDevice.swift
@@ -96,6 +96,12 @@ public enum CoreAudioDeviceQuery {
         return try outputDevice(id: deviceID)
     }
 
+    public static func outputDevices() throws -> [AudioOutputDevice] {
+        try audioDeviceIDs().compactMap { deviceID in
+            try? outputDevice(id: deviceID)
+        }
+    }
+
     public static func outputDevice(id: AudioObjectID) throws -> AudioOutputDevice {
         guard id != kAudioObjectUnknown else {
             throw AudioDeviceAvailabilityError.noDefaultOutput
@@ -435,6 +441,13 @@ public enum CoreAudioDeviceQuery {
         objectID: AudioObjectID,
         scope: AudioObjectPropertyScope
     ) throws -> Int {
+        try streamChannelCounts(objectID: objectID, scope: scope).reduce(0, +)
+    }
+
+    static func streamChannelCounts(
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope
+    ) throws -> [Int] {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyStreamConfiguration,
             mScope: scope,
@@ -461,10 +474,18 @@ public enum CoreAudioDeviceQuery {
         )
         try validateStreamConfigurationSize(size, objectID: objectID)
 
+        let bufferCount = Int(rawPointer.load(as: UInt32.self))
+        try validateAudioBufferListStorage(
+            bufferCount: bufferCount,
+            byteCount: Int(size),
+            objectID: objectID
+        )
+        guard bufferCount > 0 else {
+            return []
+        }
         let bufferList = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
-        try validateAudioBufferListStorage(bufferList.pointee, byteCount: Int(size), objectID: objectID)
-        return UnsafeMutableAudioBufferListPointer(bufferList).reduce(0) { partial, buffer in
-            partial + Int(buffer.mNumberChannels)
+        return UnsafeMutableAudioBufferListPointer(bufferList).map { buffer in
+            Int(buffer.mNumberChannels)
         }
     }
 
@@ -483,7 +504,13 @@ public enum CoreAudioDeviceQuery {
     }
 
     static func validateStreamConfigurationSize(_ size: UInt32, objectID: AudioObjectID) throws {
-        guard size >= UInt32(MemoryLayout<AudioBufferList>.size) else {
+        guard let buffersOffset = MemoryLayout<AudioBufferList>.offset(of: \.mBuffers) else {
+            throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
+                objectID,
+                "cannot determine AudioBufferList layout"
+            )
+        }
+        guard size >= UInt32(buffersOffset) else {
             throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
                 objectID,
                 "stream configuration is too small (\(size) bytes)"
@@ -569,16 +596,15 @@ public enum CoreAudioDeviceQuery {
         return count
     }
 
-    private static func validateAudioBufferListStorage(
-        _ bufferList: AudioBufferList,
+    static func validateAudioBufferListStorage(
+        bufferCount: Int,
         byteCount: Int,
         objectID: AudioObjectID
     ) throws {
         guard let buffersOffset = MemoryLayout<AudioBufferList>.offset(of: \.mBuffers) else {
             throw AudioDeviceAvailabilityError.invalidDeviceMetadata(objectID, "cannot determine AudioBufferList layout")
         }
-        let bufferCount = Int(bufferList.mNumberBuffers)
-        guard bufferCount > 0, bufferCount <= maxChannelCount else {
+        guard bufferCount >= 0, bufferCount <= maxChannelCount else {
             throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
                 objectID,
                 "stream configuration has invalid buffer count \(bufferCount)"

--- a/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
+++ b/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
@@ -1,0 +1,3827 @@
+import AudioToolbox
+import CoreAudio
+import Foundation
+import GlassEQCore
+import Synchronization
+protocol TopologyRebuildMuteGuarding: AnyObject {
+    func release()
+}
+
+struct TopologyRebuildMuteGuardUnavailable: Error, LocalizedError {
+    var underlyingError: any Error
+
+    var errorDescription: String? {
+        "GlassEQ could not guarantee silence for a profile rebuild, so the current audio engine was left running."
+    }
+}
+
+private struct SeparateClockAudioEngineInternalError: Error, LocalizedError {
+    var message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+public final class SeparateClockAudioBackend: @unchecked Sendable {
+    private static let preferredBufferFrameSize: UInt32 = 64
+    private static let preferredBluetoothBufferFrameSize: UInt32 = 64
+    private static let preferredBluetoothPlaybackTargetFrames = 128
+    // Leaves one preferred 64-frame capture callback after servicing a 64-frame output pull.
+    private static let preferredBluetoothPlaybackReservoirFrames = 64
+    private static let preferredLowSampleRateBufferFrameSize: UInt32 = 1024
+    // Low-rate routes keep at least one normal runtime callback in reserve. The configured
+    // capture callback expands this at startup when the aggregate ignores the 64-frame request.
+    private static let preferredLowSampleRatePlaybackReservoirFrames = Int(maximumRuntimeBufferFrameSize)
+    private static let preferredCaptureBufferFrameSize: UInt32 = 64
+    private static let minimumRingBufferFrames = 2048
+    private static let maximumRuntimeBufferFrameSize: UInt32 = 1024
+    private static let maximumSupportedCallbackFrames = 8192
+    // Capacity planning allows a 4:1 input/output rate ratio (above the current 48→16 kHz case)
+    // and retains one additional full converted pull as drift headroom.
+    private static let maximumPlannedPlaybackRateRatio = 4
+    private static let playbackRingPullCount = 2
+    private static let preferredPlaybackPrimeFrames = 128
+    private static let lowSampleRateThreshold = 24_000.0
+    private static let maximumPlannedPlaybackPrimeFrames =
+        maximumSupportedCallbackFrames * maximumPlannedPlaybackRateRatio
+            + maximumSupportedCallbackFrames
+    static let runtimeRingCapacityFrames = max(
+        minimumRingBufferFrames,
+        maximumPlannedPlaybackPrimeFrames * playbackRingPullCount
+    )
+
+    private struct PlaybackBufferFrameSizeDecayCandidate: Hashable {
+        var outputUID: String
+        var sampleRate: Int
+        var tapSampleRate: Int
+        var frameSize: UInt32
+
+        init(output: AudioOutputDevice, tapSampleRate: Double, frameSize: UInt32) {
+            self.outputUID = output.uid
+            self.sampleRate = Int(output.nominalSampleRate.rounded())
+            self.tapSampleRate = Int(tapSampleRate.rounded())
+            self.frameSize = frameSize
+        }
+    }
+
+    private struct ControlState {
+        var state: AudioEngineState = .stopped
+        var status: AudioEngineStatus = .stopped
+        // Persistent capture half (one global muted tap, kept alive across output switches).
+        var tapID = AudioObjectID(kAudioObjectUnknown)
+        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        var captureIOProcID: AudioDeviceIOProcID?
+        var runtime: AudioRuntime?
+        var tapSampleRate: Double = 0
+        var tapChannelCount: Int = 0
+        var captureRunning = false
+        // Swappable output half (rebuilt per output device; low-rate headset modes are converted).
+        var outputIOProcID: AudioDeviceIOProcID?
+        var preparedOutputHandoff: PreparedOutputHandoff?
+        var activeOutput: AudioOutputDevice?
+        var activeProfile: EQProfile?
+        var profileRevision: UInt64 = 0
+        var bufferFrameSizeRestorations: [String: BufferFrameSizeRestoration] = [:]
+        var sampleRateRestorations: [String: SampleRateRestoration] = [:]
+        var outputRebuildGeneration = 0
+        var playbackBufferAdaptationEvidence = PlaybackBufferAdaptationEvidence()
+        var playbackBufferCalibrationProbe: PlaybackBufferCalibrationProbe?
+        var playbackBufferStableSince: ContinuousClock.Instant?
+        var playbackBufferInstabilityPersistenceGate = PlaybackBufferInstabilityPersistenceGate()
+        var failedPlaybackFrameSizeDecayCandidates: Set<PlaybackBufferFrameSizeDecayCandidate> = []
+        var adaptivePlaybackRenderRecoveryAttempts = 0
+        var adaptivePlaybackRenderRecoveryHealthGeneration: UInt64?
+    }
+
+    private struct OutputRebuildPreparation {
+        var generation: Int
+        var output: AudioOutputDevice
+        var profile: EQProfile
+        var runtime: AudioRuntime
+        var tapSampleRate: Double
+        var originalBufferFrameSize: UInt32
+        var profileRevision: UInt64
+    }
+
+    private struct PreparedOutputHandoff {
+        var preparation: OutputRebuildPreparation
+        var output: AudioOutputDevice
+        var profile: EQProfile
+        var ioProcID: AudioDeviceIOProcID
+    }
+
+    private struct PlaybackBufferRenegotiationPreparation {
+        var outputRebuildGeneration: Int
+        var reason: PlaybackBufferInstabilityReason
+        var output: AudioOutputDevice
+        var runtime: AudioRuntime
+    }
+
+    private struct PlaybackBufferDecayPreparation {
+        var outputRebuildGeneration: Int
+        var output: AudioOutputDevice
+        var runtime: AudioRuntime
+    }
+
+    private struct OutputRebuildExpectation {
+        var generation: Int
+        var runtime: AudioRuntime
+        var profileRevision: UInt64
+    }
+
+    private struct PlaybackBufferTargetAdjustment {
+        var output: AudioOutputDevice
+        var tapSampleRate: Double
+        var previousTargetFrames: Int
+        var targetFrames: Int
+    }
+
+    private enum PlaybackBufferTargetDecayResult {
+        case adjusted
+        case atBaseline
+        case blocked
+    }
+
+    private enum PlaybackBufferAdaptationAction {
+        case stabilize(PlaybackBufferCalibrationProbe)
+        case renegotiate(PlaybackBufferRenegotiationPreparation)
+        case decay(PlaybackBufferDecayPreparation)
+    }
+
+    private enum AdaptivePlaybackRenderRecoveryAction {
+        case restart(output: AudioOutputDevice, profile: EQProfile, expectation: OutputRebuildExpectation)
+        case fail(AudioEngineFailure)
+    }
+
+    private struct StaleOutputRebuild: Error {}
+    private struct StaleProfileRequest: Error {}
+
+    struct BufferFrameSizeRestoration: Equatable, Sendable {
+        var uid: String
+        var originalFrameSize: UInt32
+    }
+
+    struct SampleRateRestoration: Equatable, Sendable {
+        var uid: String
+        var originalSampleRate: Double
+    }
+
+    private final class CoreAudioTopologyRebuildMuteGuard: TopologyRebuildMuteGuarding, @unchecked Sendable {
+        private let lock = NSLock()
+        private var tapID: AudioObjectID
+        private var aggregateDeviceID: AudioObjectID
+        private var ioProcID: AudioDeviceIOProcID?
+
+        init(
+            tapID: AudioObjectID,
+            aggregateDeviceID: AudioObjectID,
+            ioProcID: AudioDeviceIOProcID?
+        ) {
+            self.tapID = tapID
+            self.aggregateDeviceID = aggregateDeviceID
+            self.ioProcID = ioProcID
+        }
+
+        deinit {
+            release()
+        }
+
+        func release() {
+            lock.lock()
+            defer { lock.unlock() }
+
+            if aggregateDeviceID != kAudioObjectUnknown, let ioProcID {
+                _ = AudioDeviceStop(aggregateDeviceID, ioProcID)
+                _ = AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProcID)
+            }
+            if aggregateDeviceID != kAudioObjectUnknown {
+                _ = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            }
+            if tapID != kAudioObjectUnknown {
+                _ = AudioHardwareDestroyProcessTap(tapID)
+            }
+
+            ioProcID = nil
+            aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+            tapID = AudioObjectID(kAudioObjectUnknown)
+        }
+    }
+
+    private final class PreparedDSPConfigBox: @unchecked Sendable {
+        let config: EQRenderConfiguration
+        var retiredStorage: EQProcessorRetiredRenderStorage?
+        var nextRetiredPointer: UInt = 0
+
+        init(config: EQRenderConfiguration) {
+            self.config = config
+        }
+    }
+
+    private enum AdaptivePlaybackRenderResult {
+        case rendered
+        case underrun(frames: Int)
+        case failed
+    }
+
+    private final class AudioRuntime: @unchecked Sendable {
+        let ringBuffer: RealtimeAudioRingBuffer
+        let channelCount: Int
+        let sampleRate: Double
+        private let configuredCaptureCallbackFrames: Int
+        private let playbackPrimeFrames: Atomic<Int>
+        private let maxCallbackFrames: Int
+        private var processor: EQProcessor
+        private var captureScratchSamples: [Float]
+        private var adaptiveInputSamples: [Float]
+        private var sampleRateConverterInputSamples: UnsafeMutableBufferPointer<Float>
+        private let adaptiveOutputSamples: UnsafeMutableBufferPointer<Float>
+        private var playbackRateServo: PlaybackRateServo
+        private var playbackResampler: HermitePlaybackResampler
+        private var playbackSampleRatePlan: PlaybackSampleRatePlan
+        private var playbackSampleRateConverter: RealtimePCMRateConverter?
+        private var sampleRateConverterInputRatio = 1.0
+        private var sampleRateConverterInputResult = AdaptivePlaybackRenderResult.rendered
+        private var outputTimestampTracker = OutputCallbackTimestampTracker()
+
+        private let capturedFrames = Atomic<UInt64>(0)
+        private let playedFrames = Atomic<UInt64>(0)
+        private let playbackUnderrunFrames = Atomic<UInt64>(0)
+        private let droppedInputFrames = Atomic<UInt64>(0)
+        private let droppedBufferedFrames = Atomic<UInt64>(0)
+        private let saturatedSamples = Atomic<UInt64>(0)
+        private let maxBufferedFrames = Atomic<Int>(0)
+        private let maxPlaybackBufferedFrames = Atomic<Int>(0)
+        private let minPlaybackBufferedFrames = Atomic<Int>(Int.max)
+        private let totalPlaybackBufferedFrames = Atomic<UInt64>(0)
+        private let playbackBufferObservations = Atomic<UInt64>(0)
+        private let maxCaptureCallbackFrames = Atomic<Int>(0)
+        private let maxPlaybackCallbackFrames = Atomic<Int>(0)
+        private let playbackTimestampDiscontinuities = Atomic<UInt64>(0)
+        private let playbackBufferRenegotiations = Atomic<UInt64>(0)
+        private let adaptivePlaybackRenderFailures = Atomic<UInt64>(0)
+        private let adaptivePlaybackRenderFailureActive = Atomic<Bool>(false)
+        private let adaptivePlaybackRenderHealthGeneration = Atomic<UInt64>(0)
+        private let playbackInstabilityGeneration = Atomic<UInt64>(0)
+        private let latestPlaybackInstabilityReason = Atomic<UInt8>(PlaybackBufferInstabilityReason.underrun.rawValue)
+        private let adaptivePlaybackTargetFrames: Atomic<Int>
+        private let pendingPlaybackClockReset = Atomic<Bool>(true)
+        private let pendingPlaybackTargetRetarget = Atomic<Bool>(false)
+        private let playbackRateCorrectionPartsPerBillion = Atomic<Int64>(0)
+        private let playbackRateCorrectionSaturated = Atomic<Bool>(false)
+        private let filteredPlaybackOccupancyMilliFrames = Atomic<Int64>(0)
+        private let sampleRateConversionActive = Atomic<Bool>(false)
+        private let bypassEnabled: Atomic<Bool>
+        private let playbackPriming = Atomic<Bool>(true)
+        private let outputMutedForTransition = Atomic<Bool>(false)
+        private let pendingPlaybackReset = Atomic<Bool>(false)
+        private let pendingOutputTimestampReset = Atomic<Bool>(true)
+        private let pendingDSPConfigPointer = Atomic<UInt>(0)
+        private let retiredDSPConfigHeadPointer = Atomic<UInt>(0)
+        private let stopping = Atomic<Bool>(false)
+        private let captureInCallback = Atomic<Bool>(false)
+        private let playbackInCallback = Atomic<Bool>(false)
+        // Packed (left << 32 | right) so the playback callback can never observe a torn pair.
+        private let playbackChannelPair = Atomic<UInt64>(SeparateClockAudioBackend.encodedPlaybackChannelPair(left: 0, right: 1))
+
+        init(
+            profile: EQProfile,
+            sampleRate: Double,
+            channelCount: Int,
+            ringCapacityFrames: Int,
+            scratchFrames: Int,
+            captureCallbackFrames: Int,
+            playbackPrimeFrames: Int
+        ) {
+            self.channelCount = max(channelCount, 1)
+            self.sampleRate = sampleRate
+            self.configuredCaptureCallbackFrames = max(captureCallbackFrames, 1)
+            self.ringBuffer = RealtimeAudioRingBuffer(
+                channelCount: self.channelCount,
+                capacityFrames: ringCapacityFrames
+            )
+            self.captureScratchSamples = Array(repeating: 0, count: scratchFrames * self.channelCount)
+            self.adaptiveInputSamples = Array(repeating: 0, count: (scratchFrames + 8) * self.channelCount)
+            self.sampleRateConverterInputSamples = UnsafeMutableBufferPointer<Float>.allocate(
+                capacity: self.channelCount
+            )
+            self.sampleRateConverterInputSamples.initialize(repeating: 0)
+            self.adaptiveOutputSamples = UnsafeMutableBufferPointer<Float>.allocate(
+                capacity: SeparateClockAudioBackend.maximumSupportedCallbackFrames * self.channelCount
+            )
+            self.adaptiveOutputSamples.initialize(repeating: 0)
+            self.playbackPrimeFrames = Atomic(max(playbackPrimeFrames, 1))
+            self.adaptivePlaybackTargetFrames = Atomic(max(playbackPrimeFrames, 1))
+            self.maxCallbackFrames = SeparateClockAudioBackend.maximumSupportedCallbackFrames
+            self.playbackRateServo = PlaybackRateServo(
+                sampleRate: sampleRate,
+                targetFrames: playbackPrimeFrames
+            )
+            self.playbackResampler = HermitePlaybackResampler(channelCount: self.channelCount)
+            self.playbackSampleRatePlan = PlaybackSampleRatePlan(
+                inputSampleRate: sampleRate,
+                outputSampleRate: sampleRate
+            )
+            self.processor = EQProcessor(
+                renderConfiguration: EQRenderConfiguration(
+                    profile: SeparateClockAudioBackend.dspProfile(from: profile),
+                    sampleRate: sampleRate,
+                    channelCount: self.channelCount
+                )
+            )
+            self.bypassEnabled = Atomic(profile.isBypassed)
+        }
+
+        deinit {
+            drainDSPConfigBoxes()
+            sampleRateConverterInputSamples.deinitialize()
+            sampleRateConverterInputSamples.deallocate()
+            adaptiveOutputSamples.deinitialize()
+            adaptiveOutputSamples.deallocate()
+        }
+
+        func markStopping() {
+            stopping.store(true, ordering: .releasing)
+            outputMutedForTransition.store(true, ordering: .releasing)
+            playbackPriming.store(true, ordering: .releasing)
+        }
+
+        func setBypassed(_ isBypassed: Bool) {
+            bypassEnabled.store(isBypassed, ordering: .relaxed)
+        }
+
+        func muteOutputForTransition() {
+            outputMutedForTransition.store(true, ordering: .releasing)
+            playbackPriming.store(true, ordering: .releasing)
+            pendingOutputTimestampReset.store(true, ordering: .releasing)
+        }
+
+        // Stored by the control thread on every output rebuild, before the new output IOProc
+        // starts, so the first callback on the new device already maps to the right channels.
+        func setPlaybackChannelPair(left: Int, right: Int) {
+            playbackChannelPair.store(
+                SeparateClockAudioBackend.encodedPlaybackChannelPair(left: left, right: right),
+                ordering: .releasing
+            )
+        }
+
+        func configurePlayback(
+            primeFrames: Int,
+            outputSampleRate: Double
+        ) throws {
+            let targetFrames = min(max(primeFrames, 1), ringBuffer.capacityFrames)
+            let sampleRatePlan = PlaybackSampleRatePlan(
+                inputSampleRate: sampleRate,
+                outputSampleRate: outputSampleRate
+            )
+            let sampleRateConverter: RealtimePCMRateConverter? = if sampleRatePlan.requiresConversion {
+                try RealtimePCMRateConverter(
+                    inputSampleRate: sampleRatePlan.inputSampleRate,
+                    outputSampleRate: sampleRatePlan.outputSampleRate,
+                    channelCount: channelCount
+                )
+            } else {
+                nil
+            }
+            let inputCapacityFrames = try sampleRateConverter?.inputFrameCapacity(
+                forOutputFrames: maxCallbackFrames
+            ) ?? 1
+            let inputSamples = UnsafeMutableBufferPointer<Float>.allocate(
+                capacity: inputCapacityFrames * channelCount
+            )
+            inputSamples.initialize(repeating: 0)
+
+            sampleRateConverterInputSamples.deinitialize()
+            sampleRateConverterInputSamples.deallocate()
+            sampleRateConverterInputSamples = inputSamples
+            playbackSampleRateConverter = sampleRateConverter
+            playbackSampleRatePlan = sampleRatePlan
+            sampleRateConversionActive.store(sampleRateConverter != nil, ordering: .releasing)
+            adaptivePlaybackRenderFailureActive.store(false, ordering: .releasing)
+            playbackPrimeFrames.store(targetFrames, ordering: .releasing)
+            adaptivePlaybackTargetFrames.store(targetFrames, ordering: .releasing)
+            pendingPlaybackTargetRetarget.store(false, ordering: .releasing)
+            pendingPlaybackClockReset.store(true, ordering: .releasing)
+            pendingOutputTimestampReset.store(true, ordering: .releasing)
+        }
+
+        func retargetPlayback(primeFrames: Int) {
+            let targetFrames = min(max(primeFrames, 1), ringBuffer.capacityFrames)
+            playbackPrimeFrames.store(targetFrames, ordering: .releasing)
+            adaptivePlaybackTargetFrames.store(targetFrames, ordering: .releasing)
+            pendingPlaybackTargetRetarget.store(true, ordering: .releasing)
+            pendingOutputTimestampReset.store(true, ordering: .releasing)
+        }
+
+        func playbackTargetFrames() -> Int {
+            adaptivePlaybackTargetFrames.load(ordering: .acquiring)
+        }
+
+        func maximumKnownCaptureCallbackFrames() -> Int {
+            max(
+                configuredCaptureCallbackFrames,
+                maxCaptureCallbackFrames.load(ordering: .relaxed)
+            )
+        }
+
+        func hasActiveAdaptivePlaybackRenderFailure() -> Bool {
+            adaptivePlaybackRenderFailureActive.load(ordering: .acquiring)
+        }
+
+        func playbackRenderHealthGeneration() -> UInt64 {
+            adaptivePlaybackRenderHealthGeneration.load(ordering: .acquiring)
+        }
+
+        func playbackTimestampDiscontinuityCount() -> UInt64 {
+            playbackTimestampDiscontinuities.load(ordering: .acquiring)
+        }
+
+        // Called when a new output half is started. Clears any transition mute (the runtime
+        // persists across output switches now, so the mute flag would otherwise stick on and
+        // silence everything) and re-primes so playback re-anchors to the freshest audio.
+        func reprimePlayback() {
+            pendingPlaybackReset.store(true, ordering: .releasing)
+            playbackPriming.store(true, ordering: .releasing)
+            pendingOutputTimestampReset.store(true, ordering: .releasing)
+            outputMutedForTransition.store(false, ordering: .releasing)
+        }
+
+        func playbackInstabilitySnapshot() -> (generation: UInt64, reason: PlaybackBufferInstabilityReason) {
+            let generation = playbackInstabilityGeneration.load(ordering: .acquiring)
+            let latestReason = PlaybackBufferInstabilityReason(
+                rawValue: latestPlaybackInstabilityReason.load(ordering: .relaxed)
+            ) ?? .underrun
+            let reason = AdaptivePlaybackRenderRecoveryPolicy.effectiveInstabilityReason(
+                latest: latestReason,
+                renderFailureActive: adaptivePlaybackRenderFailureActive.load(ordering: .acquiring)
+            )
+            return (generation, reason)
+        }
+
+        func recordPlaybackBufferRenegotiation() {
+            playbackBufferRenegotiations.wrappingAdd(1, ordering: .relaxed)
+        }
+
+        func resetMetrics() {
+            capturedFrames.store(0, ordering: .relaxed)
+            playedFrames.store(0, ordering: .relaxed)
+            playbackUnderrunFrames.store(0, ordering: .relaxed)
+            droppedInputFrames.store(0, ordering: .relaxed)
+            droppedBufferedFrames.store(0, ordering: .relaxed)
+            saturatedSamples.store(0, ordering: .relaxed)
+            maxBufferedFrames.store(0, ordering: .relaxed)
+            maxPlaybackBufferedFrames.store(0, ordering: .relaxed)
+            minPlaybackBufferedFrames.store(Int.max, ordering: .relaxed)
+            totalPlaybackBufferedFrames.store(0, ordering: .relaxed)
+            playbackBufferObservations.store(0, ordering: .relaxed)
+            maxCaptureCallbackFrames.store(0, ordering: .relaxed)
+            maxPlaybackCallbackFrames.store(0, ordering: .relaxed)
+            playbackTimestampDiscontinuities.store(0, ordering: .relaxed)
+            playbackBufferRenegotiations.store(0, ordering: .relaxed)
+            adaptivePlaybackRenderFailures.store(0, ordering: .relaxed)
+            playbackRateCorrectionSaturated.store(false, ordering: .relaxed)
+            ringBuffer.resetOverwriteGateContentionFailureCount()
+            playbackPriming.store(true, ordering: .releasing)
+        }
+
+        func snapshotMetrics() -> AudioEngineMetrics {
+            let observations = playbackBufferObservations.load(ordering: .relaxed)
+            let minimumBufferedFrames = minPlaybackBufferedFrames.load(ordering: .relaxed)
+            return AudioEngineMetrics(
+                capturedFrames: capturedFrames.load(ordering: .relaxed),
+                playedFrames: playedFrames.load(ordering: .relaxed),
+                playbackUnderrunFrames: playbackUnderrunFrames.load(ordering: .relaxed),
+                droppedInputFrames: droppedInputFrames.load(ordering: .relaxed),
+                droppedBufferedFrames: droppedBufferedFrames.load(ordering: .relaxed),
+                ringGateContentionFailures: ringBuffer.overwriteGateContentionFailureCount(),
+                saturatedSamples: saturatedSamples.load(ordering: .relaxed),
+                currentBufferedFrames: ringBuffer.occupancyFrames(),
+                maxBufferedFrames: maxBufferedFrames.load(ordering: .relaxed),
+                maximumPlaybackBufferedFrames: maxPlaybackBufferedFrames.load(ordering: .relaxed),
+                minimumPlaybackBufferedFrames: observations == 0 ? 0 : minimumBufferedFrames,
+                averagePlaybackBufferedFrames: observations == 0
+                    ? 0
+                    : Double(totalPlaybackBufferedFrames.load(ordering: .relaxed)) / Double(observations),
+                playbackBufferObservations: observations,
+                maximumCaptureCallbackFrames: maxCaptureCallbackFrames.load(ordering: .relaxed),
+                maximumPlaybackCallbackFrames: maxPlaybackCallbackFrames.load(ordering: .relaxed),
+                playbackTimestampDiscontinuities: playbackTimestampDiscontinuities.load(ordering: .relaxed),
+                playbackBufferRenegotiations: playbackBufferRenegotiations.load(ordering: .relaxed),
+                adaptivePlaybackRenderFailures: adaptivePlaybackRenderFailures.load(ordering: .relaxed),
+                playbackRateCorrectionPPM: Double(
+                    playbackRateCorrectionPartsPerBillion.load(ordering: .relaxed)
+                ) / 1_000,
+                playbackRateCorrectionSaturated: playbackRateCorrectionSaturated.load(ordering: .relaxed),
+                playbackOccupancyTargetFrames: adaptivePlaybackTargetFrames.load(ordering: .relaxed),
+                filteredPlaybackOccupancyFrames: Double(
+                    filteredPlaybackOccupancyMilliFrames.load(ordering: .relaxed)
+                ) / 1_000,
+                playbackBufferSampleRate: sampleRate,
+                playbackSampleRateConversionActive: sampleRateConversionActive.load(ordering: .acquiring)
+            )
+        }
+
+        func publishPendingDSPConfig(_ config: EQRenderConfiguration) {
+            let box = PreparedDSPConfigBox(config: config)
+            let rawPointer = UInt(bitPattern: Unmanaged.passRetained(box).toOpaque())
+            let oldPointer = pendingDSPConfigPointer.exchange(rawPointer, ordering: .acquiringAndReleasing)
+            releaseDSPConfigBox(oldPointer)
+        }
+
+        func drainDSPConfigBoxes() {
+            releaseDSPConfigBox(pendingDSPConfigPointer.exchange(0, ordering: .acquiringAndReleasing))
+            var rawPointer = retiredDSPConfigHeadPointer.exchange(0, ordering: .acquiringAndReleasing)
+            while rawPointer != 0 {
+                guard let pointer = UnsafeRawPointer(bitPattern: rawPointer) else {
+                    return
+                }
+                let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
+                let nextPointer = box.nextRetiredPointer
+                box.nextRetiredPointer = 0
+                releaseDSPConfigBox(rawPointer)
+                rawPointer = nextPointer
+            }
+        }
+
+        func capture(inputData: UnsafePointer<AudioBufferList>) {
+            guard !stopping.load(ordering: .acquiring),
+                  enter(captureInCallback) else {
+                return
+            }
+            defer {
+                captureInCallback.store(false, ordering: .releasing)
+            }
+
+            let inputBuffers = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inputData))
+            guard let frameCount = inputFrameCount(inputBuffers),
+                  frameCount > 0 else {
+                return
+            }
+            updateMax(maxCaptureCallbackFrames, frameCount)
+
+            if outputMutedForTransition.load(ordering: .acquiring) {
+                return
+            }
+
+            applyPendingDSPConfig()
+
+            if bypassEnabled.load(ordering: .relaxed) {
+                captureBypassed(inputBuffers: inputBuffers, frameCount: frameCount)
+                return
+            }
+
+            var saturatedSampleCount: UInt64 = 0
+            captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
+                let scratchFrames = max(scratch.count / channelCount, 1)
+                var frameOffset = 0
+                while frameOffset < frameCount {
+                    let chunkFrames = min(frameCount - frameOffset, scratchFrames)
+                    let chunkSamples = UnsafeMutableBufferPointer(
+                        start: scratch.baseAddress,
+                        count: chunkFrames * channelCount
+                    )
+                    copyInput(
+                        from: inputBuffers,
+                        sourceFrameOffset: frameOffset,
+                        into: chunkSamples,
+                        frameCount: chunkFrames,
+                        channelCount: channelCount
+                    )
+                    saturatedSampleCount += processor.processInterleavedWithDiagnostics(
+                        chunkSamples,
+                        frameCount: chunkFrames,
+                        channelCount: channelCount
+                    )
+                    recordWriteResult(
+                        ringBuffer.writeInterleaved(
+                            UnsafeBufferPointer(chunkSamples),
+                            frameCount: chunkFrames,
+                            sourceChannelCount: channelCount
+                        )
+                    )
+                    frameOffset += chunkFrames
+                }
+            }
+
+            if saturatedSampleCount > 0 {
+                saturatedSamples.wrappingAdd(saturatedSampleCount, ordering: .relaxed)
+            }
+            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
+            capturedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+        }
+
+        func playback(
+            outputData: UnsafeMutablePointer<AudioBufferList>,
+            outputSampleTime: Double?
+        ) {
+            guard !stopping.load(ordering: .acquiring) else {
+                clear(outputData: outputData)
+                return
+            }
+            guard enter(playbackInCallback) else {
+                clear(outputData: outputData)
+                return
+            }
+            defer {
+                playbackInCallback.store(false, ordering: .releasing)
+            }
+
+            let outputBuffers = UnsafeMutableAudioBufferListPointer(outputData)
+            guard let frameCount = outputFrameCount(outputBuffers) else {
+                clear(outputData: outputData)
+                return
+            }
+            guard frameCount > 0 else {
+                return
+            }
+            updateMax(maxPlaybackCallbackFrames, frameCount)
+
+            if pendingOutputTimestampReset.exchange(false, ordering: .acquiringAndReleasing) {
+                outputTimestampTracker.reset()
+            }
+
+            if pendingPlaybackReset.exchange(false, ordering: .acquiringAndReleasing) {
+                _ = ringBuffer.reset()
+            }
+            if pendingPlaybackClockReset.exchange(false, ordering: .acquiringAndReleasing) {
+                pendingPlaybackTargetRetarget.store(false, ordering: .releasing)
+                playbackRateServo.reset(
+                    targetFrames: adaptivePlaybackTargetFrames.load(ordering: .acquiring)
+                )
+                playbackResampler.reset()
+                publishAdaptivePlaybackMetrics()
+            } else if pendingPlaybackTargetRetarget.exchange(false, ordering: .acquiringAndReleasing) {
+                playbackRateServo.retarget(
+                    adaptivePlaybackTargetFrames.load(ordering: .acquiring)
+                )
+                playbackResampler.reset()
+                publishAdaptivePlaybackMetrics()
+            }
+
+            if outputMutedForTransition.load(ordering: .acquiring) {
+                clear(outputData: outputData)
+                return
+            }
+
+            let inputDurationFrames = playbackSampleRatePlan.inputFrames(
+                forOutputFrames: frameCount
+            )
+
+            // Timeline reanchors and backlog trimming need a fresh prime, but neither proves that
+            // the operating point lacks capacity. Only corroborated underruns drive adaptation.
+            if outputTimestampTracker.observe(sampleTime: outputSampleTime, frameCount: frameCount) {
+                playbackTimestampDiscontinuities.wrappingAdd(1, ordering: .relaxed)
+                beginPlaybackReprime()
+            } else if !playbackPriming.load(ordering: .acquiring),
+                      PlaybackOccupancyRecoveryPolicy.shouldReprime(
+                          occupancyFrames: ringBuffer.occupancyFrames(),
+                          targetFrames: adaptivePlaybackTargetFrames.load(ordering: .acquiring),
+                          outputFrames: inputDurationFrames
+                      ) {
+                beginPlaybackReprime()
+            }
+
+            if playbackPriming.load(ordering: .acquiring) {
+                playbackRateServo.beginPriming()
+                playbackResampler.reset()
+                publishAdaptivePlaybackMetrics()
+                let bufferedFrames = ringBuffer.occupancyFrames()
+                let primeFrames = playbackPrimeFrames.load(ordering: .acquiring)
+                updateMaxBufferedFrames(bufferedFrames)
+                guard bufferedFrames >= primeFrames else {
+                    clear(outputData: outputData)
+                    return
+                }
+                guard ringBuffer.trimToLatestFrames(primeFrames) else {
+                    clear(outputData: outputData)
+                    return
+                }
+                playbackRateServo.didPrime(occupancyFrames: primeFrames)
+                publishAdaptivePlaybackMetrics()
+                playbackPriming.store(false, ordering: .releasing)
+            }
+
+            let bufferedFrames = ringBuffer.occupancyFrames()
+            recordPlaybackBufferedFrames(bufferedFrames)
+
+            let (destinationLeftChannel, destinationRightChannel) = SeparateClockAudioBackend.decodedPlaybackChannelPair(
+                playbackChannelPair.load(ordering: .acquiring)
+            )
+
+            let ratio = playbackRateServo.update(
+                occupancyFrames: bufferedFrames,
+                outputFrames: inputDurationFrames
+            )
+            publishAdaptivePlaybackMetrics()
+            let result = if playbackSampleRateConverter != nil {
+                renderSampleRateConvertedPlayback(
+                    outputBuffers: outputBuffers,
+                    frameCount: frameCount,
+                    ratio: ratio,
+                    destinationLeftChannel: destinationLeftChannel,
+                    destinationRightChannel: destinationRightChannel
+                )
+            } else {
+                renderAdaptivePlayback(
+                    outputBuffers: outputBuffers,
+                    frameCount: frameCount,
+                    ratio: ratio,
+                    destinationLeftChannel: destinationLeftChannel,
+                    destinationRightChannel: destinationRightChannel
+                )
+            }
+            var underrunFrames = 0
+            var adaptiveRenderFailed = false
+            switch result {
+            case .rendered:
+                adaptivePlaybackRenderFailureActive.store(false, ordering: .releasing)
+                adaptivePlaybackRenderHealthGeneration.wrappingAdd(1, ordering: .releasing)
+            case .underrun(let frames):
+                adaptivePlaybackRenderFailureActive.store(false, ordering: .releasing)
+                adaptivePlaybackRenderHealthGeneration.wrappingAdd(1, ordering: .releasing)
+                underrunFrames = frames
+            case .failed:
+                adaptiveRenderFailed = true
+            }
+
+            if underrunFrames > 0 {
+                playbackUnderrunFrames.wrappingAdd(UInt64(underrunFrames), ordering: .relaxed)
+                signalPlaybackInstability(.underrun)
+            } else if adaptiveRenderFailed {
+                adaptivePlaybackRenderFailures.wrappingAdd(1, ordering: .relaxed)
+                if !adaptivePlaybackRenderFailureActive.exchange(true, ordering: .acquiringAndReleasing) {
+                    signalPlaybackInstability(.adaptiveRenderFailure)
+                }
+            }
+            if underrunFrames > 0 || adaptiveRenderFailed {
+                beginPlaybackReprime()
+            }
+            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
+            playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+        }
+
+        private func beginPlaybackReprime() {
+            playbackRateServo.beginPriming()
+            playbackResampler.reset()
+            publishAdaptivePlaybackMetrics()
+            playbackPriming.store(true, ordering: .releasing)
+        }
+
+        private func signalPlaybackInstability(_ reason: PlaybackBufferInstabilityReason) {
+            latestPlaybackInstabilityReason.store(reason.rawValue, ordering: .relaxed)
+            playbackInstabilityGeneration.wrappingAdd(1, ordering: .releasing)
+        }
+
+        private func renderAdaptivePlayback(
+            outputBuffers: UnsafeMutableAudioBufferListPointer,
+            frameCount: Int,
+            ratio: Double,
+            destinationLeftChannel: Int,
+            destinationRightChannel: Int
+        ) -> AdaptivePlaybackRenderResult {
+            guard frameCount <= adaptiveOutputSamples.count / channelCount else {
+                clear(outputBuffers: outputBuffers)
+                return .failed
+            }
+            let outputSamples = UnsafeMutableBufferPointer(
+                start: adaptiveOutputSamples.baseAddress,
+                count: frameCount * channelCount
+            )
+            let result = renderAdaptiveFrames(
+                into: outputSamples,
+                frameCount: frameCount,
+                ratio: ratio
+            )
+            guard case .rendered = result else {
+                clear(outputBuffers: outputBuffers)
+                return result
+            }
+            writeInterleaved(
+                UnsafeBufferPointer(outputSamples),
+                sourceFrameOffset: 0,
+                destinationFrameOffset: 0,
+                frameCount: frameCount,
+                sourceChannelCount: channelCount,
+                destinationLeftChannel: destinationLeftChannel,
+                destinationRightChannel: destinationRightChannel,
+                to: outputBuffers
+            )
+            return .rendered
+        }
+
+        private func renderAdaptiveFrames(
+            into outputSamples: UnsafeMutableBufferPointer<Float>,
+            frameCount: Int,
+            ratio: Double
+        ) -> AdaptivePlaybackRenderResult {
+            let inputFrameCapacity = adaptiveInputSamples.count / channelCount
+            let outputFrameCapacity = outputSamples.count / channelCount
+            let chunkFrameCapacity = max(inputFrameCapacity - 8, 1)
+            guard inputFrameCapacity > 8, outputFrameCapacity >= frameCount else {
+                return .failed
+            }
+
+            var outputFrameOffset = 0
+            while outputFrameOffset < frameCount {
+                let chunkFrames = min(frameCount - outputFrameOffset, chunkFrameCapacity)
+                let plan = playbackResampler.inputPlan(outputFrames: chunkFrames, ratio: ratio)
+                guard plan.combinedFrames <= inputFrameCapacity else {
+                    playbackResampler.reset()
+                    return .failed
+                }
+
+                var readFrames = 0
+                var copiedRetainedSamples = false
+                var rendered = false
+                adaptiveInputSamples.withUnsafeMutableBufferPointer { inputSamples in
+                    copiedRetainedSamples = playbackResampler.copyRetainedSamples(into: inputSamples, plan: plan)
+                    guard copiedRetainedSamples, let inputBase = inputSamples.baseAddress else {
+                        return
+                    }
+                    let newInputSamples = UnsafeMutableBufferPointer(
+                        start: inputBase.advanced(by: plan.prefixFrames * channelCount),
+                        count: plan.newFrames * channelCount
+                    )
+                    readFrames = ringBuffer.readInterleaved(
+                        into: newInputSamples,
+                        frameCount: plan.newFrames,
+                        destinationChannelCount: channelCount
+                    )
+                    guard readFrames == plan.newFrames else {
+                        return
+                    }
+
+                    let outputChunk = UnsafeMutableBufferPointer(
+                        start: outputSamples.baseAddress?.advanced(
+                            by: outputFrameOffset * channelCount
+                        ),
+                        count: chunkFrames * channelCount
+                    )
+                    rendered = playbackResampler.render(
+                        input: inputSamples,
+                        plan: plan,
+                        output: outputChunk,
+                        outputFrames: chunkFrames,
+                        ratio: ratio
+                    )
+                }
+
+                guard copiedRetainedSamples else {
+                    playbackResampler.reset()
+                    return .failed
+                }
+                guard readFrames == plan.newFrames else {
+                    playbackResampler.reset()
+                    return .underrun(frames: max(plan.newFrames - readFrames, 1))
+                }
+                guard rendered else {
+                    playbackResampler.reset()
+                    return .failed
+                }
+                outputFrameOffset += chunkFrames
+            }
+
+            return .rendered
+        }
+
+        private func renderSampleRateConvertedPlayback(
+            outputBuffers: UnsafeMutableAudioBufferListPointer,
+            frameCount: Int,
+            ratio: Double,
+            destinationLeftChannel: Int,
+            destinationRightChannel: Int
+        ) -> AdaptivePlaybackRenderResult {
+            guard let sampleRateConverter = playbackSampleRateConverter,
+                  frameCount <= adaptiveOutputSamples.count / channelCount,
+                  let outputBase = adaptiveOutputSamples.baseAddress else {
+                clear(outputBuffers: outputBuffers)
+                return .failed
+            }
+
+            sampleRateConverterInputRatio = ratio
+            sampleRateConverterInputResult = .rendered
+            var convertedFrameCount = UInt32(frameCount)
+            var convertedData = AudioBufferList(
+                mNumberBuffers: 1,
+                mBuffers: AudioBuffer(
+                    mNumberChannels: UInt32(channelCount),
+                    mDataByteSize: UInt32(frameCount * channelCount * MemoryLayout<Float>.size),
+                    mData: outputBase
+                )
+            )
+            let status = withUnsafeMutablePointer(to: &convertedData) { outputData in
+                sampleRateConverter.fill(
+                    inputProc: Self.sampleRateConverterInputProc,
+                    inputContext: Unmanaged.passUnretained(self).toOpaque(),
+                    outputFrames: &convertedFrameCount,
+                    outputData: outputData
+                )
+            }
+            guard status == noErr else {
+                clear(outputBuffers: outputBuffers)
+                return switch sampleRateConverterInputResult {
+                case .rendered:
+                    .failed
+                case .underrun(let frames):
+                    .underrun(frames: frames)
+                case .failed:
+                    .failed
+                }
+            }
+            guard convertedFrameCount == frameCount else {
+                clear(outputBuffers: outputBuffers)
+                return .failed
+            }
+
+            let outputSamples = UnsafeBufferPointer(
+                start: outputBase,
+                count: frameCount * channelCount
+            )
+            writeInterleaved(
+                outputSamples,
+                sourceFrameOffset: 0,
+                destinationFrameOffset: 0,
+                frameCount: frameCount,
+                sourceChannelCount: channelCount,
+                destinationLeftChannel: destinationLeftChannel,
+                destinationRightChannel: destinationRightChannel,
+                to: outputBuffers
+            )
+            return .rendered
+        }
+
+        private static let sampleRateConverterInputProc: AudioConverterComplexInputDataProcRealtimeSafe = {
+            _, requestedFrames, inputData, packetDescriptions, context in
+            guard let context else {
+                requestedFrames.pointee = 0
+                return kAudioConverterErr_UnspecifiedError
+            }
+            packetDescriptions?.pointee = nil
+            return Unmanaged<AudioRuntime>
+                .fromOpaque(context)
+                .takeUnretainedValue()
+                .provideSampleRateConverterInput(
+                    requestedFrames: requestedFrames,
+                    inputData: inputData
+                )
+        }
+
+        private func provideSampleRateConverterInput(
+            requestedFrames: UnsafeMutablePointer<UInt32>,
+            inputData: UnsafeMutablePointer<AudioBufferList>
+        ) -> OSStatus {
+            let frameCount = Int(requestedFrames.pointee)
+            guard frameCount > 0,
+                  frameCount <= sampleRateConverterInputSamples.count / channelCount,
+                  let inputBase = sampleRateConverterInputSamples.baseAddress else {
+                requestedFrames.pointee = 0
+                sampleRateConverterInputResult = .failed
+                return kAudioConverterErr_InvalidInputSize
+            }
+
+            let inputSamples = UnsafeMutableBufferPointer(
+                start: inputBase,
+                count: frameCount * channelCount
+            )
+            let result = renderAdaptiveFrames(
+                into: inputSamples,
+                frameCount: frameCount,
+                ratio: sampleRateConverterInputRatio
+            )
+            sampleRateConverterInputResult = result
+            guard case .rendered = result else {
+                requestedFrames.pointee = 0
+                return kAudioConverterErr_UnspecifiedError
+            }
+
+            inputData.pointee = AudioBufferList(
+                mNumberBuffers: 1,
+                mBuffers: AudioBuffer(
+                    mNumberChannels: UInt32(channelCount),
+                    mDataByteSize: UInt32(frameCount * channelCount * MemoryLayout<Float>.size),
+                    mData: inputBase
+                )
+            )
+            return noErr
+        }
+
+        private func publishAdaptivePlaybackMetrics() {
+            playbackRateCorrectionPartsPerBillion.store(
+                Int64((playbackRateServo.correctionPartsPerMillion * 1_000).rounded()),
+                ordering: .relaxed
+            )
+            playbackRateCorrectionSaturated.store(
+                playbackRateServo.correctionIsSaturated,
+                ordering: .relaxed
+            )
+            filteredPlaybackOccupancyMilliFrames.store(
+                Int64((playbackRateServo.filteredOccupancyFrames * 1_000).rounded()),
+                ordering: .relaxed
+            )
+        }
+
+        func clear(outputData: UnsafeMutablePointer<AudioBufferList>) {
+            clear(outputBuffers: UnsafeMutableAudioBufferListPointer(outputData))
+        }
+
+        private func clear(outputBuffers: UnsafeMutableAudioBufferListPointer) {
+            for buffer in outputBuffers {
+                guard let data = buffer.mData,
+                      let byteCount = validatedClearByteCount(for: buffer) else {
+                    continue
+                }
+                data.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+            }
+        }
+
+        private func captureBypassed(
+            inputBuffers: UnsafeMutableAudioBufferListPointer,
+            frameCount: Int
+        ) {
+            if let inputSamples = contiguousInterleavedInputBuffer(
+                inputBuffers,
+                frameCount: frameCount,
+                channelCount: channelCount
+            ) {
+                recordWriteResult(
+                    ringBuffer.writeInterleaved(
+                        inputSamples,
+                        frameCount: frameCount,
+                        sourceChannelCount: channelCount
+                    )
+                )
+            } else {
+                captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
+                    let scratchFrames = max(scratch.count / channelCount, 1)
+                    var frameOffset = 0
+                    while frameOffset < frameCount {
+                        let chunkFrames = min(frameCount - frameOffset, scratchFrames)
+                        let chunkSamples = UnsafeMutableBufferPointer(
+                            start: scratch.baseAddress,
+                            count: chunkFrames * channelCount
+                        )
+                        copyInput(
+                            from: inputBuffers,
+                            sourceFrameOffset: frameOffset,
+                            into: chunkSamples,
+                            frameCount: chunkFrames,
+                            channelCount: channelCount
+                        )
+                        recordWriteResult(
+                            ringBuffer.writeInterleaved(
+                                UnsafeBufferPointer(chunkSamples),
+                                frameCount: chunkFrames,
+                                sourceChannelCount: channelCount
+                            )
+                        )
+                        frameOffset += chunkFrames
+                    }
+                }
+            }
+
+            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
+            capturedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+        }
+
+        private func recordWriteResult(_ result: RingBufferWriteResult) {
+            if result.droppedInputFrames > 0 {
+                droppedInputFrames.wrappingAdd(UInt64(result.droppedInputFrames), ordering: .relaxed)
+            }
+            if result.droppedBufferedFrames > 0 {
+                droppedBufferedFrames.wrappingAdd(UInt64(result.droppedBufferedFrames), ordering: .relaxed)
+            }
+        }
+
+        private func applyPendingDSPConfig() {
+            let rawPointer = pendingDSPConfigPointer.exchange(0, ordering: .acquiringAndReleasing)
+            guard rawPointer != 0 else {
+                return
+            }
+
+            let pointer = UnsafeRawPointer(bitPattern: rawPointer)!
+            let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
+            box.retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(box.config)
+            pushRetiredDSPConfigBox(rawPointer)
+        }
+
+        private func pushRetiredDSPConfigBox(_ rawPointer: UInt) {
+            guard rawPointer != 0,
+                  let pointer = UnsafeRawPointer(bitPattern: rawPointer) else {
+                return
+            }
+            let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
+            var head = retiredDSPConfigHeadPointer.load(ordering: .acquiring)
+            while true {
+                box.nextRetiredPointer = head
+                let result = retiredDSPConfigHeadPointer.compareExchange(
+                    expected: head,
+                    desired: rawPointer,
+                    ordering: .acquiringAndReleasing
+                )
+                if result.exchanged {
+                    return
+                }
+                head = result.original
+            }
+        }
+
+        private func releaseDSPConfigBox(_ rawPointer: UInt) {
+            guard rawPointer != 0,
+                  let pointer = UnsafeRawPointer(bitPattern: rawPointer) else {
+                return
+            }
+            Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).release()
+        }
+
+        private func updateMaxBufferedFrames(_ occupancy: Int) {
+            updateMax(maxBufferedFrames, occupancy)
+        }
+
+        private func updateMax(_ counter: borrowing Atomic<Int>, _ value: Int) {
+            var current = counter.load(ordering: .relaxed)
+            while value > current {
+                let result = counter.compareExchange(
+                    expected: current,
+                    desired: value,
+                    ordering: .relaxed
+                )
+                if result.exchanged {
+                    return
+                }
+                current = result.original
+            }
+        }
+
+        private func recordPlaybackBufferedFrames(_ frames: Int) {
+            totalPlaybackBufferedFrames.wrappingAdd(UInt64(max(frames, 0)), ordering: .relaxed)
+            playbackBufferObservations.wrappingAdd(1, ordering: .relaxed)
+            updateMax(maxPlaybackBufferedFrames, frames)
+
+            var current = minPlaybackBufferedFrames.load(ordering: .relaxed)
+            while frames < current {
+                let result = minPlaybackBufferedFrames.compareExchange(
+                    expected: current,
+                    desired: frames,
+                    ordering: .relaxed
+                )
+                if result.exchanged {
+                    return
+                }
+                current = result.original
+            }
+        }
+
+        private func inputFrameCount(_ buffers: UnsafeMutableAudioBufferListPointer) -> Int? {
+            guard let buffer = buffers.first else {
+                return 0
+            }
+            guard validatedClearByteCount(for: buffer) != nil else {
+                return nil
+            }
+            let channels = Int(buffer.mNumberChannels)
+            let bytesPerFrame = MemoryLayout<Float>.stride * channels
+            let frameCount = Int(buffer.mDataByteSize) / bytesPerFrame
+            guard frameCount <= maxCallbackFrames else {
+                return nil
+            }
+            return frameCount
+        }
+
+        private func outputFrameCount(_ buffers: UnsafeMutableAudioBufferListPointer) -> Int? {
+            guard let buffer = buffers.first else {
+                return 0
+            }
+            guard validatedClearByteCount(for: buffer) != nil else {
+                return nil
+            }
+            let channels = Int(buffer.mNumberChannels)
+            let bytesPerFrame = MemoryLayout<Float>.stride * channels
+            let frameCount = Int(buffer.mDataByteSize) / bytesPerFrame
+            guard frameCount <= maxCallbackFrames else {
+                return nil
+            }
+            return frameCount
+        }
+
+        private func validatedClearByteCount(for buffer: AudioBuffer) -> Int? {
+            guard buffer.mData != nil else {
+                return nil
+            }
+            let channels = Int(buffer.mNumberChannels)
+            guard channels > 0,
+                  channels <= CoreAudioDeviceQuery.maxChannelCount else {
+                return nil
+            }
+            let bytesPerFrame = MemoryLayout<Float>.stride * channels
+            let byteCount = Int(buffer.mDataByteSize)
+            guard byteCount >= 0,
+                  byteCount % bytesPerFrame == 0 else {
+                return nil
+            }
+            let frameCount = byteCount / bytesPerFrame
+            guard frameCount <= maxCallbackFrames else {
+                return nil
+            }
+            return byteCount
+        }
+
+        private func copyInput(
+            from buffers: UnsafeMutableAudioBufferListPointer,
+            sourceFrameOffset: Int,
+            into samples: UnsafeMutableBufferPointer<Float>,
+            frameCount: Int,
+            channelCount: Int
+        ) {
+            if buffers.count == 1,
+               let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+               Int(buffers[0].mNumberChannels) == channelCount,
+               frameCount > 0,
+               sourceFrameOffset >= 0 {
+                let sourceSampleStart = sourceFrameOffset * channelCount
+                let copySamples = frameCount * channelCount
+                let availableSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+                if samples.count >= copySamples,
+                   sourceSampleStart + copySamples <= availableSamples,
+                   let destination = samples.baseAddress {
+                    destination.update(from: data.advanced(by: sourceSampleStart), count: copySamples)
+                    return
+                }
+            }
+
+            for frameIndex in 0..<frameCount {
+                let sourceFrame = sourceFrameOffset + frameIndex
+                let sampleBase = frameIndex * channelCount
+                for channel in 0..<channelCount {
+                    samples[sampleBase + channel] = sample(from: buffers, frame: sourceFrame, channel: channel)
+                }
+            }
+        }
+
+        private func contiguousInterleavedInputBuffer(
+            _ buffers: UnsafeMutableAudioBufferListPointer,
+            frameCount: Int,
+            channelCount: Int
+        ) -> UnsafeBufferPointer<Float>? {
+            guard buffers.count == 1,
+                  frameCount > 0,
+                  Int(buffers[0].mNumberChannels) == channelCount,
+                  let data = buffers[0].mData?.assumingMemoryBound(to: Float.self) else {
+                return nil
+            }
+            let sampleCount = frameCount * channelCount
+            guard sampleCount <= Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride else {
+                return nil
+            }
+            return UnsafeBufferPointer(start: data, count: sampleCount)
+        }
+
+        private func sample(
+            from buffers: UnsafeMutableAudioBufferListPointer,
+            frame: Int,
+            channel: Int
+        ) -> Float {
+            if buffers.count == 1,
+               let data = buffers[0].mData?.assumingMemoryBound(to: Float.self) {
+                let channelCount = max(Int(buffers[0].mNumberChannels), 1)
+                let index = frame * channelCount + min(channel, channelCount - 1)
+                guard index >= 0,
+                      index < Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride else {
+                    return 0
+                }
+                return data[index]
+            }
+
+            let bufferIndex = min(channel, buffers.count - 1)
+            guard bufferIndex >= 0,
+                  let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self),
+                  frame >= 0,
+                  frame < Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride else {
+                return 0
+            }
+            return data[frame]
+        }
+
+        private func writeInterleaved(
+            _ samples: UnsafeBufferPointer<Float>,
+            sourceFrameOffset: Int,
+            destinationFrameOffset: Int,
+            frameCount: Int,
+            sourceChannelCount: Int,
+            destinationLeftChannel: Int,
+            destinationRightChannel: Int,
+            to buffers: UnsafeMutableAudioBufferListPointer
+        ) {
+            SeparateClockAudioBackend.copyInterleavedSamples(
+                samples,
+                sourceFrameOffset: sourceFrameOffset,
+                destinationFrameOffset: destinationFrameOffset,
+                frameCount: frameCount,
+                sourceChannelCount: sourceChannelCount,
+                destinationLeftChannel: destinationLeftChannel,
+                destinationRightChannel: destinationRightChannel,
+                to: buffers
+            )
+        }
+
+        private func enter(_ gate: borrowing Atomic<Bool>) -> Bool {
+            gate.compareExchange(
+                expected: false,
+                desired: true,
+                ordering: .acquiringAndReleasing
+            ).exchanged
+        }
+    }
+
+    private let control = Mutex(ControlState())
+    private let playbackBufferRenegotiationHandler = Mutex<(@Sendable (PlaybackBufferRenegotiation) -> Void)?>(nil)
+    private let runtimeFailureHandler = Mutex<(@Sendable (AudioEngineFailure) -> Void)?>(nil)
+    private let restorationStoreURL: URL
+    private let playbackBufferCalibrationStoreURL: URL
+    private let playbackBufferAdaptationQueue = DispatchQueue(
+        label: "com.glasseq.playback-buffer-adaptation",
+        qos: .userInitiated
+    )
+    private let playbackBufferAdaptationQueueKey = DispatchSpecificKey<Void>()
+    private let playbackBufferAdaptationTimer: DispatchSourceTimer
+    private let playbackBufferAdaptationTimerRunning = Mutex(false)
+
+    public var state: AudioEngineState {
+        control.withLock { $0.state }
+    }
+
+    public var status: AudioEngineStatus {
+        control.withLock { $0.status }
+    }
+
+    func activeOutputAndProfile() -> (output: AudioOutputDevice, profile: EQProfile)? {
+        control.withLock { state in
+            guard case .running = state.state,
+                  let output = state.activeOutput,
+                  let profile = state.activeProfile else {
+                return nil
+            }
+            return (output, profile)
+        }
+    }
+
+    public init(restorationStoreURL: URL? = nil) {
+        let restorationStoreURL = restorationStoreURL ?? PersistedAudioDeviceRestorationStore.defaultURL()
+        self.restorationStoreURL = restorationStoreURL
+        self.playbackBufferCalibrationStoreURL = PersistedPlaybackBufferCalibrationStore.defaultURL(
+            nextTo: restorationStoreURL
+        )
+        let timer = DispatchSource.makeTimerSource(queue: playbackBufferAdaptationQueue)
+        self.playbackBufferAdaptationTimer = timer
+        playbackBufferAdaptationQueue.setSpecific(key: playbackBufferAdaptationQueueKey, value: ())
+        Self.restorePersistedDeviceSettings(at: restorationStoreURL)
+        timer.setEventHandler { [weak self] in
+            self?.serviceAdaptivePlaybackBuffering()
+        }
+        timer.schedule(deadline: .now() + .milliseconds(250), repeating: .milliseconds(250), leeway: .milliseconds(50))
+    }
+
+    deinit {
+        stop()
+        playbackBufferAdaptationTimer.setEventHandler {}
+        playbackBufferAdaptationTimerRunning.withLock { isRunning in
+            if !isRunning {
+                playbackBufferAdaptationTimer.resume()
+            }
+            isRunning = false
+        }
+        playbackBufferAdaptationTimer.cancel()
+    }
+
+    public func start(output: AudioOutputDevice, profile: EQProfile) throws {
+        try start(output: output, profile: profile, expectation: nil)
+    }
+
+    func prepareOutputForHandoff(
+        output: AudioOutputDevice,
+        profile: EQProfile
+    ) throws {
+        pausePlaybackBufferAdaptation()
+        defer {
+            updatePlaybackBufferAdaptationTimer()
+        }
+
+        do {
+            var preparation = try control.withLock { state in
+                guard state.outputIOProcID == nil,
+                      state.preparedOutputHandoff == nil else {
+                    throw SeparateClockAudioEngineInternalError(
+                        message: "The compatibility output is already active."
+                    )
+                }
+                state.status = .starting
+                try ensureCaptureHalfLocked(&state, output: output, profile: profile)
+                state.profileRevision &+= 1
+                return try prepareOutputRebuildLocked(
+                    &state,
+                    output: output,
+                    profile: profile,
+                    profileRevision: state.profileRevision
+                )
+            }
+            let refreshedOutput = try CoreAudioDeviceQuery.outputDevice(id: preparation.output.id)
+            preparation.output = refreshedOutput
+            preparation.originalBufferFrameSize = refreshedOutput.bufferFrameSize
+            try control.withLock { state in
+                guard state.outputRebuildGeneration == preparation.generation,
+                      state.runtime === preparation.runtime,
+                      state.captureRunning else {
+                    throw StaleOutputRebuild()
+                }
+                if Self.shouldRecordSampleRateRestoration(
+                    tapSampleRate: preparation.tapSampleRate,
+                    output: refreshedOutput
+                ) {
+                    try recordSampleRateRestorationIfNeeded(for: refreshedOutput, state: &state)
+                }
+            }
+            let matchedOutput = try preparePlaybackOutput(
+                tapSampleRate: preparation.tapSampleRate,
+                output: preparation.output
+            )
+            try control.withLock { state in
+                state.preparedOutputHandoff = try prepareOutputHandoffLocked(
+                    &state,
+                    preparation: preparation,
+                    matchedOutput: matchedOutput
+                )
+            }
+        } catch {
+            control.withLock { state in
+                stopLocked(&state)
+            }
+            throw error
+        }
+    }
+
+    @discardableResult
+    func activatePreparedOutputHandoff() throws -> AudioOutputDevice {
+        pausePlaybackBufferAdaptation()
+        defer {
+            updatePlaybackBufferAdaptationTimer()
+        }
+
+        do {
+            let result = try control.withLock {
+                state -> (AudioOutputDevice, PlaybackBufferCalibrationProbe?) in
+                guard let handoff = state.preparedOutputHandoff else {
+                    throw SeparateClockAudioEngineInternalError(
+                        message: "The compatibility output was not prepared."
+                    )
+                }
+                state.preparedOutputHandoff = nil
+                let output = try activatePreparedOutputHandoffLocked(
+                    &state,
+                    handoff: handoff
+                )
+                state.state = .running(output: output)
+                state.status = .running(output: output)
+                return (output, state.playbackBufferCalibrationProbe)
+            }
+            if let probe = result.1 {
+                try? PersistedPlaybackBufferCalibrationStore.beginProbe(
+                    outputUID: probe.outputUID,
+                    sampleRate: probe.sampleRate,
+                    tapSampleRate: probe.tapSampleRate,
+                    frameSize: probe.frameSize,
+                    targetFrames: probe.targetFrames,
+                    at: playbackBufferCalibrationStoreURL
+                )
+            }
+            return result.0
+        } catch {
+            control.withLock { state in
+                stopLocked(&state)
+                let failure = audioEngineFailure(from: error)
+                state.state = .failed(failure.description)
+                state.status = .failed(failure)
+            }
+            throw error
+        }
+    }
+
+    func quiesceOutputForCombinedHandoff() {
+        pausePlaybackBufferAdaptation()
+        control.withLock { state in
+            state.runtime?.muteOutputForTransition()
+            stopOutputHalfLocked(&state)
+            state.state = .stopped
+            state.status = .starting
+        }
+    }
+
+    func completeCombinedHandoff() {
+        control.withLock { state in
+            stopLocked(&state)
+        }
+        updatePlaybackBufferAdaptationTimer()
+    }
+
+    private func start(
+        output: AudioOutputDevice,
+        profile: EQProfile,
+        expectation: OutputRebuildExpectation?
+    ) throws {
+        pausePlaybackBufferAdaptation()
+        defer {
+            updatePlaybackBufferAdaptationTimer()
+        }
+        var previousState = AudioEngineState.stopped
+        var previousStatus = AudioEngineStatus.stopped
+        var activePreparation: OutputRebuildPreparation?
+
+        do {
+            var preparation = try control.withLock { state in
+                if let expectation {
+                    guard state.outputRebuildGeneration == expectation.generation,
+                          state.runtime === expectation.runtime,
+                          state.activeOutput?.uid == output.uid else {
+                        throw StaleOutputRebuild()
+                    }
+                }
+                guard let requestedProfile = Self.requestedOutputRebuildProfile(
+                    requestedProfile: profile,
+                    expectedProfileRevision: expectation?.profileRevision,
+                    activeProfile: state.activeProfile,
+                    activeProfileRevision: state.profileRevision
+                ) else {
+                    throw StaleProfileRequest()
+                }
+                previousState = state.state
+                previousStatus = state.status
+                state.status = .starting
+                // Keep capture alive across ordinary output switches. Leaving a low-rate route
+                // refreshes it under the same mute guard used for topology changes so normal
+                // outputs regain their full capture bandwidth without leaking dry audio.
+                try ensureCaptureHalfLocked(&state, output: output, profile: requestedProfile)
+                state.profileRevision &+= 1
+                return try prepareOutputRebuildLocked(
+                    &state,
+                    output: output,
+                    profile: requestedProfile,
+                    profileRevision: state.profileRevision
+                )
+            }
+            let refreshedOutput = try CoreAudioDeviceQuery.outputDevice(id: preparation.output.id)
+            preparation.output = refreshedOutput
+            preparation.originalBufferFrameSize = refreshedOutput.bufferFrameSize
+            activePreparation = preparation
+            try control.withLock { state in
+                guard state.outputRebuildGeneration == preparation.generation,
+                      state.runtime === preparation.runtime,
+                      state.captureRunning else {
+                    throw StaleOutputRebuild()
+                }
+                if Self.shouldRecordSampleRateRestoration(
+                    tapSampleRate: preparation.tapSampleRate,
+                    output: refreshedOutput
+                ) {
+                    try recordSampleRateRestorationIfNeeded(for: refreshedOutput, state: &state)
+                }
+            }
+            let matchedOutput = try preparePlaybackOutput(
+                tapSampleRate: preparation.tapSampleRate,
+                output: preparation.output
+            )
+            let calibrationProbe = try control.withLock { state -> PlaybackBufferCalibrationProbe? in
+                try finishOutputRebuildLocked(&state, preparation: preparation, matchedOutput: matchedOutput)
+                let active = state.activeOutput ?? output
+                state.state = .running(output: active)
+                state.status = .running(output: active)
+                return state.playbackBufferCalibrationProbe
+            }
+            if let calibrationProbe {
+                try? PersistedPlaybackBufferCalibrationStore.beginProbe(
+                    outputUID: calibrationProbe.outputUID,
+                    sampleRate: calibrationProbe.sampleRate,
+                    tapSampleRate: calibrationProbe.tapSampleRate,
+                    frameSize: calibrationProbe.frameSize,
+                    targetFrames: calibrationProbe.targetFrames,
+                    at: playbackBufferCalibrationStoreURL
+                )
+            }
+        } catch is StaleOutputRebuild {
+            return
+        } catch is StaleProfileRequest {
+            return
+        } catch {
+            var shouldRethrow = true
+            control.withLock { state in
+                if let activePreparation,
+                   state.outputRebuildGeneration != activePreparation.generation {
+                    shouldRethrow = false
+                    return
+                }
+                if error is TopologyRebuildMuteGuardUnavailable {
+                    state.state = previousState
+                    state.status = previousStatus
+                    return
+                }
+                let failure = audioEngineFailure(from: error)
+                // Any failure tears the tap down too, so the system is never left muted
+                // with nothing replaying.
+                stopLocked(&state)
+                state.state = .failed(failure.description)
+                if failure.category == .systemAudioCapturePermission {
+                    state.status = .permissionRequired(failure)
+                } else {
+                    state.status = .failed(failure)
+                }
+            }
+            if shouldRethrow {
+                throw error
+            }
+        }
+    }
+
+    public func update(profile: EQProfile) throws {
+        // Prefer a lock-free hot-swap that leaves the persistent tap untouched.
+        if updateDSP(profile: profile) {
+            return
+        }
+        // Topology-incompatible change: rebuild around the persistent tap (the tap rate is
+        // constant, so start() keeps the capture half and only swaps the DSP graph + output).
+        let output = try Self.profileUpdateOutput(control.withLock { $0.activeOutput })
+        let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
+        try start(output: freshOutput, profile: profile)
+        let didApplyProfile = control.withLock { state in
+            state.activeProfile == profile
+        }
+        guard didApplyProfile else {
+            throw TopologyRebuildMuteGuardUnavailable(
+                underlyingError: SeparateClockAudioEngineInternalError(message: "Profile rebuild was not applied.")
+            )
+        }
+    }
+
+    @discardableResult
+    public func updateDSP(profile: EQProfile) -> Bool {
+        control.withLock { state in
+            updateDSPLocked(&state, profile: profile)
+        }
+    }
+
+    private func updateDSPLocked(
+        _ state: inout ControlState,
+        profile: EQProfile,
+        incrementsProfileRevision: Bool = true
+    ) -> Bool {
+        guard let runtime = state.runtime,
+              let activeProfile = state.activeProfile else {
+            return false
+        }
+        let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+            sampleRate: state.activeOutput?.nominalSampleRate ?? runtime.sampleRate
+        )
+
+        guard Self.canHotSwapDSP(
+            from: activeProfile,
+            to: profile,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ) else {
+            return false
+        }
+
+        let preparedConfig = EQRenderConfiguration(
+            profile: Self.dspProfile(from: profile),
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        )
+        runtime.drainDSPConfigBoxes()
+        runtime.publishPendingDSPConfig(preparedConfig)
+        runtime.setBypassed(profile.isBypassed)
+        state.activeProfile = profile
+        if incrementsProfileRevision {
+            state.profileRevision &+= 1
+        }
+        return true
+    }
+
+    static func canHotSwapDSP(
+        from activeProfile: EQProfile,
+        to nextProfile: EQProfile,
+        sampleRate: Double,
+        channelCount: Int,
+        maximumUsableFrequency: Double? = nil
+    ) -> Bool {
+        guard activeProfile.mode == nextProfile.mode,
+              activeProfile.channelMode == nextProfile.channelMode else {
+            return false
+        }
+
+        return EQRenderConfiguration(
+            profile: Self.dspProfile(from: nextProfile),
+            sampleRate: sampleRate,
+            channelCount: channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ).hasRealtimeCompatibleTopology(
+            with: EQRenderConfiguration(
+                profile: Self.dspProfile(from: activeProfile),
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            )
+        )
+    }
+
+    public func setBypassed(_ isBypassed: Bool) {
+        control.withLock { state in
+            state.runtime?.setBypassed(isBypassed)
+            state.activeProfile?.isBypassed = isBypassed
+            state.profileRevision &+= 1
+        }
+    }
+
+    public func muteOutputForTransition() {
+        control.withLock { state in
+            state.runtime?.muteOutputForTransition()
+        }
+    }
+
+    public func stop() {
+        pausePlaybackBufferAdaptation()
+        control.withLock { state in
+            stopLocked(&state)
+        }
+        updatePlaybackBufferAdaptationTimer()
+    }
+
+    public func snapshotMetrics() -> AudioEngineMetrics {
+        let runtime = control.withLock { $0.runtime }
+        return runtime?.snapshotMetrics() ?? AudioEngineMetrics()
+    }
+
+    public func resetDiagnostics() {
+        let runtime = control.withLock { $0.runtime }
+        runtime?.resetMetrics()
+    }
+
+    public func resetPlaybackBufferCalibration(forOutputUID outputUID: String) throws {
+        guard !outputUID.isEmpty else {
+            return
+        }
+        pausePlaybackBufferAdaptation()
+        defer {
+            updatePlaybackBufferAdaptationTimer()
+        }
+        try PersistedPlaybackBufferCalibrationStore.removeCalibrations(
+            outputUID: outputUID,
+            at: playbackBufferCalibrationStoreURL
+        )
+        let activeOutputAndProfile = control.withLock {
+            state -> (AudioOutputDevice, EQProfile, OutputRebuildExpectation)? in
+            if state.playbackBufferCalibrationProbe?.outputUID == outputUID {
+                state.playbackBufferCalibrationProbe = nil
+            }
+            state.playbackBufferStableSince = nil
+            state.playbackBufferAdaptationEvidence.resetUnderrunEpisodes()
+            state.playbackBufferInstabilityPersistenceGate.reset(outputUID: outputUID)
+            state.failedPlaybackFrameSizeDecayCandidates = Set(
+                state.failedPlaybackFrameSizeDecayCandidates.filter { $0.outputUID != outputUID }
+            )
+            guard let output = state.activeOutput,
+                  output.uid == outputUID,
+                  let profile = state.activeProfile else {
+                return nil
+            }
+            guard let runtime = state.runtime else {
+                return nil
+            }
+            return (
+                output,
+                profile,
+                OutputRebuildExpectation(
+                    generation: state.outputRebuildGeneration,
+                    runtime: runtime,
+                    profileRevision: state.profileRevision
+                )
+            )
+        }
+        if let (activeOutput, activeProfile, expectation) = activeOutputAndProfile {
+            let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: activeOutput.id)
+            try start(
+                output: freshOutput,
+                profile: activeProfile,
+                expectation: expectation
+            )
+        }
+    }
+
+    public func setPlaybackBufferRenegotiationHandler(
+        _ handler: (@Sendable (PlaybackBufferRenegotiation) -> Void)?
+    ) {
+        playbackBufferRenegotiationHandler.withLock { currentHandler in
+            currentHandler = handler
+        }
+    }
+
+    public func setRuntimeFailureHandler(
+        _ handler: (@Sendable (AudioEngineFailure) -> Void)?
+    ) {
+        runtimeFailureHandler.withLock { currentHandler in
+            currentHandler = handler
+        }
+    }
+
+    private func stopLocked(_ state: inout ControlState) {
+        state.runtime?.markStopping()
+        stopOutputHalfLocked(&state)
+        stopCaptureHalfLocked(&state)
+        state.activeProfile = nil
+        state.profileRevision &+= 1
+        state.playbackBufferAdaptationEvidence = PlaybackBufferAdaptationEvidence()
+        state.playbackBufferStableSince = nil
+        state.adaptivePlaybackRenderRecoveryAttempts = 0
+        state.adaptivePlaybackRenderRecoveryHealthGeneration = nil
+        state.playbackBufferInstabilityPersistenceGate.reset()
+        state.failedPlaybackFrameSizeDecayCandidates.removeAll()
+        state.state = .stopped
+        state.status = .stopped
+    }
+
+    // MARK: - Capture half (persistent global muted tap @ the tap rate)
+
+    private func ensureCaptureHalfLocked(
+        _ state: inout ControlState,
+        output: AudioOutputDevice,
+        profile: EQProfile
+    ) throws {
+        if state.captureRunning, state.runtime != nil {
+            let shouldRefreshCapture = Self.shouldRefreshCaptureForOutput(
+                tapSampleRate: state.tapSampleRate,
+                output: output
+            )
+            if !shouldRefreshCapture,
+               updateDSPLocked(&state, profile: profile, incrementsProfileRevision: false) {
+                return
+            }
+            // Hold a second global muted tap while capture is recreated, so HAL-level muting
+            // never lapses during topology changes or low-rate capture refreshes.
+            try Self.performTopologyRebuild(
+                acquireMuteGuard: { try createTopologyRebuildMuteGuard() }
+            ) {
+                stopOutputHalfLocked(&state)
+                stopCaptureHalfLocked(&state)
+                try createCaptureHalfLocked(&state, profile: profile)
+            }
+            return
+        }
+        try createCaptureHalfLocked(&state, profile: profile)
+    }
+
+    private func createCaptureHalfLocked(_ state: inout ControlState, profile: EQProfile) throws {
+        let tapID = try createSystemTap()
+        state.tapID = tapID
+
+        let format = try tapStreamFormat(tapID)
+        let tapSampleRate = format.mSampleRate > 0 ? format.mSampleRate : 48_000
+        let tapChannelCount = min(max(Int(format.mChannelsPerFrame), 1), 2)
+        state.tapSampleRate = tapSampleRate
+        state.tapChannelCount = tapChannelCount
+
+        let runtimeBufferFrameSize = Int(Self.maximumRuntimeBufferFrameSize)
+        // Low-latency tuning: a 128-frame prime (~2.7 ms @ 48k) — about 2x the tap's callback
+        // once we request a 64-frame capture buffer below. Capacity is sized from the largest
+        // runtime output callback so every supported prime retains equal drift headroom.
+        let playbackPrimeFrames = Self.preferredPlaybackPrimeFrames
+        let ringCapacityFrames = Self.runtimeRingCapacityFrames
+        let scratchFrames = max(runtimeBufferFrameSize, Self.minimumRingBufferFrames)
+
+        state.aggregateDeviceID = try createPrivateAggregateDevice(tapID: tapID)
+        // Ask the capture aggregate for small callbacks to cut latency. The write is best-effort,
+        // so size the initial playback reservoir from the value the aggregate actually reports.
+        try? CoreAudioDeviceQuery.setBufferFrameSize(
+            Self.preferredCaptureBufferFrameSize,
+            objectID: state.aggregateDeviceID
+        )
+        let reportedCaptureCallbackFrames = try? CoreAudioDeviceQuery.getUInt32Property(
+            objectID: state.aggregateDeviceID,
+            selector: kAudioDevicePropertyBufferFrameSize,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+        let captureCallbackFrames = Self.startupCaptureCallbackFrames(
+            reportedFrames: reportedCaptureCallbackFrames
+        )
+
+        let runtime = AudioRuntime(
+            profile: profile,
+            sampleRate: tapSampleRate,
+            channelCount: tapChannelCount,
+            ringCapacityFrames: ringCapacityFrames,
+            scratchFrames: scratchFrames,
+            captureCallbackFrames: captureCallbackFrames,
+            playbackPrimeFrames: playbackPrimeFrames
+        )
+        state.runtime = runtime
+        state.activeProfile = profile
+
+        state.captureIOProcID = try createCaptureIOProc(deviceID: state.aggregateDeviceID, runtime: runtime)
+        try checkOSStatus(
+            AudioDeviceStart(state.aggregateDeviceID, state.captureIOProcID),
+            operation: "AudioDeviceStart(capture tap)"
+        )
+        state.captureRunning = true
+    }
+
+    private func stopCaptureHalfLocked(_ state: inout ControlState) {
+        state.runtime?.markStopping()
+
+        if state.aggregateDeviceID != kAudioObjectUnknown, let captureIOProcID = state.captureIOProcID {
+            _ = AudioDeviceStop(state.aggregateDeviceID, captureIOProcID)
+            _ = AudioDeviceDestroyIOProcID(state.aggregateDeviceID, captureIOProcID)
+        }
+        if state.aggregateDeviceID != kAudioObjectUnknown {
+            _ = AudioHardwareDestroyAggregateDevice(state.aggregateDeviceID)
+        }
+        if state.tapID != kAudioObjectUnknown {
+            _ = AudioHardwareDestroyProcessTap(state.tapID)
+        }
+
+        state.runtime?.drainDSPConfigBoxes()
+        state.captureIOProcID = nil
+        state.aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        state.tapID = AudioObjectID(kAudioObjectUnknown)
+        state.runtime = nil
+        state.tapSampleRate = 0
+        state.tapChannelCount = 0
+        state.captureRunning = false
+    }
+
+    // MARK: - Output half (swappable; direct-rate or converted low-rate playback)
+
+    private func prepareOutputRebuildLocked(
+        _ state: inout ControlState,
+        output: AudioOutputDevice,
+        profile: EQProfile,
+        profileRevision: UInt64
+    ) throws -> OutputRebuildPreparation {
+        guard let runtime = state.runtime else {
+            throw CoreAudioError(operation: "rebuildOutputHalf(missing runtime)", status: kAudioHardwareNotRunningError)
+        }
+        // Mismatched low-rate endpoints keep their device-owned rates and receive realtime
+        // sample-rate conversion in the playback callback.
+        let originalBufferFrameSize = output.bufferFrameSize
+        _ = try Self.supportedRuntimeChannelCount(for: output)
+        stopOutputHalfLocked(&state)
+        return OutputRebuildPreparation(
+            generation: state.outputRebuildGeneration,
+            output: output,
+            profile: profile,
+            runtime: runtime,
+            tapSampleRate: state.tapSampleRate,
+            originalBufferFrameSize: originalBufferFrameSize,
+            profileRevision: profileRevision
+        )
+    }
+
+    private func finishOutputRebuildLocked(
+        _ state: inout ControlState,
+        preparation: OutputRebuildPreparation,
+        matchedOutput: AudioOutputDevice
+    ) throws {
+        let handoff = try prepareOutputHandoffLocked(
+            &state,
+            preparation: preparation,
+            matchedOutput: matchedOutput
+        )
+        _ = try activatePreparedOutputHandoffLocked(&state, handoff: handoff)
+    }
+
+    private func prepareOutputHandoffLocked(
+        _ state: inout ControlState,
+        preparation: OutputRebuildPreparation,
+        matchedOutput: AudioOutputDevice
+    ) throws -> PreparedOutputHandoff {
+        guard state.outputRebuildGeneration == preparation.generation,
+              state.runtime === preparation.runtime,
+              state.captureRunning else {
+            throw StaleOutputRebuild()
+        }
+        let runtime = preparation.runtime
+        let output = preparation.output
+        let effectiveProfile = Self.effectiveOutputRebuildProfile(
+            preparedProfile: preparation.profile,
+            preparedProfileRevision: preparation.profileRevision,
+            activeProfile: state.activeProfile,
+            activeProfileRevision: state.profileRevision
+        )
+        _ = try Self.supportedRuntimeChannelCount(for: matchedOutput)
+        if state.bufferFrameSizeRestorations[output.uid] == nil {
+            let restoration = BufferFrameSizeRestoration(
+                uid: output.uid,
+                originalFrameSize: preparation.originalBufferFrameSize
+            )
+            try PersistedAudioDeviceRestorationStore.recordBufferFrameSize(
+                uid: restoration.uid,
+                originalFrameSize: restoration.originalFrameSize,
+                at: restorationStoreURL
+            )
+            state.bufferFrameSizeRestorations[output.uid] = restoration
+        }
+
+        // Keep our replay muted while we claim and reconfigure the device. The ORDER matters:
+        // start our output IOProc (so GlassEQ owns the device) BEFORE writing the buffer size.
+        // Writing the buffer size restarts the device's hardware stream; doing it after we own
+        // the device means that restart re-engages our (muted) IOProc instead of briefly
+        // replaying the un-muted system mix. The buffer write's own property-change notification
+        // is ignored via CoreAudioSelfChangeGuard, so it no longer triggers a rebuild loop.
+        runtime.muteOutputForTransition()
+
+        // Multi-channel devices play the stereo stream on their preferred stereo pair (the same
+        // channels macOS routes system audio to); every other channel receives silence. The pair
+        // must be stored before AudioDeviceStart so the first callback already maps correctly.
+        let preferredChannels = try? CoreAudioDeviceQuery.preferredStereoChannels(objectID: matchedOutput.id)
+        let channelPair = Self.playbackStereoPair(
+            preferredChannels: preferredChannels,
+            outputChannelCount: matchedOutput.outputChannelCount
+        )
+        runtime.setPlaybackChannelPair(left: channelPair.left, right: channelPair.right)
+
+        guard let outputIOProcID = try createOutputIOProc(deviceID: matchedOutput.id, runtime: runtime) else {
+            throw CoreAudioError(operation: "AudioDeviceCreateIOProcID(default output)", status: kAudioHardwareUnspecifiedError)
+        }
+        do {
+            let targetFrames = preferredPlaybackTargetFrames(
+                for: matchedOutput,
+                tapSampleRate: runtime.sampleRate,
+                captureCallbackFrames: runtime.maximumKnownCaptureCallbackFrames()
+            )
+            runtime.drainDSPConfigBoxes()
+            runtime.publishPendingDSPConfig(EQRenderConfiguration(
+                profile: Self.dspProfile(from: effectiveProfile),
+                sampleRate: runtime.sampleRate,
+                channelCount: runtime.channelCount,
+                maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
+                    sampleRate: matchedOutput.nominalSampleRate
+                )
+            ))
+            try runtime.configurePlayback(
+                primeFrames: targetFrames,
+                outputSampleRate: matchedOutput.nominalSampleRate
+            )
+        } catch {
+            _ = AudioDeviceDestroyIOProcID(matchedOutput.id, outputIOProcID)
+            throw error
+        }
+
+        return PreparedOutputHandoff(
+            preparation: preparation,
+            output: matchedOutput,
+            profile: effectiveProfile,
+            ioProcID: outputIOProcID
+        )
+    }
+
+    private func activatePreparedOutputHandoffLocked(
+        _ state: inout ControlState,
+        handoff: PreparedOutputHandoff
+    ) throws -> AudioOutputDevice {
+        let preparation = handoff.preparation
+        guard state.outputRebuildGeneration == preparation.generation,
+              state.runtime === preparation.runtime,
+              state.captureRunning else {
+            _ = AudioDeviceDestroyIOProcID(handoff.output.id, handoff.ioProcID)
+            throw StaleOutputRebuild()
+        }
+        let runtime = preparation.runtime
+        do {
+            try checkOSStatus(
+                AudioDeviceStart(handoff.output.id, handoff.ioProcID),
+                operation: "AudioDeviceStart(default output)"
+            )
+        } catch {
+            _ = AudioDeviceDestroyIOProcID(handoff.output.id, handoff.ioProcID)
+            throw error
+        }
+        state.outputIOProcID = handoff.ioProcID
+        // Keep IOProc ownership paired with its device so failure cleanup can stop it.
+        state.activeOutput = handoff.output
+
+        // Now that our output owns the device, apply the low-latency buffer size. The stream
+        // restart it triggers happens under our muted IOProc, so it plays silence, not dry audio.
+        let tunedOutput = tuneBufferFrameSize(
+            for: handoff.output,
+            tapSampleRate: runtime.sampleRate
+        )
+        try Self.validatePlaybackCallbackCapacity(for: tunedOutput)
+        try Self.validatePlaybackConversionCapacity(
+            for: tunedOutput,
+            tapSampleRate: runtime.sampleRate,
+            captureCallbackFrames: runtime.maximumKnownCaptureCallbackFrames()
+        )
+        state.activeOutput = tunedOutput
+        let targetFrames = preferredPlaybackTargetFrames(
+            for: tunedOutput,
+            tapSampleRate: runtime.sampleRate,
+            captureCallbackFrames: runtime.maximumKnownCaptureCallbackFrames()
+        )
+        runtime.retargetPlayback(primeFrames: targetFrames)
+        state.playbackBufferAdaptationEvidence.reset(
+            instabilityGeneration: runtime.playbackInstabilitySnapshot().generation,
+            timestampDiscontinuities: runtime.playbackTimestampDiscontinuityCount()
+        )
+        state.playbackBufferCalibrationProbe = playbackBufferCalibrationProbe(
+            for: tunedOutput,
+            tapSampleRate: runtime.sampleRate,
+            targetFrames: targetFrames
+        )
+        state.playbackBufferStableSince = state.playbackBufferCalibrationProbe == nil
+            ? ContinuousClock().now
+            : nil
+
+        // Unmute and re-anchor playback to the freshest captured audio on the new device.
+        runtime.reprimePlayback()
+
+        state.activeProfile = handoff.profile
+        return tunedOutput
+    }
+
+    private func stopOutputHalfLocked(_ state: inout ControlState) {
+        state.outputRebuildGeneration += 1
+        if let prepared = state.preparedOutputHandoff {
+            _ = AudioDeviceDestroyIOProcID(prepared.output.id, prepared.ioProcID)
+            state.preparedOutputHandoff = nil
+        }
+        if let output = state.activeOutput, let outputIOProcID = state.outputIOProcID {
+            _ = AudioDeviceStop(output.id, outputIOProcID)
+            _ = AudioDeviceDestroyIOProcID(output.id, outputIOProcID)
+        }
+        state.outputIOProcID = nil
+        restoreDeviceSettingsIfNeeded(&state)
+        state.activeOutput = nil
+        state.playbackBufferCalibrationProbe = nil
+    }
+
+    private func forceSampleRate(
+        _ sampleRate: Double,
+        on output: AudioOutputDevice
+    ) throws -> AudioOutputDevice {
+        guard sampleRate > 0, abs(output.nominalSampleRate - sampleRate) >= 1 else {
+            return output
+        }
+        try CoreAudioDeviceQuery.setNominalSampleRate(sampleRate, objectID: output.id)
+        for _ in 0..<3 {
+            let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
+            if abs(freshOutput.nominalSampleRate - sampleRate) < 1 {
+                return freshOutput
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
+        throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
+            output.id,
+            "output sample rate \(freshOutput.nominalSampleRate) does not match tap sample rate \(sampleRate)"
+        )
+    }
+
+    private func preparePlaybackOutput(
+        tapSampleRate: Double,
+        output: AudioOutputDevice
+    ) throws -> AudioOutputDevice {
+        if Self.shouldUseSampleRateConversion(tapSampleRate: tapSampleRate, output: output) {
+            return output
+        }
+        return try forceSampleRate(tapSampleRate, on: output)
+    }
+
+    private func recordSampleRateRestorationIfNeeded(
+        for output: AudioOutputDevice,
+        state: inout ControlState
+    ) throws {
+        guard state.sampleRateRestorations[output.uid] == nil else {
+            return
+        }
+        let restoration = SampleRateRestoration(
+            uid: output.uid,
+            originalSampleRate: output.nominalSampleRate
+        )
+        try PersistedAudioDeviceRestorationStore.recordSampleRate(
+            uid: restoration.uid,
+            originalSampleRate: restoration.originalSampleRate,
+            at: restorationStoreURL
+        )
+        state.sampleRateRestorations[output.uid] = restoration
+    }
+
+    static func setSampleRateAfterRecordingRestoration(
+        _ sampleRate: Double,
+        on output: AudioOutputDevice,
+        needsRestoration: Bool,
+        recordRestoration: (SampleRateRestoration) throws -> Void,
+        installRestoration: (SampleRateRestoration) -> Void,
+        setSampleRate: (Double, AudioObjectID) throws -> Void
+    ) throws {
+        if needsRestoration {
+            let restoration = SampleRateRestoration(
+                uid: output.uid,
+                originalSampleRate: output.nominalSampleRate
+            )
+            try recordRestoration(restoration)
+            installRestoration(restoration)
+        }
+        try setSampleRate(sampleRate, output.id)
+    }
+
+    private func restoreDeviceSettingsIfNeeded(_ state: inout ControlState) {
+        var restoredSampleRateUIDs: [String] = []
+        for (uid, restoration) in state.sampleRateRestorations {
+            if Self.restoreSampleRateRestoration(restoration) {
+                try? PersistedAudioDeviceRestorationStore.clearSampleRate(uid: uid, at: restorationStoreURL)
+                restoredSampleRateUIDs.append(uid)
+            }
+        }
+        for uid in restoredSampleRateUIDs {
+            state.sampleRateRestorations.removeValue(forKey: uid)
+        }
+
+        var restoredBufferFrameSizeUIDs: [String] = []
+        for (uid, restoration) in state.bufferFrameSizeRestorations {
+            if Self.restoreBufferFrameSizeRestoration(restoration) {
+                try? PersistedAudioDeviceRestorationStore.clearBufferFrameSize(uid: uid, at: restorationStoreURL)
+                restoredBufferFrameSizeUIDs.append(uid)
+            }
+        }
+        for uid in restoredBufferFrameSizeUIDs {
+            state.bufferFrameSizeRestorations.removeValue(forKey: uid)
+        }
+    }
+
+    static func restoreSampleRateRestoration(
+        _ restoration: SampleRateRestoration,
+        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
+        setSampleRate: (Double, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:)
+    ) -> Bool {
+        do {
+            guard let output = try outputForUID(restoration.uid) else {
+                return false
+            }
+            guard abs(output.nominalSampleRate - restoration.originalSampleRate) >= 1 else {
+                return true
+            }
+            try setSampleRate(restoration.originalSampleRate, output.id)
+            guard let verifiedOutput = try outputForUID(restoration.uid) else {
+                return false
+            }
+            return abs(verifiedOutput.nominalSampleRate - restoration.originalSampleRate) < 1
+        } catch {
+            return false
+        }
+    }
+
+    static func restoreBufferFrameSizeRestoration(
+        _ restoration: BufferFrameSizeRestoration,
+        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
+    ) -> Bool {
+        do {
+            guard let output = try outputForUID(restoration.uid) else {
+                return false
+            }
+            guard output.bufferFrameSize != restoration.originalFrameSize else {
+                return true
+            }
+            try setBufferFrameSize(restoration.originalFrameSize, output.id)
+            guard let verifiedOutput = try outputForUID(restoration.uid) else {
+                return false
+            }
+            return verifiedOutput.bufferFrameSize == restoration.originalFrameSize
+        } catch {
+            return false
+        }
+    }
+
+    static func restorePersistedDeviceSettings(
+        at url: URL,
+        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
+        setSampleRate: (Double, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:),
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
+    ) {
+        var records = PersistedAudioDeviceRestorationStore.load(from: url)
+        guard !records.isEmpty else {
+            return
+        }
+
+        for (uid, record) in records {
+            var updated = record
+            if let originalSampleRate = record.originalSampleRate,
+               restoreSampleRateRestoration(
+                   SampleRateRestoration(uid: uid, originalSampleRate: originalSampleRate),
+                   outputForUID: outputForUID,
+                   setSampleRate: setSampleRate
+               ) {
+                updated.originalSampleRate = nil
+            }
+            if let originalBufferFrameSize = record.originalBufferFrameSize,
+               restoreBufferFrameSizeRestoration(
+                   BufferFrameSizeRestoration(uid: uid, originalFrameSize: originalBufferFrameSize),
+                   outputForUID: outputForUID,
+                   setBufferFrameSize: setBufferFrameSize
+               ) {
+                updated.originalBufferFrameSize = nil
+            }
+            records[uid] = updated.isEmpty ? nil : updated
+        }
+
+        try? PersistedAudioDeviceRestorationStore.save(records, to: url)
+    }
+
+    private static func dspProfile(from profile: EQProfile) -> EQProfile {
+        var profile = profile
+        profile.isBypassed = false
+        return profile
+    }
+
+    private func audioEngineFailure(from error: Error) -> AudioEngineFailure {
+        if let coreAudioError = error as? CoreAudioError {
+            return classifyCoreAudioError(coreAudioError)
+        }
+        if let availabilityError = error as? AudioDeviceAvailabilityError {
+            switch availabilityError {
+            case .unsupportedOutputChannelCount,
+                 .unsupportedOutputBufferFrameSize,
+                 .unsupportedPlaybackConversionBuffer:
+                return AudioEngineFailure(
+                    category: .deviceFormatUnsupported,
+                    userMessage: availabilityError.description,
+                    operation: "CoreAudioDeviceQuery"
+                )
+            default:
+                return AudioEngineFailure(
+                    category: .outputDeviceUnavailable,
+                    userMessage: availabilityError.description,
+                    operation: "CoreAudioDeviceQuery"
+                )
+            }
+        }
+        return AudioEngineFailure(
+            category: .coreAudioOperationFailed,
+            userMessage: String(describing: error),
+            operation: "SeparateClockAudioBackend"
+        )
+    }
+
+    static func supportedRuntimeChannelCount(for output: AudioOutputDevice) throws -> Int {
+        guard output.outputChannelCount > 0 else {
+            throw AudioDeviceAvailabilityError.outputDeviceHasNoOutputChannels(output.id)
+        }
+        // getChannelCount sums per-buffer mNumberChannels without bounding them, so a broken
+        // device can still report absurd counts; the playback mapper handles anything below this.
+        guard output.outputChannelCount <= CoreAudioDeviceQuery.maxChannelCount else {
+            throw AudioDeviceAvailabilityError.unsupportedOutputChannelCount(output.id, output.outputChannelCount)
+        }
+        return output.outputChannelCount
+    }
+
+    static func validatePlaybackCallbackCapacity(for output: AudioOutputDevice) throws {
+        guard output.bufferFrameSize <= UInt32(maximumSupportedCallbackFrames) else {
+            throw AudioDeviceAvailabilityError.unsupportedOutputBufferFrameSize(
+                output.id,
+                output.bufferFrameSize,
+                maximum: UInt32(maximumSupportedCallbackFrames)
+            )
+        }
+    }
+
+    static func validatePlaybackConversionCapacity(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double,
+        captureCallbackFrames: Int = preferredLowSampleRatePlaybackReservoirFrames
+    ) throws {
+        guard shouldUseSampleRateConversion(tapSampleRate: tapSampleRate, output: output) else {
+            return
+        }
+        let requiredPrimeFrames = preferredPlaybackPrimeFrames(
+            for: output,
+            tapSampleRate: tapSampleRate,
+            captureCallbackFrames: captureCallbackFrames
+        )
+        let maximumPrimeFrames = runtimeRingCapacityFrames / playbackRingPullCount
+        guard requiredPrimeFrames <= maximumPrimeFrames else {
+            throw AudioDeviceAvailabilityError.unsupportedPlaybackConversionBuffer(
+                output.id,
+                requiredPrimeFrames: requiredPrimeFrames,
+                maximumPrimeFrames: maximumPrimeFrames
+            )
+        }
+    }
+
+    /// Normalizes a device-reported preferred stereo pair (1-based channel numbers; the HAL
+    /// reports zeros when the pair was never configured) into 0-based destination channel
+    /// indices. Falls back to the first two channels whenever the report is missing or
+    /// inconsistent; mono devices collapse to (0, 0).
+    static func playbackStereoPair(
+        preferredChannels: (left: UInt32, right: UInt32)?,
+        outputChannelCount: Int
+    ) -> (left: Int, right: Int) {
+        guard outputChannelCount > 1 else {
+            return outputChannelCount == 1 ? (0, 0) : (0, 1)
+        }
+        guard let preferredChannels,
+              preferredChannels.left >= 1,
+              preferredChannels.right >= 1,
+              preferredChannels.left != preferredChannels.right,
+              preferredChannels.left <= UInt32(outputChannelCount),
+              preferredChannels.right <= UInt32(outputChannelCount) else {
+            return (0, 1)
+        }
+        return (Int(preferredChannels.left) - 1, Int(preferredChannels.right) - 1)
+    }
+
+    static func encodedPlaybackChannelPair(left: Int, right: Int) -> UInt64 {
+        let maxChannelIndex = CoreAudioDeviceQuery.maxChannelCount - 1
+        let clampedLeft = UInt64(min(max(left, 0), maxChannelIndex))
+        let clampedRight = UInt64(min(max(right, 0), maxChannelIndex))
+        return (clampedLeft << 32) | clampedRight
+    }
+
+    static func decodedPlaybackChannelPair(_ encoded: UInt64) -> (left: Int, right: Int) {
+        (Int(encoded >> 32), Int(encoded & 0xFFFF_FFFF))
+    }
+
+    static func performAfterRuntimeChannelValidation<T>(
+        for output: AudioOutputDevice,
+        _ operation: () throws -> T
+    ) throws -> T {
+        _ = try supportedRuntimeChannelCount(for: output)
+        return try operation()
+    }
+
+    static func monoDownmix(
+        _ samples: UnsafeBufferPointer<Float>,
+        frame: Int,
+        sourceChannelCount: Int
+    ) -> Float {
+        guard frame >= 0 else {
+            return 0
+        }
+        let sourceChannelCount = max(sourceChannelCount, 1)
+        let sampleBaseResult = frame.multipliedReportingOverflow(by: sourceChannelCount)
+        guard !sampleBaseResult.overflow else {
+            return 0
+        }
+        let sampleBase = sampleBaseResult.partialValue
+        guard sampleBase >= 0,
+              sampleBase < samples.count else {
+            return 0
+        }
+        guard sourceChannelCount > 1,
+              sampleBase + 1 < samples.count else {
+            return samples[sampleBase]
+        }
+        return (samples[sampleBase] + samples[sampleBase + 1]) * 0.5
+    }
+
+    static func copyInterleavedSamples(
+        _ samples: UnsafeBufferPointer<Float>,
+        sourceFrameOffset: Int,
+        destinationFrameOffset: Int,
+        frameCount: Int,
+        sourceChannelCount: Int,
+        destinationLeftChannel: Int = 0,
+        destinationRightChannel: Int = 1,
+        to buffers: UnsafeMutableAudioBufferListPointer
+    ) {
+        let sourceChannelCount = max(sourceChannelCount, 1)
+        if buffers.count == 1,
+           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+           Int(buffers[0].mNumberChannels) == 1,
+           sourceChannelCount > 1,
+           frameCount > 0,
+           sourceFrameOffset >= 0,
+           destinationFrameOffset >= 0 {
+            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+            for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSamples {
+                data[destinationFrameOffset + frameIndex] = monoDownmix(
+                    samples,
+                    frame: sourceFrameOffset + frameIndex,
+                    sourceChannelCount: sourceChannelCount
+                )
+            }
+            return
+        }
+
+        if buffers.count == 1,
+           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+           Int(buffers[0].mNumberChannels) == sourceChannelCount,
+           destinationLeftChannel == 0,
+           destinationRightChannel == 1,
+           frameCount > 0,
+           sourceFrameOffset >= 0,
+           destinationFrameOffset >= 0 {
+            let copySamples = frameCount * sourceChannelCount
+            let sourceSampleStart = sourceFrameOffset * sourceChannelCount
+            let destinationSampleStart = destinationFrameOffset * sourceChannelCount
+            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+            if sourceSampleStart + copySamples <= samples.count,
+               destinationSampleStart + copySamples <= destinationSamples,
+               let source = samples.baseAddress {
+                data.advanced(by: destinationSampleStart)
+                    .update(from: source.advanced(by: sourceSampleStart), count: copySamples)
+                return
+            }
+        }
+
+        // General mapped case: the destination pair channels receive source L/R (mono sources
+        // feed both); every other channel gets explicit zeros. Never trust HAL pre-zeroing —
+        // stray signal would leak into a multi-channel interface's DAW/loopback channels.
+        // Walks the AudioBufferList with a running global channel offset so interleaved,
+        // multi-stream, and per-channel-buffer layouts all map correctly.
+        guard frameCount > 0, sourceFrameOffset >= 0, destinationFrameOffset >= 0 else {
+            return
+        }
+        let sourceRightChannel = min(1, sourceChannelCount - 1)
+        var globalChannelOffset = 0
+        for bufferIndex in buffers.indices {
+            let bufferChannels = Int(buffers[bufferIndex].mNumberChannels)
+            guard bufferChannels > 0,
+                  let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self) else {
+                globalChannelOffset += max(bufferChannels, 0)
+                continue
+            }
+            let destinationSampleCount = Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride
+            let zeroStart = destinationFrameOffset * bufferChannels
+            let zeroEnd = min((destinationFrameOffset + frameCount) * bufferChannels, destinationSampleCount)
+            if zeroStart < zeroEnd {
+                data.advanced(by: zeroStart).update(repeating: 0, count: zeroEnd - zeroStart)
+            }
+            scatterMappedChannel(
+                samples,
+                sourceChannel: 0,
+                sourceFrameOffset: sourceFrameOffset,
+                sourceChannelCount: sourceChannelCount,
+                localChannel: destinationLeftChannel - globalChannelOffset,
+                destinationFrameOffset: destinationFrameOffset,
+                frameCount: frameCount,
+                bufferChannels: bufferChannels,
+                destinationSampleCount: destinationSampleCount,
+                into: data
+            )
+            scatterMappedChannel(
+                samples,
+                sourceChannel: sourceRightChannel,
+                sourceFrameOffset: sourceFrameOffset,
+                sourceChannelCount: sourceChannelCount,
+                localChannel: destinationRightChannel - globalChannelOffset,
+                destinationFrameOffset: destinationFrameOffset,
+                frameCount: frameCount,
+                bufferChannels: bufferChannels,
+                destinationSampleCount: destinationSampleCount,
+                into: data
+            )
+            globalChannelOffset += bufferChannels
+        }
+    }
+
+    private static func scatterMappedChannel(
+        _ samples: UnsafeBufferPointer<Float>,
+        sourceChannel: Int,
+        sourceFrameOffset: Int,
+        sourceChannelCount: Int,
+        localChannel: Int,
+        destinationFrameOffset: Int,
+        frameCount: Int,
+        bufferChannels: Int,
+        destinationSampleCount: Int,
+        into data: UnsafeMutablePointer<Float>
+    ) {
+        guard localChannel >= 0, localChannel < bufferChannels else {
+            return
+        }
+        for frameIndex in 0..<frameCount {
+            let sourceIndex = (sourceFrameOffset + frameIndex) * sourceChannelCount + sourceChannel
+            guard sourceIndex < samples.count else {
+                continue
+            }
+            let destinationIndex = (destinationFrameOffset + frameIndex) * bufferChannels + localChannel
+            guard destinationIndex < destinationSampleCount else {
+                continue
+            }
+            data[destinationIndex] = samples[sourceIndex]
+        }
+    }
+
+    static func performTopologyRebuild<T>(
+        acquireMuteGuard: () throws -> any TopologyRebuildMuteGuarding,
+        rebuild: () throws -> T
+    ) throws -> T {
+        let muteGuard: any TopologyRebuildMuteGuarding
+        do {
+            muteGuard = try acquireMuteGuard()
+        } catch {
+            throw TopologyRebuildMuteGuardUnavailable(underlyingError: error)
+        }
+        defer {
+            muteGuard.release()
+        }
+        return try rebuild()
+    }
+
+    private func tuneBufferFrameSize(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double
+    ) -> AudioOutputDevice {
+        do {
+            let range = try CoreAudioDeviceQuery.bufferFrameSizeRangeValue(objectID: output.id)
+            let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
+                outputUID: output.uid,
+                sampleRate: output.nominalSampleRate,
+                tapSampleRate: tapSampleRate,
+                from: playbackBufferCalibrationStoreURL
+            )
+            let requested = AdaptivePlaybackBufferPolicy.startupFrameSize(
+                preferredFrameSize: Self.preferredBufferFrameSize(for: output),
+                calibration: calibration,
+                supportedRange: range
+            )
+            guard requested != output.bufferFrameSize else {
+                return output
+            }
+            try CoreAudioDeviceQuery.setBufferFrameSize(requested, objectID: output.id)
+            return try CoreAudioDeviceQuery.outputDevice(id: output.id)
+        } catch {
+            return output
+        }
+    }
+
+    private func playbackBufferCalibrationProbe(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double,
+        targetFrames: Int,
+        startedAt: ContinuousClock.Instant = ContinuousClock().now
+    ) -> PlaybackBufferCalibrationProbe? {
+        guard Self.shouldAdaptPlaybackBuffer(for: output) else {
+            return nil
+        }
+        let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
+            outputUID: output.uid,
+            sampleRate: output.nominalSampleRate,
+            tapSampleRate: tapSampleRate,
+            from: playbackBufferCalibrationStoreURL
+        )
+        guard PlaybackBufferCalibrationPolicy.shouldProbe(
+            frameSize: output.bufferFrameSize,
+            targetFrames: targetFrames,
+            calibration: calibration
+        ) else {
+            return nil
+        }
+        return PlaybackBufferCalibrationProbe(
+            outputUID: output.uid,
+            sampleRate: output.nominalSampleRate,
+            tapSampleRate: tapSampleRate,
+            frameSize: output.bufferFrameSize,
+            targetFrames: targetFrames,
+            startedAt: startedAt
+        )
+    }
+
+    private func preferredPlaybackTargetFrames(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double,
+        captureCallbackFrames: Int
+    ) -> Int {
+        let baseline = Self.preferredPlaybackPrimeFrames(
+            for: output,
+            tapSampleRate: tapSampleRate,
+            captureCallbackFrames: captureCallbackFrames
+        )
+        guard Self.shouldAdaptPlaybackBuffer(for: output) else {
+            return baseline
+        }
+        let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
+            outputUID: output.uid,
+            sampleRate: output.nominalSampleRate,
+            tapSampleRate: tapSampleRate,
+            from: playbackBufferCalibrationStoreURL
+        )
+        let targetFrames = AdaptivePlaybackBufferPolicy.startupTargetFrames(
+            baselineTargetFrames: baseline,
+            operatingPoint: calibration?.operatingPoint(for: output.bufferFrameSize)
+        )
+        return min(targetFrames, Self.runtimeRingCapacityFrames / 2)
+    }
+
+    private func updatePlaybackBufferAdaptationTimer() {
+        let shouldRun = control.withLock { state in
+            guard case .running = state.state,
+                  let output = state.activeOutput else {
+                return false
+            }
+            return Self.shouldAdaptPlaybackBuffer(for: output)
+        }
+        setPlaybackBufferAdaptationTimerRunning(shouldRun)
+    }
+
+    private func pausePlaybackBufferAdaptation() {
+        setPlaybackBufferAdaptationTimerRunning(false)
+        if DispatchQueue.getSpecific(key: playbackBufferAdaptationQueueKey) == nil {
+            playbackBufferAdaptationQueue.sync {}
+        }
+    }
+
+    private func setPlaybackBufferAdaptationTimerRunning(_ shouldRun: Bool) {
+        playbackBufferAdaptationTimerRunning.withLock { isRunning in
+            guard isRunning != shouldRun else {
+                return
+            }
+            isRunning = shouldRun
+            if shouldRun {
+                playbackBufferAdaptationTimer.resume()
+            } else {
+                playbackBufferAdaptationTimer.suspend()
+            }
+        }
+    }
+
+    private func serviceAdaptivePlaybackBuffering() {
+        let now = ContinuousClock().now
+        guard let action = control.withLock({ state -> PlaybackBufferAdaptationAction? in
+            guard let runtime = state.runtime,
+                  let output = state.activeOutput,
+                  Self.shouldAdaptPlaybackBuffer(for: output) else {
+                return nil
+            }
+
+            if let recoveryGeneration = state.adaptivePlaybackRenderRecoveryHealthGeneration,
+               runtime.playbackRenderHealthGeneration() != recoveryGeneration {
+                state.adaptivePlaybackRenderRecoveryAttempts = 0
+                state.adaptivePlaybackRenderRecoveryHealthGeneration = nil
+            }
+
+            let instability = runtime.playbackInstabilitySnapshot()
+            let evidence = state.playbackBufferAdaptationEvidence.observe(
+                instabilityGeneration: instability.generation,
+                reason: instability.reason,
+                timestampDiscontinuities: runtime.playbackTimestampDiscontinuityCount(),
+                at: now
+            )
+            if evidence.observedDisturbance {
+                if state.playbackBufferCalibrationProbe != nil {
+                    state.playbackBufferCalibrationProbe?.startedAt = now
+                    state.playbackBufferStableSince = nil
+                } else {
+                    state.playbackBufferStableSince = now
+                }
+            }
+            if let reason = evidence.escalationReason {
+                state.playbackBufferStableSince = nil
+                return .renegotiate(PlaybackBufferRenegotiationPreparation(
+                    outputRebuildGeneration: state.outputRebuildGeneration,
+                    reason: reason,
+                    output: output,
+                    runtime: runtime
+                ))
+            }
+
+            if let probe = state.playbackBufferCalibrationProbe,
+               probe.hasCompletedProbation(at: now) {
+                return .stabilize(probe)
+            }
+            if let stableSince = state.playbackBufferStableSince,
+               stableSince.duration(to: now) >= PlaybackBufferAdaptationPolicy.decayDelay {
+                state.playbackBufferStableSince = nil
+                return .decay(PlaybackBufferDecayPreparation(
+                    outputRebuildGeneration: state.outputRebuildGeneration,
+                    output: output,
+                    runtime: runtime
+                ))
+            }
+            return nil
+        }) else {
+            return
+        }
+
+        let preparation: PlaybackBufferRenegotiationPreparation
+        switch action {
+        case .stabilize(let probe):
+            do {
+                try PersistedPlaybackBufferCalibrationStore.recordStable(
+                    outputUID: probe.outputUID,
+                    sampleRate: probe.sampleRate,
+                    tapSampleRate: probe.tapSampleRate,
+                    frameSize: probe.frameSize,
+                    targetFrames: probe.targetFrames,
+                    at: playbackBufferCalibrationStoreURL
+                )
+            } catch {
+                return
+            }
+            control.withLock { state in
+                if state.playbackBufferCalibrationProbe == probe {
+                    state.playbackBufferCalibrationProbe = nil
+                    state.playbackBufferStableSince = now
+                    state.playbackBufferInstabilityPersistenceGate.reset(outputUID: probe.outputUID)
+                }
+            }
+            return
+        case .decay(let preparation):
+            decayPlaybackBufferIfPossible(preparation)
+            return
+        case .renegotiate(let pendingRenegotiation):
+            preparation = pendingRenegotiation
+        }
+
+        if preparation.reason == .adaptiveRenderFailure {
+            recoverAdaptivePlaybackRenderFailure(preparation)
+            return
+        }
+
+        if increasePlaybackTargetIfPossible(preparation) {
+            return
+        }
+
+        let range: AudioBufferFrameSizeRange
+        do {
+            range = try CoreAudioDeviceQuery.bufferFrameSizeRangeValue(objectID: preparation.output.id)
+        } catch {
+            continueCalibrationAfterUnresolvedInstability(preparation)
+            return
+        }
+        guard let nextFrameSize = AdaptivePlaybackBufferPolicy.nextFrameSize(
+            after: preparation.output.bufferFrameSize,
+            supportedRange: range
+        ) else {
+            continueCalibrationAfterUnresolvedInstability(preparation)
+            return
+        }
+        var proposedOutput = preparation.output
+        proposedOutput.bufferFrameSize = nextFrameSize
+        do {
+            try Self.validatePlaybackConversionCapacity(
+                for: proposedOutput,
+                tapSampleRate: preparation.runtime.sampleRate,
+                captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames()
+            )
+        } catch {
+            continueCalibrationAfterUnresolvedInstability(preparation)
+            return
+        }
+
+        let updatedOutput: AudioOutputDevice
+        do {
+            guard let result = try Self.renegotiatedPlaybackOutput(
+                preparation.output,
+                supportedRange: range,
+                setBufferFrameSize: { [self] frameSize, objectID in
+                    try control.withLock { state in
+                        guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                              state.runtime === preparation.runtime,
+                              state.activeOutput == preparation.output else {
+                            throw StaleOutputRebuild()
+                        }
+                        preparation.runtime.muteOutputForTransition()
+                        try CoreAudioDeviceQuery.setBufferFrameSize(
+                            frameSize,
+                            objectID: objectID
+                        )
+                    }
+                }
+            ) else {
+                recoverFailedPlaybackBufferRenegotiation(preparation)
+                continueCalibrationAfterUnresolvedInstability(preparation)
+                return
+            }
+            updatedOutput = result
+        } catch {
+            recoverFailedPlaybackBufferRenegotiation(preparation)
+            continueCalibrationAfterUnresolvedInstability(preparation)
+            return
+        }
+
+        let completedRenegotiation = control.withLock { state -> PlaybackBufferRenegotiation? in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return nil
+            }
+
+            let previousTargetFrames = preparation.runtime.playbackTargetFrames()
+            let targetFrames = preferredPlaybackTargetFrames(
+                for: updatedOutput,
+                tapSampleRate: preparation.runtime.sampleRate,
+                captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames()
+            )
+            preparation.runtime.retargetPlayback(
+                primeFrames: targetFrames
+            )
+            preparation.runtime.recordPlaybackBufferRenegotiation()
+            preparation.runtime.reprimePlayback()
+
+            state.activeOutput = updatedOutput
+            state.state = .running(output: updatedOutput)
+            state.status = .running(output: updatedOutput)
+            state.playbackBufferAdaptationEvidence.reset(
+                instabilityGeneration: preparation.runtime.playbackInstabilitySnapshot().generation,
+                timestampDiscontinuities: preparation.runtime.playbackTimestampDiscontinuityCount()
+            )
+            state.playbackBufferStableSince = nil
+            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
+                outputUID: updatedOutput.uid,
+                sampleRate: updatedOutput.nominalSampleRate,
+                tapSampleRate: preparation.runtime.sampleRate,
+                frameSize: updatedOutput.bufferFrameSize,
+                targetFrames: targetFrames,
+                startedAt: ContinuousClock().now
+            )
+            return PlaybackBufferRenegotiation(
+                outputName: updatedOutput.name,
+                outputUID: updatedOutput.uid,
+                sampleRate: updatedOutput.nominalSampleRate,
+                previousFrameSize: preparation.output.bufferFrameSize,
+                frameSize: updatedOutput.bufferFrameSize,
+                previousPlaybackTargetFrames: previousTargetFrames,
+                playbackTargetFrames: targetFrames,
+                cause: .instability(preparation.reason)
+            )
+        }
+        guard let completedRenegotiation else {
+            return
+        }
+        try? PersistedPlaybackBufferCalibrationStore.recordInstability(
+            outputUID: completedRenegotiation.outputUID,
+            sampleRate: completedRenegotiation.sampleRate,
+            tapSampleRate: preparation.runtime.sampleRate,
+            previousFrameSize: completedRenegotiation.previousFrameSize,
+            resultingFrameSize: completedRenegotiation.frameSize,
+            previousTargetFrames: completedRenegotiation.previousPlaybackTargetFrames,
+            resultingTargetFrames: completedRenegotiation.playbackTargetFrames,
+            reason: preparation.reason,
+            at: playbackBufferCalibrationStoreURL
+        )
+        let handler = playbackBufferRenegotiationHandler.withLock { $0 }
+        handler?(completedRenegotiation)
+    }
+
+    private func increasePlaybackTargetIfPossible(
+        _ preparation: PlaybackBufferRenegotiationPreparation
+    ) -> Bool {
+        let adjustment = control.withLock { state -> PlaybackBufferTargetAdjustment? in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return nil
+            }
+            let previousTargetFrames = preparation.runtime.playbackTargetFrames()
+            guard let targetFrames = AdaptivePlaybackBufferPolicy.nextTargetFrames(
+                callbackFrames: Self.playbackInputCallbackFrames(
+                    for: preparation.output,
+                    tapSampleRate: preparation.runtime.sampleRate
+                ),
+                after: previousTargetFrames,
+                maximumReservoirFrames: Self.maximumPlaybackReservoirFrames(
+                    for: preparation.output,
+                    tapSampleRate: preparation.runtime.sampleRate,
+                    maximumKnownCaptureCallbackFrames: preparation.runtime
+                        .maximumKnownCaptureCallbackFrames()
+                )
+            ) else {
+                return nil
+            }
+
+            preparation.runtime.retargetPlayback(
+                primeFrames: targetFrames
+            )
+            preparation.runtime.recordPlaybackBufferRenegotiation()
+            preparation.runtime.reprimePlayback()
+            state.playbackBufferAdaptationEvidence.reset(
+                instabilityGeneration: preparation.runtime.playbackInstabilitySnapshot().generation,
+                timestampDiscontinuities: preparation.runtime.playbackTimestampDiscontinuityCount()
+            )
+            state.playbackBufferStableSince = nil
+            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
+                outputUID: preparation.output.uid,
+                sampleRate: preparation.output.nominalSampleRate,
+                tapSampleRate: preparation.runtime.sampleRate,
+                frameSize: preparation.output.bufferFrameSize,
+                targetFrames: targetFrames,
+                startedAt: ContinuousClock().now
+            )
+            return PlaybackBufferTargetAdjustment(
+                output: preparation.output,
+                tapSampleRate: preparation.runtime.sampleRate,
+                previousTargetFrames: previousTargetFrames,
+                targetFrames: targetFrames
+            )
+        }
+        guard let adjustment else {
+            return false
+        }
+
+        try? PersistedPlaybackBufferCalibrationStore.recordInstability(
+            outputUID: adjustment.output.uid,
+            sampleRate: adjustment.output.nominalSampleRate,
+            tapSampleRate: adjustment.tapSampleRate,
+            previousFrameSize: adjustment.output.bufferFrameSize,
+            resultingFrameSize: adjustment.output.bufferFrameSize,
+            previousTargetFrames: adjustment.previousTargetFrames,
+            resultingTargetFrames: adjustment.targetFrames,
+            reason: .underrun,
+            at: playbackBufferCalibrationStoreURL
+        )
+        return true
+    }
+
+    private func decayPlaybackBufferIfPossible(
+        _ preparation: PlaybackBufferDecayPreparation
+    ) {
+        switch decayPlaybackTargetIfPossible(preparation) {
+        case .adjusted, .blocked:
+            return
+        case .atBaseline:
+            break
+        }
+
+        let range: AudioBufferFrameSizeRange
+        do {
+            range = try CoreAudioDeviceQuery.bufferFrameSizeRangeValue(objectID: preparation.output.id)
+        } catch {
+            resumePlaybackBufferDecayAfterFailure(preparation)
+            return
+        }
+        guard let frameSize = AdaptivePlaybackBufferPolicy.previousFrameSize(
+            before: preparation.output.bufferFrameSize,
+            supportedRange: range
+        ),
+              frameSize >= Self.preferredBufferFrameSize(for: preparation.output) else {
+            return
+        }
+
+        var proposedOutput = preparation.output
+        proposedOutput.bufferFrameSize = frameSize
+        do {
+            try Self.validatePlaybackConversionCapacity(
+                for: proposedOutput,
+                tapSampleRate: preparation.runtime.sampleRate,
+                captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames()
+            )
+        } catch {
+            return
+        }
+
+        let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
+            outputUID: proposedOutput.uid,
+            sampleRate: proposedOutput.nominalSampleRate,
+            tapSampleRate: preparation.runtime.sampleRate,
+            from: playbackBufferCalibrationStoreURL
+        )
+        let operatingPoint = calibration?.operatingPoint(for: frameSize)
+        let baselineTargetFrames = Self.preferredPlaybackPrimeFrames(
+            for: proposedOutput,
+            tapSampleRate: preparation.runtime.sampleRate,
+            captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames()
+        )
+        let targetFrames = max(
+            baselineTargetFrames,
+            Int(operatingPoint?.stableTargetFrames ?? 0)
+        )
+        guard targetFrames > Int(operatingPoint?.unstableThroughTargetFrames ?? 0) else {
+            return
+        }
+
+        let candidate = PlaybackBufferFrameSizeDecayCandidate(
+            output: preparation.output,
+            tapSampleRate: preparation.runtime.sampleRate,
+            frameSize: frameSize
+        )
+        let shouldAttemptDecay = control.withLock { state in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return false
+            }
+            return !state.failedPlaybackFrameSizeDecayCandidates.contains(candidate)
+        }
+        guard shouldAttemptDecay else {
+            return
+        }
+
+        let updatedOutput: AudioOutputDevice
+        do {
+            guard let result = try Self.decayedPlaybackOutput(
+                preparation.output,
+                supportedRange: range,
+                setBufferFrameSize: { [self] frameSize, objectID in
+                    try control.withLock { state in
+                        guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                              state.runtime === preparation.runtime,
+                              state.activeOutput == preparation.output,
+                              !state.failedPlaybackFrameSizeDecayCandidates.contains(candidate) else {
+                            throw StaleOutputRebuild()
+                        }
+                        preparation.runtime.muteOutputForTransition()
+                        try CoreAudioDeviceQuery.setBufferFrameSize(
+                            frameSize,
+                            objectID: objectID
+                        )
+                    }
+                }
+            ) else {
+                failPlaybackBufferFrameSizeDecay(preparation, candidate: candidate)
+                return
+            }
+            updatedOutput = result
+        } catch {
+            failPlaybackBufferFrameSizeDecay(preparation, candidate: candidate)
+            return
+        }
+
+        let completedRenegotiation = control.withLock { state -> PlaybackBufferRenegotiation? in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return nil
+            }
+            let previousTargetFrames = preparation.runtime.playbackTargetFrames()
+            preparation.runtime.retargetPlayback(primeFrames: targetFrames)
+            preparation.runtime.recordPlaybackBufferRenegotiation()
+            preparation.runtime.reprimePlayback()
+
+            state.activeOutput = updatedOutput
+            state.state = .running(output: updatedOutput)
+            state.status = .running(output: updatedOutput)
+            state.playbackBufferAdaptationEvidence.reset(
+                instabilityGeneration: preparation.runtime.playbackInstabilitySnapshot().generation,
+                timestampDiscontinuities: preparation.runtime.playbackTimestampDiscontinuityCount()
+            )
+            state.playbackBufferStableSince = nil
+            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
+                outputUID: updatedOutput.uid,
+                sampleRate: updatedOutput.nominalSampleRate,
+                tapSampleRate: preparation.runtime.sampleRate,
+                frameSize: updatedOutput.bufferFrameSize,
+                targetFrames: targetFrames,
+                startedAt: ContinuousClock().now
+            )
+            return PlaybackBufferRenegotiation(
+                outputName: updatedOutput.name,
+                outputUID: updatedOutput.uid,
+                sampleRate: updatedOutput.nominalSampleRate,
+                previousFrameSize: preparation.output.bufferFrameSize,
+                frameSize: updatedOutput.bufferFrameSize,
+                previousPlaybackTargetFrames: previousTargetFrames,
+                playbackTargetFrames: targetFrames,
+                cause: .stableDecay
+            )
+        }
+        guard let completedRenegotiation else {
+            return
+        }
+        try? PersistedPlaybackBufferCalibrationStore.beginProbe(
+            outputUID: completedRenegotiation.outputUID,
+            sampleRate: completedRenegotiation.sampleRate,
+            tapSampleRate: preparation.runtime.sampleRate,
+            frameSize: completedRenegotiation.frameSize,
+            targetFrames: completedRenegotiation.playbackTargetFrames,
+            at: playbackBufferCalibrationStoreURL
+        )
+        playbackBufferRenegotiationHandler.withLock { $0 }?(completedRenegotiation)
+    }
+
+    private func decayPlaybackTargetIfPossible(
+        _ preparation: PlaybackBufferDecayPreparation
+    ) -> PlaybackBufferTargetDecayResult {
+        let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
+            outputUID: preparation.output.uid,
+            sampleRate: preparation.output.nominalSampleRate,
+            tapSampleRate: preparation.runtime.sampleRate,
+            from: playbackBufferCalibrationStoreURL
+        )
+        var probe: PlaybackBufferCalibrationProbe?
+        let result = control.withLock { state -> PlaybackBufferTargetDecayResult in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return .blocked
+            }
+            let currentTargetFrames = preparation.runtime.playbackTargetFrames()
+            let baselineTargetFrames = Self.preferredPlaybackPrimeFrames(
+                for: preparation.output,
+                tapSampleRate: preparation.runtime.sampleRate,
+                captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames()
+            )
+            guard currentTargetFrames >= baselineTargetFrames else {
+                return .blocked
+            }
+            guard currentTargetFrames > baselineTargetFrames else {
+                return .atBaseline
+            }
+            guard let targetFrames = AdaptivePlaybackBufferPolicy.nextDecayTargetFrames(
+                callbackFrames: Self.playbackInputCallbackFrames(
+                    for: preparation.output,
+                    tapSampleRate: preparation.runtime.sampleRate
+                ),
+                stableTargetFrames: currentTargetFrames,
+                unstableThroughTargetFrames: calibration?
+                    .operatingPoint(for: preparation.output.bufferFrameSize)?
+                    .unstableThroughTargetFrames,
+                baselineTargetFrames: baselineTargetFrames
+            ) else {
+                return .blocked
+            }
+
+            preparation.runtime.retargetPlayback(primeFrames: targetFrames)
+            preparation.runtime.recordPlaybackBufferRenegotiation()
+            preparation.runtime.reprimePlayback()
+            state.playbackBufferAdaptationEvidence.reset(
+                instabilityGeneration: preparation.runtime.playbackInstabilitySnapshot().generation,
+                timestampDiscontinuities: preparation.runtime.playbackTimestampDiscontinuityCount()
+            )
+            state.playbackBufferStableSince = nil
+            probe = PlaybackBufferCalibrationProbe(
+                outputUID: preparation.output.uid,
+                sampleRate: preparation.output.nominalSampleRate,
+                tapSampleRate: preparation.runtime.sampleRate,
+                frameSize: preparation.output.bufferFrameSize,
+                targetFrames: targetFrames,
+                startedAt: ContinuousClock().now
+            )
+            state.playbackBufferCalibrationProbe = probe
+            return .adjusted
+        }
+        if let probe {
+            try? PersistedPlaybackBufferCalibrationStore.beginProbe(
+                outputUID: probe.outputUID,
+                sampleRate: probe.sampleRate,
+                tapSampleRate: probe.tapSampleRate,
+                frameSize: probe.frameSize,
+                targetFrames: probe.targetFrames,
+                at: playbackBufferCalibrationStoreURL
+            )
+        }
+        return result
+    }
+
+    private func resumePlaybackBufferDecayAfterFailure(
+        _ preparation: PlaybackBufferDecayPreparation
+    ) {
+        control.withLock { state in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return
+            }
+            state.playbackBufferStableSince = ContinuousClock().now
+        }
+    }
+
+    private func failPlaybackBufferFrameSizeDecay(
+        _ preparation: PlaybackBufferDecayPreparation,
+        candidate: PlaybackBufferFrameSizeDecayCandidate
+    ) {
+        control.withLock { state in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return
+            }
+            state.failedPlaybackFrameSizeDecayCandidates.insert(candidate)
+            state.playbackBufferStableSince = nil
+            preparation.runtime.reprimePlayback()
+        }
+    }
+
+    private func continueCalibrationAfterUnresolvedInstability(
+        _ preparation: PlaybackBufferRenegotiationPreparation
+    ) {
+        let targetFrames = preparation.runtime.playbackTargetFrames()
+        let instability = UnresolvedPlaybackBufferInstability(
+            outputUID: preparation.output.uid,
+            sampleRate: preparation.output.nominalSampleRate,
+            tapSampleRate: preparation.runtime.sampleRate,
+            frameSize: preparation.output.bufferFrameSize,
+            targetFrames: targetFrames,
+            reason: preparation.reason
+        )
+        let shouldPersist = control.withLock { state -> Bool? in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return nil
+            }
+            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
+                outputUID: preparation.output.uid,
+                sampleRate: preparation.output.nominalSampleRate,
+                tapSampleRate: preparation.runtime.sampleRate,
+                frameSize: preparation.output.bufferFrameSize,
+                targetFrames: targetFrames,
+                startedAt: ContinuousClock().now
+            )
+            return state.playbackBufferInstabilityPersistenceGate.shouldPersist(instability)
+        }
+        guard shouldPersist == true else {
+            return
+        }
+        do {
+            try PersistedPlaybackBufferCalibrationStore.recordInstability(
+                outputUID: preparation.output.uid,
+                sampleRate: preparation.output.nominalSampleRate,
+                tapSampleRate: preparation.runtime.sampleRate,
+                previousFrameSize: preparation.output.bufferFrameSize,
+                resultingFrameSize: preparation.output.bufferFrameSize,
+                previousTargetFrames: targetFrames,
+                resultingTargetFrames: targetFrames,
+                reason: preparation.reason,
+                at: playbackBufferCalibrationStoreURL
+            )
+        } catch {
+            control.withLock { state in
+                state.playbackBufferInstabilityPersistenceGate.persistenceFailed(for: instability)
+            }
+        }
+    }
+
+    private func recoverFailedPlaybackBufferRenegotiation(
+        _ preparation: PlaybackBufferRenegotiationPreparation
+    ) {
+        control.withLock { state in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output else {
+                return
+            }
+            preparation.runtime.reprimePlayback()
+        }
+    }
+
+    private func recoverAdaptivePlaybackRenderFailure(
+        _ preparation: PlaybackBufferRenegotiationPreparation
+    ) {
+        let action = control.withLock { state -> AdaptivePlaybackRenderRecoveryAction? in
+            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
+                  state.runtime === preparation.runtime,
+                  state.activeOutput == preparation.output,
+                  preparation.runtime.hasActiveAdaptivePlaybackRenderFailure(),
+                  let profile = state.activeProfile else {
+                return nil
+            }
+            if AdaptivePlaybackRenderRecoveryPolicy.shouldRestart(
+                afterCompletedAttempts: state.adaptivePlaybackRenderRecoveryAttempts
+            ) {
+                state.adaptivePlaybackRenderRecoveryAttempts += 1
+                state.adaptivePlaybackRenderRecoveryHealthGeneration = preparation.runtime
+                    .playbackRenderHealthGeneration()
+                return .restart(
+                    output: preparation.output,
+                    profile: profile,
+                    expectation: OutputRebuildExpectation(
+                        generation: state.outputRebuildGeneration,
+                        runtime: preparation.runtime,
+                        profileRevision: state.profileRevision
+                    )
+                )
+            }
+
+            let failure = AudioEngineFailure(
+                category: .coreAudioOperationFailed,
+                userMessage: "Adaptive playback rendering repeatedly failed, so GlassEQ stopped processing audio.",
+                operation: "AdaptivePlaybackRender"
+            )
+            stopLocked(&state)
+            state.state = .failed(failure.description)
+            state.status = .failed(failure)
+            return .fail(failure)
+        }
+        guard let action else {
+            return
+        }
+
+        switch action {
+        case .restart(let output, let profile, let expectation):
+            do {
+                try start(
+                    output: output,
+                    profile: profile,
+                    expectation: expectation
+                )
+            } catch {
+                let failure = control.withLock { state in
+                    if case .failed(let failure) = state.status {
+                        return failure
+                    }
+                    return audioEngineFailure(from: error)
+                }
+                runtimeFailureHandler.withLock { $0 }?(failure)
+            }
+        case .fail(let failure):
+            updatePlaybackBufferAdaptationTimer()
+            runtimeFailureHandler.withLock { $0 }?(failure)
+        }
+    }
+
+    static func renegotiatedPlaybackOutput(
+        _ output: AudioOutputDevice,
+        supportedRange: AudioBufferFrameSizeRange,
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:),
+        queryOutput: (AudioObjectID) throws -> AudioOutputDevice = CoreAudioDeviceQuery.outputDevice(id:),
+        waitForPropertySettlement: () -> Void = { Thread.sleep(forTimeInterval: 0.01) }
+    ) throws -> AudioOutputDevice? {
+        guard let requestedFrameSize = AdaptivePlaybackBufferPolicy.nextFrameSize(
+            after: output.bufferFrameSize,
+            supportedRange: supportedRange
+        ) else {
+            return nil
+        }
+
+        try setBufferFrameSize(requestedFrameSize, output.id)
+        for attempt in 0..<3 {
+            let updatedOutput = try queryOutput(output.id)
+            if updatedOutput.id == output.id,
+               updatedOutput.bufferFrameSize > output.bufferFrameSize {
+                return updatedOutput
+            }
+            if attempt < 2 {
+                waitForPropertySettlement()
+            }
+        }
+        return nil
+    }
+
+    static func decayedPlaybackOutput(
+        _ output: AudioOutputDevice,
+        supportedRange: AudioBufferFrameSizeRange,
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:),
+        queryOutput: (AudioObjectID) throws -> AudioOutputDevice = CoreAudioDeviceQuery.outputDevice(id:),
+        waitForPropertySettlement: () -> Void = { Thread.sleep(forTimeInterval: 0.01) }
+    ) throws -> AudioOutputDevice? {
+        guard let requestedFrameSize = AdaptivePlaybackBufferPolicy.previousFrameSize(
+            before: output.bufferFrameSize,
+            supportedRange: supportedRange
+        ) else {
+            return nil
+        }
+
+        try setBufferFrameSize(requestedFrameSize, output.id)
+        for attempt in 0..<3 {
+            let updatedOutput = try queryOutput(output.id)
+            if updatedOutput.id == output.id,
+               updatedOutput.bufferFrameSize < output.bufferFrameSize {
+                return updatedOutput
+            }
+            if attempt < 2 {
+                waitForPropertySettlement()
+            }
+        }
+        return nil
+    }
+
+    static func preferredBufferFrameSize(for output: AudioOutputDevice) -> UInt32 {
+        if isLowSampleRateRoute(output) {
+            return Self.preferredLowSampleRateBufferFrameSize
+        }
+        if output.isBluetoothTransport {
+            return Self.preferredBluetoothBufferFrameSize
+        }
+        // Low-latency: request a small output buffer rather than keeping the device's larger
+        // default. Clamped to the device's supported range by the caller (tuneBufferFrameSize).
+        return Self.preferredBufferFrameSize
+    }
+
+    static func preferredPlaybackPrimeFrames(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double? = nil,
+        captureCallbackFrames: Int = preferredLowSampleRatePlaybackReservoirFrames
+    ) -> Int {
+        let outputCallbackFrames = max(Int(output.bufferFrameSize), 1)
+        if hasLowSampleRateEndpoint(
+            tapSampleRate: tapSampleRate ?? output.nominalSampleRate,
+            output: output
+        ) {
+            let sampleRatePlan = PlaybackSampleRatePlan(
+                inputSampleRate: tapSampleRate ?? output.nominalSampleRate,
+                outputSampleRate: output.nominalSampleRate
+            )
+            let reservoirFrames = min(
+                max(captureCallbackFrames, Self.preferredLowSampleRatePlaybackReservoirFrames),
+                Self.maximumSupportedCallbackFrames
+            )
+            return max(
+                sampleRatePlan.inputFrames(forOutputFrames: Int(Self.preferredLowSampleRateBufferFrameSize)),
+                sampleRatePlan.inputFrames(forOutputFrames: outputCallbackFrames)
+                    + reservoirFrames
+            )
+        }
+        if output.isBluetoothTransport {
+            return max(
+                Self.preferredBluetoothPlaybackTargetFrames,
+                outputCallbackFrames + Self.preferredBluetoothPlaybackReservoirFrames
+            )
+        }
+        return max(
+            Self.preferredPlaybackPrimeFrames,
+            outputCallbackFrames + Int(Self.preferredCaptureBufferFrameSize)
+        )
+    }
+
+    static func shouldAdaptPlaybackBuffer(for output: AudioOutputDevice) -> Bool {
+        output.nominalSampleRate > 0
+    }
+
+    static func playbackInputCallbackFrames(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double
+    ) -> UInt32 {
+        UInt32(clamping: PlaybackSampleRatePlan(
+            inputSampleRate: tapSampleRate,
+            outputSampleRate: output.nominalSampleRate
+        ).inputFrames(forOutputFrames: Int(output.bufferFrameSize)))
+    }
+
+    static func startupCaptureCallbackFrames(reportedFrames: UInt32?) -> Int {
+        guard let reportedFrames,
+              reportedFrames > 0,
+              reportedFrames <= UInt32(maximumSupportedCallbackFrames) else {
+            return maximumSupportedCallbackFrames
+        }
+        return Int(reportedFrames)
+    }
+
+    static func shouldUseSampleRateConversion(
+        tapSampleRate: Double,
+        output: AudioOutputDevice
+    ) -> Bool {
+        abs(tapSampleRate - output.nominalSampleRate) >= 1
+            && hasLowSampleRateEndpoint(tapSampleRate: tapSampleRate, output: output)
+    }
+
+    static func shouldRecordSampleRateRestoration(
+        tapSampleRate: Double,
+        output: AudioOutputDevice
+    ) -> Bool {
+        tapSampleRate > 0
+            && abs(output.nominalSampleRate - tapSampleRate) >= 1
+            && !shouldUseSampleRateConversion(tapSampleRate: tapSampleRate, output: output)
+    }
+
+    static func effectiveOutputRebuildProfile(
+        preparedProfile: EQProfile,
+        preparedProfileRevision: UInt64,
+        activeProfile: EQProfile?,
+        activeProfileRevision: UInt64
+    ) -> EQProfile {
+        guard activeProfileRevision != preparedProfileRevision,
+              let activeProfile else {
+            return preparedProfile
+        }
+        return activeProfile
+    }
+
+    static func requestedOutputRebuildProfile(
+        requestedProfile: EQProfile,
+        expectedProfileRevision: UInt64?,
+        activeProfile: EQProfile?,
+        activeProfileRevision: UInt64
+    ) -> EQProfile? {
+        guard let expectedProfileRevision,
+              activeProfileRevision != expectedProfileRevision else {
+            return requestedProfile
+        }
+        return activeProfile
+    }
+
+    static func profileUpdateOutput(_ output: AudioOutputDevice?) throws -> AudioOutputDevice {
+        guard let output else {
+            throw AudioEngineProfileUpdateUnavailable()
+        }
+        return output
+    }
+
+    static func shouldRefreshCaptureForOutput(
+        tapSampleRate: Double,
+        output: AudioOutputDevice
+    ) -> Bool {
+        isLowSampleRate(tapSampleRate)
+            && output.nominalSampleRate - tapSampleRate >= 1
+    }
+
+    static func maximumPlaybackReservoirFrames(
+        for output: AudioOutputDevice,
+        tapSampleRate: Double,
+        maximumKnownCaptureCallbackFrames: Int
+    ) -> Int {
+        guard hasLowSampleRateEndpoint(tapSampleRate: tapSampleRate, output: output) else {
+            return AdaptivePlaybackBufferPolicy.maximumReservoirFrames
+        }
+        return max(
+            Self.preferredLowSampleRatePlaybackReservoirFrames,
+            maximumKnownCaptureCallbackFrames
+        )
+    }
+
+    private static func isLowSampleRateRoute(_ output: AudioOutputDevice) -> Bool {
+        isLowSampleRate(output.nominalSampleRate)
+    }
+
+    private static func isLowSampleRate(_ sampleRate: Double) -> Bool {
+        sampleRate > 0 && sampleRate <= Self.lowSampleRateThreshold
+    }
+
+    private static func hasLowSampleRateEndpoint(
+        tapSampleRate: Double,
+        output: AudioOutputDevice
+    ) -> Bool {
+        isLowSampleRate(tapSampleRate) || isLowSampleRateRoute(output)
+    }
+
+    private func createTopologyRebuildMuteGuard() throws -> any TopologyRebuildMuteGuarding {
+        let tapID = try createSystemTap(name: "GlassEQ Profile Rebuild Mute Tap")
+        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        var ioProcID: AudioDeviceIOProcID?
+
+        do {
+            aggregateDeviceID = try createPrivateAggregateDevice(tapID: tapID)
+            ioProcID = try createSilenceIOProc(deviceID: aggregateDeviceID)
+            try checkOSStatus(
+                AudioDeviceStart(aggregateDeviceID, ioProcID),
+                operation: "AudioDeviceStart(profile rebuild mute tap)"
+            )
+            return CoreAudioTopologyRebuildMuteGuard(
+                tapID: tapID,
+                aggregateDeviceID: aggregateDeviceID,
+                ioProcID: ioProcID
+            )
+        } catch {
+            if aggregateDeviceID != kAudioObjectUnknown, let ioProcID {
+                _ = AudioDeviceStop(aggregateDeviceID, ioProcID)
+                _ = AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProcID)
+            }
+            if aggregateDeviceID != kAudioObjectUnknown {
+                _ = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            }
+            _ = AudioHardwareDestroyProcessTap(tapID)
+            throw error
+        }
+    }
+
+    private func createSystemTap(name: String = "GlassEQ System Output Tap") throws -> AudioObjectID {
+        let ownProcess = try currentAudioProcessObjectID()
+        // Global tap (not bound to a device): one muted tap removes the dry system mix from
+        // every output device and survives default-output switches without rebuild, so dry
+        // audio never leaks to a newly selected device during the route handoff. Verified on
+        // hardware across built-in / USB / Bluetooth / HDMI and 44.1k–192k device rates.
+        let description = CATapDescription(stereoGlobalTapButExcludeProcesses: [ownProcess])
+        description.name = name
+        description.uuid = UUID()
+        description.isPrivate = true
+        description.muteBehavior = CATapMuteBehavior.muted
+
+        var tapID = AudioObjectID(kAudioObjectUnknown)
+        try checkOSStatus(
+            AudioHardwareCreateProcessTap(description, &tapID),
+            operation: "AudioHardwareCreateProcessTap"
+        )
+        return tapID
+    }
+
+    private func tapStreamFormat(_ tapID: AudioObjectID) throws -> AudioStreamBasicDescription {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var asbd = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(tapID, &address, 0, nil, &size, &asbd),
+            operation: "AudioObjectGetPropertyData(tap format)"
+        )
+        try CoreAudioDeviceQuery.validatePropertySize(
+            actual: size,
+            expected: UInt32(MemoryLayout<AudioStreamBasicDescription>.size),
+            operation: "AudioObjectGetPropertyData(tap format)",
+            objectID: tapID
+        )
+        return asbd
+    }
+
+    private func createPrivateAggregateDevice(tapID: AudioObjectID) throws -> AudioObjectID {
+        let tapUID = try tapUID(tapID)
+        let aggregateUID = "com.glasseq.aggregate.\(UUID().uuidString)"
+        let description: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "GlassEQ Private Tap Device",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapUIDKey: tapUID
+                ]
+            ]
+        ]
+
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        try checkOSStatus(
+            AudioHardwareCreateAggregateDevice(description as CFDictionary, &deviceID),
+            operation: "AudioHardwareCreateAggregateDevice"
+        )
+        return deviceID
+    }
+
+    private func createCaptureIOProc(deviceID: AudioObjectID, runtime: AudioRuntime) throws -> AudioDeviceIOProcID? {
+        var ioProcID: AudioDeviceIOProcID?
+
+        try checkOSStatus(
+            AudioDeviceCreateIOProcIDWithBlock(&ioProcID, deviceID, nil) { _, inputData, _, outputData, _ in
+                runtime.capture(inputData: inputData)
+                runtime.clear(outputData: outputData)
+            },
+            operation: "AudioDeviceCreateIOProcIDWithBlock(capture)"
+        )
+
+        return ioProcID
+    }
+
+    private func createSilenceIOProc(deviceID: AudioObjectID) throws -> AudioDeviceIOProcID? {
+        var ioProcID: AudioDeviceIOProcID?
+
+        try checkOSStatus(
+            AudioDeviceCreateIOProcIDWithBlock(&ioProcID, deviceID, nil) { _, _, _, outputData, _ in
+                Self.clear(outputData: outputData)
+            },
+            operation: "AudioDeviceCreateIOProcIDWithBlock(profile rebuild mute tap)"
+        )
+
+        return ioProcID
+    }
+
+    private func createOutputIOProc(deviceID: AudioObjectID, runtime: AudioRuntime) throws -> AudioDeviceIOProcID? {
+        var ioProcID: AudioDeviceIOProcID?
+
+        try checkOSStatus(
+            AudioDeviceCreateIOProcIDWithBlock(&ioProcID, deviceID, nil) { _, _, _, outputData, outputTime in
+                let outputTimestamp = outputTime.pointee
+                let sampleTime: Double? = if outputTimestamp.mFlags.contains(.sampleTimeValid) {
+                    outputTimestamp.mSampleTime
+                } else {
+                    nil
+                }
+                runtime.playback(outputData: outputData, outputSampleTime: sampleTime)
+            },
+            operation: "AudioDeviceCreateIOProcIDWithBlock(output)"
+        )
+
+        return ioProcID
+    }
+
+    private static func clear(outputData: UnsafeMutablePointer<AudioBufferList>) {
+        for buffer in UnsafeMutableAudioBufferListPointer(outputData) {
+            guard let data = buffer.mData else {
+                continue
+            }
+            let byteCount = Int(buffer.mDataByteSize)
+            let maxByteCount = Int(CoreAudioDeviceQuery.maxBufferFrameSize)
+                * CoreAudioDeviceQuery.maxChannelCount
+                * MemoryLayout<Float>.stride
+            guard byteCount >= 0,
+                  byteCount <= maxByteCount else {
+                continue
+            }
+            data.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+        }
+    }
+
+    private func tapUID(_ tapID: AudioObjectID) throws -> String {
+        try CoreAudioDeviceQuery.getStringProperty(
+            objectID: tapID,
+            selector: kAudioTapPropertyUID,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+    }
+
+    private func currentAudioProcessObjectID() throws -> AudioObjectID {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var pid = getpid()
+        var processID = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let qualifierSize = UInt32(MemoryLayout<pid_t>.size)
+
+        try checkOSStatus(
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                qualifierSize,
+                &pid,
+                &size,
+                &processID
+            ),
+            operation: "AudioObjectGetPropertyData(translate pid)"
+        )
+
+        guard processID != kAudioObjectUnknown else {
+            throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
+                AudioObjectID(kAudioObjectSystemObject),
+                "current audio process object is unknown"
+            )
+        }
+        return processID
+    }
+}

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -1,4 +1,3 @@
-import AudioToolbox
 import CoreAudio
 import Foundation
 import GlassEQCore
@@ -8,6 +7,35 @@ public enum AudioEngineState: Equatable, Sendable {
     case stopped
     case running(output: AudioOutputDevice)
     case failed(String)
+}
+
+public enum HeadsetAggregatePromotionResult: Equatable, Sendable {
+    case notApplicable
+    case clockUnstable
+    case aggregateUnstable
+    case promoted(AudioOutputDevice)
+}
+
+public struct AggregateAudioRouteFingerprint: Codable, Equatable, Hashable, Sendable {
+    public var outputDeviceUID: String
+    public var nativeOutputStreamIndex: Int
+    public var nominalSampleRate: Int64
+
+    public init(
+        outputDeviceUID: String,
+        nativeOutputStreamIndex: Int,
+        nominalSampleRate: Double
+    ) {
+        self.outputDeviceUID = outputDeviceUID
+        self.nativeOutputStreamIndex = nativeOutputStreamIndex
+        self.nominalSampleRate = Int64(nominalSampleRate.rounded())
+    }
+
+    public var isValid: Bool {
+        !outputDeviceUID.isEmpty
+            && nativeOutputStreamIndex >= 0
+            && nominalSampleRate > 0
+    }
 }
 
 public struct AudioEngineMetrics: Equatable, Sendable {
@@ -24,6 +52,18 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var minimumPlaybackBufferedFrames: Int
     public var averagePlaybackBufferedFrames: Double
     public var playbackBufferObservations: UInt64
+    public var inputTimestampDiscontinuities: UInt64
+    public var outputTimestampDiscontinuities: UInt64
+    public var pairedTimestampDiscontinuities: UInt64
+    public var qualifyingPairedTimestampDiscontinuities: UInt64
+    public var lastInputTimestampJumpFrames: Double
+    public var lastOutputTimestampJumpFrames: Double
+    public var lastInputHostIntervalErrorNanoseconds: Int64
+    public var lastOutputHostIntervalErrorNanoseconds: Int64
+    public var timestampJumpIntervalObservations: UInt64
+    public var minimumTimestampJumpIntervalNanoseconds: UInt64
+    public var maximumTimestampJumpIntervalNanoseconds: UInt64
+    public var averageTimestampJumpIntervalNanoseconds: Double
     public var maximumCaptureCallbackFrames: Int
     public var maximumPlaybackCallbackFrames: Int
     public var playbackTimestampDiscontinuities: UInt64
@@ -35,6 +75,17 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var filteredPlaybackOccupancyFrames: Double
     public var playbackBufferSampleRate: Double
     public var playbackSampleRateConversionActive: Bool
+    public var tapToOutputLatencyObservations: UInt64
+    public var minimumTapToOutputLatencyNanoseconds: UInt64
+    public var maximumTapToOutputLatencyNanoseconds: UInt64
+    public var averageTapToOutputLatencyNanoseconds: Double
+    public var callbackTimingObservations: UInt64
+    public var minimumInputAgeNanoseconds: UInt64
+    public var maximumInputAgeNanoseconds: UInt64
+    public var averageInputAgeNanoseconds: Double
+    public var minimumOutputLeadNanoseconds: UInt64
+    public var maximumOutputLeadNanoseconds: UInt64
+    public var averageOutputLeadNanoseconds: Double
 
     public init(
         capturedFrames: UInt64 = 0,
@@ -50,6 +101,18 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         minimumPlaybackBufferedFrames: Int = 0,
         averagePlaybackBufferedFrames: Double = 0,
         playbackBufferObservations: UInt64 = 0,
+        inputTimestampDiscontinuities: UInt64 = 0,
+        outputTimestampDiscontinuities: UInt64 = 0,
+        pairedTimestampDiscontinuities: UInt64 = 0,
+        qualifyingPairedTimestampDiscontinuities: UInt64 = 0,
+        lastInputTimestampJumpFrames: Double = 0,
+        lastOutputTimestampJumpFrames: Double = 0,
+        lastInputHostIntervalErrorNanoseconds: Int64 = 0,
+        lastOutputHostIntervalErrorNanoseconds: Int64 = 0,
+        timestampJumpIntervalObservations: UInt64 = 0,
+        minimumTimestampJumpIntervalNanoseconds: UInt64 = 0,
+        maximumTimestampJumpIntervalNanoseconds: UInt64 = 0,
+        averageTimestampJumpIntervalNanoseconds: Double = 0,
         maximumCaptureCallbackFrames: Int = 0,
         maximumPlaybackCallbackFrames: Int = 0,
         playbackTimestampDiscontinuities: UInt64 = 0,
@@ -60,7 +123,18 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         playbackOccupancyTargetFrames: Int = 0,
         filteredPlaybackOccupancyFrames: Double = 0,
         playbackBufferSampleRate: Double = 0,
-        playbackSampleRateConversionActive: Bool = false
+        playbackSampleRateConversionActive: Bool = false,
+        tapToOutputLatencyObservations: UInt64 = 0,
+        minimumTapToOutputLatencyNanoseconds: UInt64 = 0,
+        maximumTapToOutputLatencyNanoseconds: UInt64 = 0,
+        averageTapToOutputLatencyNanoseconds: Double = 0,
+        callbackTimingObservations: UInt64 = 0,
+        minimumInputAgeNanoseconds: UInt64 = 0,
+        maximumInputAgeNanoseconds: UInt64 = 0,
+        averageInputAgeNanoseconds: Double = 0,
+        minimumOutputLeadNanoseconds: UInt64 = 0,
+        maximumOutputLeadNanoseconds: UInt64 = 0,
+        averageOutputLeadNanoseconds: Double = 0
     ) {
         self.capturedFrames = capturedFrames
         self.playedFrames = playedFrames
@@ -75,6 +149,18 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.minimumPlaybackBufferedFrames = minimumPlaybackBufferedFrames
         self.averagePlaybackBufferedFrames = averagePlaybackBufferedFrames
         self.playbackBufferObservations = playbackBufferObservations
+        self.inputTimestampDiscontinuities = inputTimestampDiscontinuities
+        self.outputTimestampDiscontinuities = outputTimestampDiscontinuities
+        self.pairedTimestampDiscontinuities = pairedTimestampDiscontinuities
+        self.qualifyingPairedTimestampDiscontinuities = qualifyingPairedTimestampDiscontinuities
+        self.lastInputTimestampJumpFrames = lastInputTimestampJumpFrames
+        self.lastOutputTimestampJumpFrames = lastOutputTimestampJumpFrames
+        self.lastInputHostIntervalErrorNanoseconds = lastInputHostIntervalErrorNanoseconds
+        self.lastOutputHostIntervalErrorNanoseconds = lastOutputHostIntervalErrorNanoseconds
+        self.timestampJumpIntervalObservations = timestampJumpIntervalObservations
+        self.minimumTimestampJumpIntervalNanoseconds = minimumTimestampJumpIntervalNanoseconds
+        self.maximumTimestampJumpIntervalNanoseconds = maximumTimestampJumpIntervalNanoseconds
+        self.averageTimestampJumpIntervalNanoseconds = averageTimestampJumpIntervalNanoseconds
         self.maximumCaptureCallbackFrames = maximumCaptureCallbackFrames
         self.maximumPlaybackCallbackFrames = maximumPlaybackCallbackFrames
         self.playbackTimestampDiscontinuities = playbackTimestampDiscontinuities
@@ -86,18 +172,125 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.filteredPlaybackOccupancyFrames = filteredPlaybackOccupancyFrames
         self.playbackBufferSampleRate = playbackBufferSampleRate
         self.playbackSampleRateConversionActive = playbackSampleRateConversionActive
+        self.tapToOutputLatencyObservations = tapToOutputLatencyObservations
+        self.minimumTapToOutputLatencyNanoseconds = minimumTapToOutputLatencyNanoseconds
+        self.maximumTapToOutputLatencyNanoseconds = maximumTapToOutputLatencyNanoseconds
+        self.averageTapToOutputLatencyNanoseconds = averageTapToOutputLatencyNanoseconds
+        self.callbackTimingObservations = callbackTimingObservations
+        self.minimumInputAgeNanoseconds = minimumInputAgeNanoseconds
+        self.maximumInputAgeNanoseconds = maximumInputAgeNanoseconds
+        self.averageInputAgeNanoseconds = averageInputAgeNanoseconds
+        self.minimumOutputLeadNanoseconds = minimumOutputLeadNanoseconds
+        self.maximumOutputLeadNanoseconds = maximumOutputLeadNanoseconds
+        self.averageOutputLeadNanoseconds = averageOutputLeadNanoseconds
     }
 }
 
-protocol TopologyRebuildMuteGuarding: AnyObject {
-    func release()
+public struct AudioTimestampProbeRecord: Equatable, Sendable {
+    public var sequence: UInt64
+    public var inputJumpDetected: Bool
+    public var outputJumpDetected: Bool
+    public var inputFrameCount: Int
+    public var outputFrameCount: Int
+    public var inputSampleTime: Float64
+    public var inputHostTime: UInt64
+    public var inputRateScalar: Float64
+    public var inputFlags: UInt32
+    public var outputSampleTime: Float64
+    public var outputHostTime: UInt64
+    public var outputRateScalar: Float64
+    public var outputFlags: UInt32
+    public var inputSampleTimeDeltaFrames: Double
+    public var outputSampleTimeDeltaFrames: Double
+    public var inputHostIntervalErrorNanoseconds: Int64
+    public var outputHostIntervalErrorNanoseconds: Int64
+
+    public init(
+        sequence: UInt64 = 0,
+        inputJumpDetected: Bool = false,
+        outputJumpDetected: Bool = false,
+        inputFrameCount: Int = 0,
+        outputFrameCount: Int = 0,
+        inputSampleTime: Float64 = 0,
+        inputHostTime: UInt64 = 0,
+        inputRateScalar: Float64 = 0,
+        inputFlags: UInt32 = 0,
+        outputSampleTime: Float64 = 0,
+        outputHostTime: UInt64 = 0,
+        outputRateScalar: Float64 = 0,
+        outputFlags: UInt32 = 0,
+        inputSampleTimeDeltaFrames: Double = 0,
+        outputSampleTimeDeltaFrames: Double = 0,
+        inputHostIntervalErrorNanoseconds: Int64 = 0,
+        outputHostIntervalErrorNanoseconds: Int64 = 0
+    ) {
+        self.sequence = sequence
+        self.inputJumpDetected = inputJumpDetected
+        self.outputJumpDetected = outputJumpDetected
+        self.inputFrameCount = inputFrameCount
+        self.outputFrameCount = outputFrameCount
+        self.inputSampleTime = inputSampleTime
+        self.inputHostTime = inputHostTime
+        self.inputRateScalar = inputRateScalar
+        self.inputFlags = inputFlags
+        self.outputSampleTime = outputSampleTime
+        self.outputHostTime = outputHostTime
+        self.outputRateScalar = outputRateScalar
+        self.outputFlags = outputFlags
+        self.inputSampleTimeDeltaFrames = inputSampleTimeDeltaFrames
+        self.outputSampleTimeDeltaFrames = outputSampleTimeDeltaFrames
+        self.inputHostIntervalErrorNanoseconds = inputHostIntervalErrorNanoseconds
+        self.outputHostIntervalErrorNanoseconds = outputHostIntervalErrorNanoseconds
+    }
 }
 
-struct TopologyRebuildMuteGuardUnavailable: Error, LocalizedError {
-    var underlyingError: any Error
+public struct AudioDeviceLatencyMetadata: Equatable, Sendable {
+    public var objectID: AudioObjectID
+    public var bufferFrameSize: UInt32?
+    public var inputStreamChannelCounts: [Int]?
+    public var outputStreamChannelCounts: [Int]?
+    public var inputLatencyFrames: UInt32?
+    public var inputSafetyOffsetFrames: UInt32?
+    public var inputSafetyOffsetSettable: Bool?
+    public var outputLatencyFrames: UInt32?
+    public var outputSafetyOffsetFrames: UInt32?
+    public var outputSafetyOffsetSettable: Bool?
 
-    var errorDescription: String? {
-        "GlassEQ could not guarantee silence for a profile rebuild, so the current audio engine was left running."
+    public init(
+        objectID: AudioObjectID,
+        bufferFrameSize: UInt32?,
+        inputStreamChannelCounts: [Int]?,
+        outputStreamChannelCounts: [Int]?,
+        inputLatencyFrames: UInt32?,
+        inputSafetyOffsetFrames: UInt32?,
+        inputSafetyOffsetSettable: Bool?,
+        outputLatencyFrames: UInt32?,
+        outputSafetyOffsetFrames: UInt32?,
+        outputSafetyOffsetSettable: Bool?
+    ) {
+        self.objectID = objectID
+        self.bufferFrameSize = bufferFrameSize
+        self.inputStreamChannelCounts = inputStreamChannelCounts
+        self.outputStreamChannelCounts = outputStreamChannelCounts
+        self.inputLatencyFrames = inputLatencyFrames
+        self.inputSafetyOffsetFrames = inputSafetyOffsetFrames
+        self.inputSafetyOffsetSettable = inputSafetyOffsetSettable
+        self.outputLatencyFrames = outputLatencyFrames
+        self.outputSafetyOffsetFrames = outputSafetyOffsetFrames
+        self.outputSafetyOffsetSettable = outputSafetyOffsetSettable
+    }
+}
+
+public struct AudioEngineLatencyMetadata: Equatable, Sendable {
+    public var physicalDevice: AudioDeviceLatencyMetadata
+    public var aggregateDevice: AudioDeviceLatencyMetadata
+
+    public init(
+        physicalDevice: AudioDeviceLatencyMetadata,
+        aggregateDevice: AudioDeviceLatencyMetadata
+    ) {
+        self.physicalDevice = physicalDevice
+        self.aggregateDevice = aggregateDevice
     }
 }
 
@@ -115,129 +308,113 @@ struct AudioEngineProfileUpdateUnavailable: Error, LocalizedError {
     }
 }
 
+struct RealtimeOutputFade: Sendable {
+    // Five milliseconds removes callback-boundary steps without delaying steady-state audio.
+    static let durationSeconds = 0.005
+
+    private let rampFrameCount: Int
+    private(set) var gain: Float
+    private var startGain: Float
+    private var targetGain: Float
+    private var completedFrames = 0
+    private var remainingFrames = 0
+
+    init(
+        sampleRate: Double,
+        initiallyMuted: Bool = true,
+        durationSeconds: Double = Self.durationSeconds
+    ) {
+        let validSampleRate = sampleRate.isFinite && sampleRate > 0 ? sampleRate : 48_000
+        let validDuration = durationSeconds.isFinite && durationSeconds > 0
+            ? durationSeconds
+            : Self.durationSeconds
+        self.rampFrameCount = max(Int((validSampleRate * validDuration).rounded()), 1)
+        let initialGain: Float = initiallyMuted ? 0 : 1
+        self.gain = initialGain
+        self.startGain = initialGain
+        self.targetGain = initialGain
+    }
+
+    var isMuted: Bool {
+        remainingFrames == 0 && gain == 0
+    }
+
+    mutating func setMuted(_ isMuted: Bool) {
+        let nextTarget: Float = isMuted ? 0 : 1
+        guard nextTarget != targetGain else {
+            return
+        }
+        startGain = gain
+        targetGain = nextTarget
+        completedFrames = 0
+        remainingFrames = rampFrameCount
+    }
+
+    mutating func apply(
+        to samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) {
+        let channels = max(channelCount, 1)
+        let availableFrames = min(max(frameCount, 0), samples.count / channels)
+        guard availableFrames > 0 else {
+            return
+        }
+
+        if remainingFrames == 0 {
+            guard gain != 1 else {
+                return
+            }
+            for index in 0..<(availableFrames * channels) {
+                samples[index] = 0
+            }
+            return
+        }
+
+        var sampleIndex = 0
+        for _ in 0..<availableFrames {
+            let frameGain = gain
+            for channel in 0..<channels {
+                samples[sampleIndex + channel] *= frameGain
+            }
+            sampleIndex += channels
+            advance()
+        }
+    }
+
+    private mutating func advance() {
+        guard remainingFrames > 0 else {
+            return
+        }
+        remainingFrames -= 1
+        if remainingFrames == 0 {
+            gain = targetGain
+        } else {
+            completedFrames += 1
+            let progress = Float(completedFrames) / Float(rampFrameCount)
+            let smoothedProgress = progress * progress * (3 - 2 * progress)
+            gain = startGain + (targetGain - startGain) * smoothedProgress
+        }
+    }
+}
+
 public final class SystemTapAudioEngine: @unchecked Sendable {
-    private static let preferredBufferFrameSize: UInt32 = 64
-    private static let preferredBluetoothBufferFrameSize: UInt32 = 64
-    private static let preferredBluetoothPlaybackTargetFrames = 128
-    // Leaves one preferred 64-frame capture callback after servicing a 64-frame output pull.
-    private static let preferredBluetoothPlaybackReservoirFrames = 64
-    private static let preferredLowSampleRateBufferFrameSize: UInt32 = 1024
-    // Low-rate routes keep at least one normal runtime callback in reserve. The configured
-    // capture callback expands this at startup when the aggregate ignores the 64-frame request.
-    private static let preferredLowSampleRatePlaybackReservoirFrames = Int(maximumRuntimeBufferFrameSize)
-    private static let preferredCaptureBufferFrameSize: UInt32 = 64
-    private static let minimumRingBufferFrames = 2048
-    private static let maximumRuntimeBufferFrameSize: UInt32 = 1024
+    private static let preferredAggregateBufferFrameSize: UInt32 = 16
     private static let maximumSupportedCallbackFrames = 8192
-    // Capacity planning allows a 4:1 input/output rate ratio (above the current 48→16 kHz case)
-    // and retains one additional full converted pull as drift headroom.
-    private static let maximumPlannedPlaybackRateRatio = 4
-    private static let playbackRingPullCount = 2
-    private static let preferredPlaybackPrimeFrames = 128
-    private static let lowSampleRateThreshold = 24_000.0
-    private static let maximumPlannedPlaybackPrimeFrames =
-        maximumSupportedCallbackFrames * maximumPlannedPlaybackRateRatio
-            + maximumSupportedCallbackFrames
-    static let runtimeRingCapacityFrames = max(
-        minimumRingBufferFrames,
-        maximumPlannedPlaybackPrimeFrames * playbackRingPullCount
-    )
+    private static let systemSoundServerBundleID = "systemsoundserverd"
+    private static let headsetClockProbeDuration: TimeInterval = 0.5
+    private static let headsetAggregateValidationDuration: TimeInterval = 0.75
+    static let runtimeRingCapacityFrames = SeparateClockAudioBackend.runtimeRingCapacityFrames
 
-    private struct PlaybackBufferOperatingPointKey: Hashable {
+    private enum ActiveBackend: Equatable {
+        case combinedAggregate
+        case separateClock
+    }
+
+    private struct PromotedHeadsetRoute: Equatable {
         var outputUID: String
-        var sampleRate: Int
-        var tapSampleRate: Int
-        var frameSize: UInt32
-
-        init(output: AudioOutputDevice, tapSampleRate: Double) {
-            self.outputUID = output.uid
-            self.sampleRate = Int(output.nominalSampleRate.rounded())
-            self.tapSampleRate = Int(tapSampleRate.rounded())
-            self.frameSize = output.bufferFrameSize
-        }
+        var nominalSampleRate: Int64
     }
-
-    private struct PlaybackBufferRouteKey: Hashable {
-        var outputUID: String
-        var sampleRate: Int
-
-        init(output: AudioOutputDevice) {
-            self.outputUID = output.uid
-            self.sampleRate = Int(output.nominalSampleRate.rounded())
-        }
-    }
-
-    private struct ControlState {
-        var state: AudioEngineState = .stopped
-        var status: AudioEngineStatus = .stopped
-        // Persistent capture half (one global muted tap, kept alive across output switches).
-        var tapID = AudioObjectID(kAudioObjectUnknown)
-        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
-        var captureIOProcID: AudioDeviceIOProcID?
-        var runtime: AudioRuntime?
-        var tapSampleRate: Double = 0
-        var tapChannelCount: Int = 0
-        var captureRunning = false
-        // Swappable output half (rebuilt per output device; low-rate headset modes are converted).
-        var outputIOProcID: AudioDeviceIOProcID?
-        var activeOutput: AudioOutputDevice?
-        var activeProfile: EQProfile?
-        var profileRevision: UInt64 = 0
-        var bufferFrameSizeRestorations: [String: BufferFrameSizeRestoration] = [:]
-        var sampleRateRestorations: [String: SampleRateRestoration] = [:]
-        var outputRebuildGeneration = 0
-        var handledPlaybackInstabilityGeneration: UInt64 = 0
-        var playbackBufferCalibrationProbe: PlaybackBufferCalibrationProbe?
-        var playbackBufferInstabilityPersistenceGate = PlaybackBufferInstabilityPersistenceGate()
-        var attemptedPlaybackTargetDownProbes: Set<PlaybackBufferOperatingPointKey> = []
-        var attemptedPlaybackFrameSizeDownProbes: Set<PlaybackBufferRouteKey> = []
-        var adaptivePlaybackRenderRecoveryAttempts = 0
-        var adaptivePlaybackRenderRecoveryHealthGeneration: UInt64?
-    }
-
-    private struct OutputRebuildPreparation {
-        var generation: Int
-        var output: AudioOutputDevice
-        var profile: EQProfile
-        var runtime: AudioRuntime
-        var tapSampleRate: Double
-        var originalBufferFrameSize: UInt32
-        var profileRevision: UInt64
-    }
-
-    private struct PlaybackBufferRenegotiationPreparation {
-        var outputRebuildGeneration: Int
-        var reason: PlaybackBufferInstabilityReason
-        var output: AudioOutputDevice
-        var runtime: AudioRuntime
-    }
-
-    private struct OutputRebuildExpectation {
-        var generation: Int
-        var runtime: AudioRuntime
-        var profileRevision: UInt64
-    }
-
-    private struct PlaybackBufferTargetAdjustment {
-        var output: AudioOutputDevice
-        var tapSampleRate: Double
-        var previousTargetFrames: Int
-        var targetFrames: Int
-        var reason: PlaybackBufferInstabilityReason
-    }
-
-    private enum PlaybackBufferAdaptationAction {
-        case stabilize(PlaybackBufferCalibrationProbe)
-        case renegotiate(PlaybackBufferRenegotiationPreparation)
-    }
-
-    private enum AdaptivePlaybackRenderRecoveryAction {
-        case restart(output: AudioOutputDevice, profile: EQProfile, expectation: OutputRebuildExpectation)
-        case fail(AudioEngineFailure)
-    }
-
-    private struct StaleOutputRebuild: Error {}
-    private struct StaleProfileRequest: Error {}
 
     struct BufferFrameSizeRestoration: Equatable, Sendable {
         var uid: String
@@ -249,197 +426,370 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         var originalSampleRate: Double
     }
 
-    private final class CoreAudioTopologyRebuildMuteGuard: TopologyRebuildMuteGuarding, @unchecked Sendable {
-        private let lock = NSLock()
-        private var tapID: AudioObjectID
-        private var aggregateDeviceID: AudioObjectID
-        private var ioProcID: AudioDeviceIOProcID?
+    private struct ControlState {
+        var state: AudioEngineState = .stopped
+        var status: AudioEngineStatus = .stopped
+        var tapID = AudioObjectID(kAudioObjectUnknown)
+        var systemSoundTapID = AudioObjectID(kAudioObjectUnknown)
+        var tapOutputUID: String?
+        var tapOutputStreamIndex: Int?
+        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        var ioProcID: AudioDeviceIOProcID?
+        var runtime: AudioRuntime?
+        var lastTimestampProbeRecords: [AudioTimestampProbeRecord] = []
+        var activeOutput: AudioOutputDevice?
+        var activeProfile: EQProfile?
+        var preferredAggregateBufferFrameSize = SystemTapAudioEngine.preferredAggregateBufferFrameSize
+    }
 
-        init(
-            tapID: AudioObjectID,
-            aggregateDeviceID: AudioObjectID,
-            ioProcID: AudioDeviceIOProcID?
-        ) {
-            self.tapID = tapID
-            self.aggregateDeviceID = aggregateDeviceID
-            self.ioProcID = ioProcID
-        }
+    private struct CombinedRoutePreparation {
+        var output: AudioOutputDevice
+        var outputStreamIndex: Int
+        var outputStreamChannelCounts: [Int]
+        var channelPair: (left: Int, right: Int)
+    }
 
-        deinit {
-            release()
-        }
+    private struct CombinedTapSet {
+        var main: AudioObjectID
+        var systemSounds: AudioObjectID
+        var outputUID: String
+        var outputStreamIndex: Int
+    }
 
-        func release() {
-            lock.lock()
-            defer { lock.unlock() }
+    private struct DetachedCombinedAggregate {
+        var deviceID: AudioObjectID
+        var ioProcID: AudioDeviceIOProcID?
+        var runtime: AudioRuntime?
+    }
 
-            if aggregateDeviceID != kAudioObjectUnknown, let ioProcID {
-                _ = AudioDeviceStop(aggregateDeviceID, ioProcID)
-                _ = AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProcID)
-            }
-            if aggregateDeviceID != kAudioObjectUnknown {
-                _ = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
-            }
-            if tapID != kAudioObjectUnknown {
-                _ = AudioHardwareDestroyProcessTap(tapID)
-            }
+    private struct PreparedCombinedAggregate {
+        var taps: CombinedTapSet
+        var deviceID: AudioObjectID
+        var ioProcID: AudioDeviceIOProcID
+        var runtime: AudioRuntime
+        var output: AudioOutputDevice
+        var profile: EQProfile
+    }
 
-            ioProcID = nil
-            aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
-            tapID = AudioObjectID(kAudioObjectUnknown)
-        }
+    private struct CombinedAggregateCreation {
+        var deviceID: AudioObjectID
+        var mainTapUID: String
+        var systemSoundTapUID: String
     }
 
     private final class PreparedDSPConfigBox: @unchecked Sendable {
         let config: EQRenderConfiguration
+        let systemSoundPreampGains: (left: Float, right: Float)
         var retiredStorage: EQProcessorRetiredRenderStorage?
         var nextRetiredPointer: UInt = 0
 
         init(config: EQRenderConfiguration) {
             self.config = config
+            self.systemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
+                for: config
+            )
         }
     }
 
-    private enum AdaptivePlaybackRenderResult {
-        case rendered
-        case underrun(frames: Int)
-        case failed
-    }
-
     private final class AudioRuntime: @unchecked Sendable {
-        let ringBuffer: RealtimeAudioRingBuffer
+        private struct TimestampContinuityState {
+            var expectedSampleTime: Float64?
+            var previousHostTime: UInt64?
+            var previousFrameCount = 0
+            var stableSlopeObservations = 0
+        }
+
+        private struct TimestampJump {
+            var sampleTimeDeltaFrames: Double
+            var hostIntervalErrorNanoseconds: Int64
+            var precededByStableSlope: Bool
+        }
+
         let channelCount: Int
         let sampleRate: Double
-        private let configuredCaptureCallbackFrames: Int
-        private let playbackPrimeFrames: Atomic<Int>
+
+        private let inputChannelOffset: Int
+        private let systemSoundInputChannelOffset: Int
         private let maxCallbackFrames: Int
         private var processor: EQProcessor
-        private var captureScratchSamples: [Float]
-        private var adaptiveInputSamples: [Float]
-        private var sampleRateConverterInputSamples: UnsafeMutableBufferPointer<Float>
-        private let adaptiveOutputSamples: UnsafeMutableBufferPointer<Float>
-        private var playbackRateServo: PlaybackRateServo
-        private var playbackResampler: HermitePlaybackResampler
-        private var playbackSampleRatePlan: PlaybackSampleRatePlan
-        private var playbackSampleRateConverter: RealtimePCMRateConverter?
-        private var sampleRateConverterInputRatio = 1.0
-        private var sampleRateConverterInputResult = AdaptivePlaybackRenderResult.rendered
-        private var outputTimestampTracker = OutputCallbackTimestampTracker()
-
+        private var activeSystemSoundPreampGains: (left: Float, right: Float)
+        private var outputFade: RealtimeOutputFade
+        private var dspTransitionInProgress = false
+        private var activeBypassEnabled: Bool
+        private var scratchSamples: [Float]
+        private var inputTimestampState = TimestampContinuityState()
+        private var outputTimestampState = TimestampContinuityState()
+        private var lastPairedTimestampJumpHostTime: UInt64?
+        private var timestampProbeRecords = Array(
+            repeating: AudioTimestampProbeRecord(),
+            count: 64
+        )
+        private var timestampProbeWriteIndex = 0
+        private var timestampProbeRecordCount = 0
+        private var timestampProbeSequence: UInt64 = 0
         private let capturedFrames = Atomic<UInt64>(0)
         private let playedFrames = Atomic<UInt64>(0)
         private let playbackUnderrunFrames = Atomic<UInt64>(0)
         private let droppedInputFrames = Atomic<UInt64>(0)
-        private let droppedBufferedFrames = Atomic<UInt64>(0)
         private let saturatedSamples = Atomic<UInt64>(0)
-        private let maxBufferedFrames = Atomic<Int>(0)
-        private let maxPlaybackBufferedFrames = Atomic<Int>(0)
-        private let minPlaybackBufferedFrames = Atomic<Int>(Int.max)
-        private let totalPlaybackBufferedFrames = Atomic<UInt64>(0)
-        private let playbackBufferObservations = Atomic<UInt64>(0)
+        private let inputTimestampDiscontinuities = Atomic<UInt64>(0)
+        private let outputTimestampDiscontinuities = Atomic<UInt64>(0)
+        private let pairedTimestampDiscontinuities = Atomic<UInt64>(0)
+        private let qualifyingPairedTimestampDiscontinuities = Atomic<UInt64>(0)
+        private let renderCallbackObservations = Atomic<UInt64>(0)
+        private let lastInputTimestampJumpMilliFrames = Atomic<Int64>(0)
+        private let lastOutputTimestampJumpMilliFrames = Atomic<Int64>(0)
+        private let lastInputHostIntervalErrorNanoseconds = Atomic<Int64>(0)
+        private let lastOutputHostIntervalErrorNanoseconds = Atomic<Int64>(0)
+        private let timestampJumpIntervalObservations = Atomic<UInt64>(0)
+        private let minimumTimestampJumpIntervalNanoseconds = Atomic<UInt64>(.max)
+        private let maximumTimestampJumpIntervalNanoseconds = Atomic<UInt64>(0)
+        private let totalTimestampJumpIntervalNanoseconds = Atomic<UInt64>(0)
         private let maxCaptureCallbackFrames = Atomic<Int>(0)
         private let maxPlaybackCallbackFrames = Atomic<Int>(0)
-        private let playbackTimestampDiscontinuities = Atomic<UInt64>(0)
-        private let playbackBufferRenegotiations = Atomic<UInt64>(0)
-        private let adaptivePlaybackRenderFailures = Atomic<UInt64>(0)
-        private let adaptivePlaybackRenderFailureActive = Atomic<Bool>(false)
-        private let adaptivePlaybackRenderHealthGeneration = Atomic<UInt64>(0)
-        private let playbackInstabilityGeneration = Atomic<UInt64>(0)
-        private let latestPlaybackInstabilityReason = Atomic<UInt8>(PlaybackBufferInstabilityReason.underrun.rawValue)
-        private let adaptivePlaybackTargetFrames: Atomic<Int>
-        private let pendingPlaybackClockReset = Atomic<Bool>(true)
-        private let pendingPlaybackTargetRetarget = Atomic<Bool>(false)
-        private let playbackRateCorrectionPartsPerBillion = Atomic<Int64>(0)
-        private let playbackRateCorrectionSaturated = Atomic<Bool>(false)
-        private let filteredPlaybackOccupancyMilliFrames = Atomic<Int64>(0)
-        private let sampleRateConversionActive = Atomic<Bool>(false)
-        private let bypassEnabled: Atomic<Bool>
-        private let playbackPriming = Atomic<Bool>(true)
-        private let outputMutedForTransition = Atomic<Bool>(false)
-        private let pendingPlaybackReset = Atomic<Bool>(false)
-        private let pendingOutputTimestampReset = Atomic<Bool>(true)
+        private let tapToOutputLatencyObservations = Atomic<UInt64>(0)
+        private let minTapToOutputLatencyNanoseconds = Atomic<UInt64>(.max)
+        private let maxTapToOutputLatencyNanoseconds = Atomic<UInt64>(0)
+        private let totalTapToOutputLatencyNanoseconds = Atomic<UInt64>(0)
+        private let callbackTimingObservations = Atomic<UInt64>(0)
+        private let minInputAgeNanoseconds = Atomic<UInt64>(.max)
+        private let maxInputAgeNanoseconds = Atomic<UInt64>(0)
+        private let totalInputAgeNanoseconds = Atomic<UInt64>(0)
+        private let minOutputLeadNanoseconds = Atomic<UInt64>(.max)
+        private let maxOutputLeadNanoseconds = Atomic<UInt64>(0)
+        private let totalOutputLeadNanoseconds = Atomic<UInt64>(0)
+        private let requestedBypassEnabled: Atomic<Bool>
+        private let outputMutedForTransition = Atomic<Bool>(true)
+        private let outputIsMuted = Atomic<Bool>(true)
         private let pendingDSPConfigPointer = Atomic<UInt>(0)
         private let retiredDSPConfigHeadPointer = Atomic<UInt>(0)
         private let stopping = Atomic<Bool>(false)
-        private let captureInCallback = Atomic<Bool>(false)
-        private let playbackInCallback = Atomic<Bool>(false)
-        // Packed (left << 32 | right) so the playback callback can never observe a torn pair.
-        private let playbackChannelPair = Atomic<UInt64>(SystemTapAudioEngine.encodedPlaybackChannelPair(left: 0, right: 1))
+        private let inCallback = Atomic<Bool>(false)
+        private let playbackChannelPair = Atomic<UInt64>(
+            SystemTapAudioEngine.encodedPlaybackChannelPair(left: 0, right: 1)
+        )
 
         init(
             profile: EQProfile,
             sampleRate: Double,
             channelCount: Int,
-            ringCapacityFrames: Int,
-            scratchFrames: Int,
-            captureCallbackFrames: Int,
-            playbackPrimeFrames: Int
+            inputChannelOffset: Int,
+            systemSoundInputChannelOffset: Int,
+            maxCallbackFrames: Int
         ) {
             self.channelCount = max(channelCount, 1)
             self.sampleRate = sampleRate
-            self.configuredCaptureCallbackFrames = max(captureCallbackFrames, 1)
-            self.ringBuffer = RealtimeAudioRingBuffer(
-                channelCount: self.channelCount,
-                capacityFrames: ringCapacityFrames
+            self.inputChannelOffset = max(inputChannelOffset, 0)
+            self.systemSoundInputChannelOffset = max(systemSoundInputChannelOffset, 0)
+            self.maxCallbackFrames = maxCallbackFrames
+            self.outputFade = RealtimeOutputFade(sampleRate: sampleRate)
+            self.activeBypassEnabled = profile.isBypassed
+            self.scratchSamples = Array(
+                repeating: 0,
+                count: maxCallbackFrames * self.channelCount
             )
-            self.captureScratchSamples = Array(repeating: 0, count: scratchFrames * self.channelCount)
-            self.adaptiveInputSamples = Array(repeating: 0, count: (scratchFrames + 8) * self.channelCount)
-            self.sampleRateConverterInputSamples = UnsafeMutableBufferPointer<Float>.allocate(
-                capacity: self.channelCount
-            )
-            self.sampleRateConverterInputSamples.initialize(repeating: 0)
-            self.adaptiveOutputSamples = UnsafeMutableBufferPointer<Float>.allocate(
-                capacity: SystemTapAudioEngine.maximumSupportedCallbackFrames * self.channelCount
-            )
-            self.adaptiveOutputSamples.initialize(repeating: 0)
-            self.playbackPrimeFrames = Atomic(max(playbackPrimeFrames, 1))
-            self.adaptivePlaybackTargetFrames = Atomic(max(playbackPrimeFrames, 1))
-            self.maxCallbackFrames = SystemTapAudioEngine.maximumSupportedCallbackFrames
-            self.playbackRateServo = PlaybackRateServo(
+            let renderConfiguration = EQRenderConfiguration(
+                profile: SystemTapAudioEngine.dspProfile(from: profile),
                 sampleRate: sampleRate,
-                targetFrames: playbackPrimeFrames
-            )
-            self.playbackResampler = HermitePlaybackResampler(channelCount: self.channelCount)
-            self.playbackSampleRatePlan = PlaybackSampleRatePlan(
-                inputSampleRate: sampleRate,
-                outputSampleRate: sampleRate
-            )
-            self.processor = EQProcessor(
-                renderConfiguration: EQRenderConfiguration(
-                    profile: SystemTapAudioEngine.dspProfile(from: profile),
-                    sampleRate: sampleRate,
-                    channelCount: self.channelCount
+                channelCount: self.channelCount,
+                maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
+                    sampleRate: sampleRate
                 )
             )
-            self.bypassEnabled = Atomic(profile.isBypassed)
+            self.processor = EQProcessor(renderConfiguration: renderConfiguration)
+            self.activeSystemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
+                for: renderConfiguration
+            )
+            self.requestedBypassEnabled = Atomic(profile.isBypassed)
         }
 
         deinit {
             drainDSPConfigBoxes()
-            sampleRateConverterInputSamples.deinitialize()
-            sampleRateConverterInputSamples.deallocate()
-            adaptiveOutputSamples.deinitialize()
-            adaptiveOutputSamples.deallocate()
+        }
+
+        func render(
+            inputData: UnsafePointer<AudioBufferList>,
+            inputTime: AudioTimeStamp,
+            outputData: UnsafeMutablePointer<AudioBufferList>,
+            outputTime: AudioTimeStamp
+        ) {
+            let outputBuffers = UnsafeMutableAudioBufferListPointer(outputData)
+            clear(outputBuffers)
+
+            guard !stopping.load(ordering: .acquiring),
+                  enter(inCallback) else {
+                return
+            }
+            let callbackHostTime = AudioGetCurrentHostTime()
+            defer {
+                inCallback.store(false, ordering: .releasing)
+            }
+
+            let inputBuffers = UnsafeMutableAudioBufferListPointer(
+                UnsafeMutablePointer(mutating: inputData)
+            )
+            guard let mainInputFrameCount = frameCount(
+                inputBuffers,
+                channelOffset: inputChannelOffset,
+                channelCount: channelCount
+            ),
+                  let rawSystemSoundFrameCount = frameCount(
+                    inputBuffers,
+                    channelOffset: systemSoundInputChannelOffset,
+                    channelCount: channelCount
+                  ),
+                  let outputFrameCount = frameCount(outputBuffers) else {
+                return
+            }
+            let systemSoundFrameCount = rawSystemSoundFrameCount == 0
+                ? mainInputFrameCount
+                : rawSystemSoundFrameCount
+            let inputFrameCount = min(mainInputFrameCount, systemSoundFrameCount)
+
+            recordTimestampContinuity(
+                inputTime: inputTime,
+                inputFrameCount: inputFrameCount,
+                outputTime: outputTime,
+                outputFrameCount: outputFrameCount
+            )
+            renderCallbackObservations.wrappingAdd(1, ordering: .relaxed)
+
+            updateMax(maxCaptureCallbackFrames, inputFrameCount)
+            updateMax(maxPlaybackCallbackFrames, outputFrameCount)
+            capturedFrames.wrappingAdd(UInt64(inputFrameCount), ordering: .relaxed)
+
+            if inputFrameCount < outputFrameCount {
+                playbackUnderrunFrames.wrappingAdd(
+                    UInt64(outputFrameCount - inputFrameCount),
+                    ordering: .relaxed
+                )
+            } else if inputFrameCount > outputFrameCount {
+                droppedInputFrames.wrappingAdd(
+                    UInt64(inputFrameCount - outputFrameCount),
+                    ordering: .relaxed
+                )
+            }
+
+            let frameCount = min(inputFrameCount, outputFrameCount)
+            guard frameCount > 0,
+                  frameCount <= maxCallbackFrames else {
+                return
+            }
+
+            recordCallbackLatency(
+                inputTime: inputTime,
+                callbackHostTime: callbackHostTime,
+                outputTime: outputTime
+            )
+            prepareDSPAndOutputFade()
+            let sampleCount = frameCount * channelCount
+            scratchSamples.withUnsafeMutableBufferPointer { scratch in
+                let samples = UnsafeMutableBufferPointer(
+                    start: scratch.baseAddress,
+                    count: sampleCount
+                )
+                SystemTapAudioEngine.copyInputSamples(
+                    from: inputBuffers,
+                    into: samples,
+                    frameCount: frameCount,
+                    channelCount: channelCount,
+                    sourceChannelOffset: inputChannelOffset
+                )
+
+                if !activeBypassEnabled {
+                    let saturated = processor.processInterleavedWithDiagnostics(
+                        samples,
+                        frameCount: frameCount,
+                        channelCount: channelCount
+                    )
+                    if saturated > 0 {
+                        saturatedSamples.wrappingAdd(saturated, ordering: .relaxed)
+                    }
+                }
+
+                let systemSoundSaturated = SystemTapAudioEngine.mixInputSamples(
+                    from: inputBuffers,
+                    into: samples,
+                    frameCount: frameCount,
+                    channelCount: channelCount,
+                    sourceChannelOffset: systemSoundInputChannelOffset,
+                    preampGains: activeBypassEnabled
+                        ? (left: 1, right: 1)
+                        : activeSystemSoundPreampGains
+                )
+                if systemSoundSaturated > 0 {
+                    saturatedSamples.wrappingAdd(
+                        systemSoundSaturated,
+                        ordering: .relaxed
+                    )
+                }
+
+                outputFade.apply(
+                    to: samples,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+                outputIsMuted.store(outputFade.isMuted, ordering: .releasing)
+
+                let channelPair = SystemTapAudioEngine.decodedPlaybackChannelPair(
+                    playbackChannelPair.load(ordering: .acquiring)
+                )
+                SystemTapAudioEngine.copyInterleavedSamples(
+                    UnsafeBufferPointer(samples),
+                    sourceFrameOffset: 0,
+                    destinationFrameOffset: 0,
+                    frameCount: frameCount,
+                    sourceChannelCount: channelCount,
+                    destinationLeftChannel: channelPair.left,
+                    destinationRightChannel: channelPair.right,
+                    to: outputBuffers
+                )
+            }
+            playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+        }
+
+        func activate() {
+            outputMutedForTransition.store(false, ordering: .releasing)
+        }
+
+        func waitForSilentWarmUp(
+            minimumCallbacks: UInt64,
+            timeout: TimeInterval
+        ) {
+            let initialCallbacks = renderCallbackObservations.load(ordering: .acquiring)
+            let deadline = DispatchTime.now().uptimeNanoseconds
+                + UInt64(max(timeout, 0) * 1_000_000_000)
+            while renderCallbackObservations.load(ordering: .acquiring)
+                    < initialCallbacks + minimumCallbacks,
+                  DispatchTime.now().uptimeNanoseconds < deadline {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
         }
 
         func markStopping() {
             stopping.store(true, ordering: .releasing)
             outputMutedForTransition.store(true, ordering: .releasing)
-            playbackPriming.store(true, ordering: .releasing)
+        }
+
+        func fadeOutForStop() {
+            outputMutedForTransition.store(true, ordering: .releasing)
+            // A disconnected route may no longer deliver callbacks, so never wait indefinitely.
+            let timeout = DispatchTime.now().uptimeNanoseconds
+                + UInt64((RealtimeOutputFade.durationSeconds + 0.02) * 1_000_000_000)
+            while !outputIsMuted.load(ordering: .acquiring),
+                  DispatchTime.now().uptimeNanoseconds < timeout {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
         }
 
         func setBypassed(_ isBypassed: Bool) {
-            bypassEnabled.store(isBypassed, ordering: .relaxed)
+            requestedBypassEnabled.store(isBypassed, ordering: .releasing)
         }
 
         func muteOutputForTransition() {
             outputMutedForTransition.store(true, ordering: .releasing)
-            playbackPriming.store(true, ordering: .releasing)
-            pendingOutputTimestampReset.store(true, ordering: .releasing)
         }
 
-        // Stored by the control thread on every output rebuild, before the new output IOProc
-        // starts, so the first callback on the new device already maps to the right channels.
         func setPlaybackChannelPair(left: Int, right: Int) {
             playbackChannelPair.store(
                 SystemTapAudioEngine.encodedPlaybackChannelPair(left: left, right: right),
@@ -447,173 +797,161 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             )
         }
 
-        func configurePlayback(
-            primeFrames: Int,
-            outputSampleRate: Double
-        ) throws {
-            let targetFrames = min(max(primeFrames, 1), ringBuffer.capacityFrames)
-            let sampleRatePlan = PlaybackSampleRatePlan(
-                inputSampleRate: sampleRate,
-                outputSampleRate: outputSampleRate
-            )
-            let sampleRateConverter: RealtimePCMRateConverter? = if sampleRatePlan.requiresConversion {
-                try RealtimePCMRateConverter(
-                    inputSampleRate: sampleRatePlan.inputSampleRate,
-                    outputSampleRate: sampleRatePlan.outputSampleRate,
-                    channelCount: channelCount
-                )
-            } else {
-                nil
-            }
-            let inputCapacityFrames = try sampleRateConverter?.inputFrameCapacity(
-                forOutputFrames: maxCallbackFrames
-            ) ?? 1
-            let inputSamples = UnsafeMutableBufferPointer<Float>.allocate(
-                capacity: inputCapacityFrames * channelCount
-            )
-            inputSamples.initialize(repeating: 0)
-
-            sampleRateConverterInputSamples.deinitialize()
-            sampleRateConverterInputSamples.deallocate()
-            sampleRateConverterInputSamples = inputSamples
-            playbackSampleRateConverter = sampleRateConverter
-            playbackSampleRatePlan = sampleRatePlan
-            sampleRateConversionActive.store(sampleRateConverter != nil, ordering: .releasing)
-            adaptivePlaybackRenderFailureActive.store(false, ordering: .releasing)
-            playbackPrimeFrames.store(targetFrames, ordering: .releasing)
-            adaptivePlaybackTargetFrames.store(targetFrames, ordering: .releasing)
-            pendingPlaybackTargetRetarget.store(false, ordering: .releasing)
-            pendingPlaybackClockReset.store(true, ordering: .releasing)
-            pendingOutputTimestampReset.store(true, ordering: .releasing)
-        }
-
-        func retargetPlayback(primeFrames: Int) {
-            let targetFrames = min(max(primeFrames, 1), ringBuffer.capacityFrames)
-            playbackPrimeFrames.store(targetFrames, ordering: .releasing)
-            adaptivePlaybackTargetFrames.store(targetFrames, ordering: .releasing)
-            pendingPlaybackTargetRetarget.store(true, ordering: .releasing)
-            pendingOutputTimestampReset.store(true, ordering: .releasing)
-        }
-
-        func playbackTargetFrames() -> Int {
-            adaptivePlaybackTargetFrames.load(ordering: .acquiring)
-        }
-
-        func maximumKnownCaptureCallbackFrames() -> Int {
-            max(
-                configuredCaptureCallbackFrames,
-                maxCaptureCallbackFrames.load(ordering: .relaxed)
-            )
-        }
-
-        func hasActiveAdaptivePlaybackRenderFailure() -> Bool {
-            adaptivePlaybackRenderFailureActive.load(ordering: .acquiring)
-        }
-
-        func playbackRenderHealthGeneration() -> UInt64 {
-            adaptivePlaybackRenderHealthGeneration.load(ordering: .acquiring)
-        }
-
-        // Called when a new output half is started. Clears any transition mute (the runtime
-        // persists across output switches now, so the mute flag would otherwise stick on and
-        // silence everything) and re-primes so playback re-anchors to the freshest audio.
-        func reprimePlayback() {
-            pendingPlaybackReset.store(true, ordering: .releasing)
-            playbackPriming.store(true, ordering: .releasing)
-            pendingOutputTimestampReset.store(true, ordering: .releasing)
-            outputMutedForTransition.store(false, ordering: .releasing)
-        }
-
-        func playbackInstabilitySnapshot() -> (generation: UInt64, reason: PlaybackBufferInstabilityReason) {
-            let generation = playbackInstabilityGeneration.load(ordering: .acquiring)
-            let latestReason = PlaybackBufferInstabilityReason(
-                rawValue: latestPlaybackInstabilityReason.load(ordering: .relaxed)
-            ) ?? .underrun
-            let reason = AdaptivePlaybackRenderRecoveryPolicy.effectiveInstabilityReason(
-                latest: latestReason,
-                renderFailureActive: adaptivePlaybackRenderFailureActive.load(ordering: .acquiring)
-            )
-            return (generation, reason)
-        }
-
-        func recordPlaybackBufferRenegotiation() {
-            playbackBufferRenegotiations.wrappingAdd(1, ordering: .relaxed)
-        }
-
         func resetMetrics() {
             capturedFrames.store(0, ordering: .relaxed)
             playedFrames.store(0, ordering: .relaxed)
             playbackUnderrunFrames.store(0, ordering: .relaxed)
             droppedInputFrames.store(0, ordering: .relaxed)
-            droppedBufferedFrames.store(0, ordering: .relaxed)
             saturatedSamples.store(0, ordering: .relaxed)
-            maxBufferedFrames.store(0, ordering: .relaxed)
-            maxPlaybackBufferedFrames.store(0, ordering: .relaxed)
-            minPlaybackBufferedFrames.store(Int.max, ordering: .relaxed)
-            totalPlaybackBufferedFrames.store(0, ordering: .relaxed)
-            playbackBufferObservations.store(0, ordering: .relaxed)
+            inputTimestampDiscontinuities.store(0, ordering: .relaxed)
+            outputTimestampDiscontinuities.store(0, ordering: .relaxed)
+            pairedTimestampDiscontinuities.store(0, ordering: .relaxed)
+            qualifyingPairedTimestampDiscontinuities.store(0, ordering: .relaxed)
+            lastInputTimestampJumpMilliFrames.store(0, ordering: .relaxed)
+            lastOutputTimestampJumpMilliFrames.store(0, ordering: .relaxed)
+            lastInputHostIntervalErrorNanoseconds.store(0, ordering: .relaxed)
+            lastOutputHostIntervalErrorNanoseconds.store(0, ordering: .relaxed)
+            timestampJumpIntervalObservations.store(0, ordering: .relaxed)
+            minimumTimestampJumpIntervalNanoseconds.store(.max, ordering: .relaxed)
+            maximumTimestampJumpIntervalNanoseconds.store(0, ordering: .relaxed)
+            totalTimestampJumpIntervalNanoseconds.store(0, ordering: .relaxed)
             maxCaptureCallbackFrames.store(0, ordering: .relaxed)
             maxPlaybackCallbackFrames.store(0, ordering: .relaxed)
-            playbackTimestampDiscontinuities.store(0, ordering: .relaxed)
-            playbackBufferRenegotiations.store(0, ordering: .relaxed)
-            adaptivePlaybackRenderFailures.store(0, ordering: .relaxed)
-            playbackRateCorrectionSaturated.store(false, ordering: .relaxed)
-            ringBuffer.resetOverwriteGateContentionFailureCount()
-            playbackPriming.store(true, ordering: .releasing)
+            tapToOutputLatencyObservations.store(0, ordering: .relaxed)
+            minTapToOutputLatencyNanoseconds.store(.max, ordering: .relaxed)
+            maxTapToOutputLatencyNanoseconds.store(0, ordering: .relaxed)
+            totalTapToOutputLatencyNanoseconds.store(0, ordering: .relaxed)
+            callbackTimingObservations.store(0, ordering: .relaxed)
+            minInputAgeNanoseconds.store(.max, ordering: .relaxed)
+            maxInputAgeNanoseconds.store(0, ordering: .relaxed)
+            totalInputAgeNanoseconds.store(0, ordering: .relaxed)
+            minOutputLeadNanoseconds.store(.max, ordering: .relaxed)
+            maxOutputLeadNanoseconds.store(0, ordering: .relaxed)
+            totalOutputLeadNanoseconds.store(0, ordering: .relaxed)
         }
 
         func snapshotMetrics() -> AudioEngineMetrics {
-            let observations = playbackBufferObservations.load(ordering: .relaxed)
-            let minimumBufferedFrames = minPlaybackBufferedFrames.load(ordering: .relaxed)
+            let latencyObservations = tapToOutputLatencyObservations.load(ordering: .relaxed)
+            let minimumLatency = minTapToOutputLatencyNanoseconds.load(ordering: .relaxed)
+            let totalLatency = totalTapToOutputLatencyNanoseconds.load(ordering: .relaxed)
+            let timingObservations = callbackTimingObservations.load(ordering: .relaxed)
+            let minimumInputAge = minInputAgeNanoseconds.load(ordering: .relaxed)
+            let totalInputAge = totalInputAgeNanoseconds.load(ordering: .relaxed)
+            let minimumOutputLead = minOutputLeadNanoseconds.load(ordering: .relaxed)
+            let totalOutputLead = totalOutputLeadNanoseconds.load(ordering: .relaxed)
+            let jumpIntervalObservations = timestampJumpIntervalObservations.load(
+                ordering: .relaxed
+            )
+            let minimumJumpInterval = minimumTimestampJumpIntervalNanoseconds.load(
+                ordering: .relaxed
+            )
+            let totalJumpInterval = totalTimestampJumpIntervalNanoseconds.load(
+                ordering: .relaxed
+            )
             return AudioEngineMetrics(
                 capturedFrames: capturedFrames.load(ordering: .relaxed),
                 playedFrames: playedFrames.load(ordering: .relaxed),
                 playbackUnderrunFrames: playbackUnderrunFrames.load(ordering: .relaxed),
                 droppedInputFrames: droppedInputFrames.load(ordering: .relaxed),
-                droppedBufferedFrames: droppedBufferedFrames.load(ordering: .relaxed),
-                ringGateContentionFailures: ringBuffer.overwriteGateContentionFailureCount(),
                 saturatedSamples: saturatedSamples.load(ordering: .relaxed),
-                currentBufferedFrames: ringBuffer.occupancyFrames(),
-                maxBufferedFrames: maxBufferedFrames.load(ordering: .relaxed),
-                maximumPlaybackBufferedFrames: maxPlaybackBufferedFrames.load(ordering: .relaxed),
-                minimumPlaybackBufferedFrames: observations == 0 ? 0 : minimumBufferedFrames,
-                averagePlaybackBufferedFrames: observations == 0
+                inputTimestampDiscontinuities: inputTimestampDiscontinuities.load(
+                    ordering: .relaxed
+                ),
+                outputTimestampDiscontinuities: outputTimestampDiscontinuities.load(
+                    ordering: .relaxed
+                ),
+                pairedTimestampDiscontinuities: pairedTimestampDiscontinuities.load(
+                    ordering: .relaxed
+                ),
+                qualifyingPairedTimestampDiscontinuities:
+                    qualifyingPairedTimestampDiscontinuities.load(ordering: .relaxed),
+                lastInputTimestampJumpFrames: Double(
+                    lastInputTimestampJumpMilliFrames.load(ordering: .relaxed)
+                ) / 1_000,
+                lastOutputTimestampJumpFrames: Double(
+                    lastOutputTimestampJumpMilliFrames.load(ordering: .relaxed)
+                ) / 1_000,
+                lastInputHostIntervalErrorNanoseconds:
+                    lastInputHostIntervalErrorNanoseconds.load(ordering: .relaxed),
+                lastOutputHostIntervalErrorNanoseconds:
+                    lastOutputHostIntervalErrorNanoseconds.load(ordering: .relaxed),
+                timestampJumpIntervalObservations: jumpIntervalObservations,
+                minimumTimestampJumpIntervalNanoseconds:
+                    jumpIntervalObservations == 0 || minimumJumpInterval == .max
+                        ? 0
+                        : minimumJumpInterval,
+                maximumTimestampJumpIntervalNanoseconds:
+                    maximumTimestampJumpIntervalNanoseconds.load(ordering: .relaxed),
+                averageTimestampJumpIntervalNanoseconds: jumpIntervalObservations == 0
                     ? 0
-                    : Double(totalPlaybackBufferedFrames.load(ordering: .relaxed)) / Double(observations),
-                playbackBufferObservations: observations,
+                    : Double(totalJumpInterval) / Double(jumpIntervalObservations),
                 maximumCaptureCallbackFrames: maxCaptureCallbackFrames.load(ordering: .relaxed),
                 maximumPlaybackCallbackFrames: maxPlaybackCallbackFrames.load(ordering: .relaxed),
-                playbackTimestampDiscontinuities: playbackTimestampDiscontinuities.load(ordering: .relaxed),
-                playbackBufferRenegotiations: playbackBufferRenegotiations.load(ordering: .relaxed),
-                adaptivePlaybackRenderFailures: adaptivePlaybackRenderFailures.load(ordering: .relaxed),
-                playbackRateCorrectionPPM: Double(
-                    playbackRateCorrectionPartsPerBillion.load(ordering: .relaxed)
-                ) / 1_000,
-                playbackRateCorrectionSaturated: playbackRateCorrectionSaturated.load(ordering: .relaxed),
-                playbackOccupancyTargetFrames: adaptivePlaybackTargetFrames.load(ordering: .relaxed),
-                filteredPlaybackOccupancyFrames: Double(
-                    filteredPlaybackOccupancyMilliFrames.load(ordering: .relaxed)
-                ) / 1_000,
-                playbackBufferSampleRate: sampleRate,
-                playbackSampleRateConversionActive: sampleRateConversionActive.load(ordering: .acquiring)
+                tapToOutputLatencyObservations: latencyObservations,
+                minimumTapToOutputLatencyNanoseconds: latencyObservations == 0 || minimumLatency == .max
+                    ? 0
+                    : minimumLatency,
+                maximumTapToOutputLatencyNanoseconds: maxTapToOutputLatencyNanoseconds.load(
+                    ordering: .relaxed
+                ),
+                averageTapToOutputLatencyNanoseconds: latencyObservations == 0
+                    ? 0
+                    : Double(totalLatency) / Double(latencyObservations),
+                callbackTimingObservations: timingObservations,
+                minimumInputAgeNanoseconds: timingObservations == 0 || minimumInputAge == .max
+                    ? 0
+                    : minimumInputAge,
+                maximumInputAgeNanoseconds: maxInputAgeNanoseconds.load(ordering: .relaxed),
+                averageInputAgeNanoseconds: timingObservations == 0
+                    ? 0
+                    : Double(totalInputAge) / Double(timingObservations),
+                minimumOutputLeadNanoseconds: timingObservations == 0 || minimumOutputLead == .max
+                    ? 0
+                    : minimumOutputLead,
+                maximumOutputLeadNanoseconds: maxOutputLeadNanoseconds.load(ordering: .relaxed),
+                averageOutputLeadNanoseconds: timingObservations == 0
+                    ? 0
+                    : Double(totalOutputLead) / Double(timingObservations)
             )
+        }
+
+        func snapshotTimestampProbeRecords() -> [AudioTimestampProbeRecord] {
+            guard timestampProbeRecordCount > 0 else {
+                return []
+            }
+            let capacity = timestampProbeRecords.count
+            let firstIndex = (timestampProbeWriteIndex - timestampProbeRecordCount + capacity)
+                % capacity
+            return (0..<timestampProbeRecordCount).map { offset in
+                timestampProbeRecords[(firstIndex + offset) % capacity]
+            }
         }
 
         func publishPendingDSPConfig(_ config: EQRenderConfiguration) {
             let box = PreparedDSPConfigBox(config: config)
             let rawPointer = UInt(bitPattern: Unmanaged.passRetained(box).toOpaque())
-            let oldPointer = pendingDSPConfigPointer.exchange(rawPointer, ordering: .acquiringAndReleasing)
+            let oldPointer = pendingDSPConfigPointer.exchange(
+                rawPointer,
+                ordering: .acquiringAndReleasing
+            )
             releaseDSPConfigBox(oldPointer)
         }
 
         func drainDSPConfigBoxes() {
-            releaseDSPConfigBox(pendingDSPConfigPointer.exchange(0, ordering: .acquiringAndReleasing))
-            var rawPointer = retiredDSPConfigHeadPointer.exchange(0, ordering: .acquiringAndReleasing)
+            releaseDSPConfigBox(
+                pendingDSPConfigPointer.exchange(0, ordering: .acquiringAndReleasing)
+            )
+            var rawPointer = retiredDSPConfigHeadPointer.exchange(
+                0,
+                ordering: .acquiringAndReleasing
+            )
             while rawPointer != 0 {
                 guard let pointer = UnsafeRawPointer(bitPattern: rawPointer) else {
                     return
                 }
-                let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
+                let box = Unmanaged<PreparedDSPConfigBox>
+                    .fromOpaque(pointer)
+                    .takeUnretainedValue()
                 let nextPointer = box.nextRetiredPointer
                 box.nextRetiredPointer = 0
                 releaseDSPConfigBox(rawPointer)
@@ -621,565 +959,44 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             }
         }
 
-        func capture(inputData: UnsafePointer<AudioBufferList>) {
-            guard !stopping.load(ordering: .acquiring),
-                  enter(captureInCallback) else {
-                return
-            }
-            defer {
-                captureInCallback.store(false, ordering: .releasing)
-            }
-
-            let inputBuffers = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inputData))
-            guard let frameCount = inputFrameCount(inputBuffers),
-                  frameCount > 0 else {
-                return
-            }
-            updateMax(maxCaptureCallbackFrames, frameCount)
-
-            if outputMutedForTransition.load(ordering: .acquiring) {
-                return
-            }
-
-            applyPendingDSPConfig()
-
-            if bypassEnabled.load(ordering: .relaxed) {
-                captureBypassed(inputBuffers: inputBuffers, frameCount: frameCount)
-                return
-            }
-
-            var saturatedSampleCount: UInt64 = 0
-            captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
-                let scratchFrames = max(scratch.count / channelCount, 1)
-                var frameOffset = 0
-                while frameOffset < frameCount {
-                    let chunkFrames = min(frameCount - frameOffset, scratchFrames)
-                    let chunkSamples = UnsafeMutableBufferPointer(
-                        start: scratch.baseAddress,
-                        count: chunkFrames * channelCount
-                    )
-                    copyInput(
-                        from: inputBuffers,
-                        sourceFrameOffset: frameOffset,
-                        into: chunkSamples,
-                        frameCount: chunkFrames,
-                        channelCount: channelCount
-                    )
-                    saturatedSampleCount += processor.processInterleavedWithDiagnostics(
-                        chunkSamples,
-                        frameCount: chunkFrames,
-                        channelCount: channelCount
-                    )
-                    recordWriteResult(
-                        ringBuffer.writeInterleaved(
-                            UnsafeBufferPointer(chunkSamples),
-                            frameCount: chunkFrames,
-                            sourceChannelCount: channelCount
-                        )
-                    )
-                    frameOffset += chunkFrames
-                }
-            }
-
-            if saturatedSampleCount > 0 {
-                saturatedSamples.wrappingAdd(saturatedSampleCount, ordering: .relaxed)
-            }
-            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
-            capturedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
-        }
-
-        func playback(
-            outputData: UnsafeMutablePointer<AudioBufferList>,
-            outputSampleTime: Double?
-        ) {
-            guard !stopping.load(ordering: .acquiring) else {
-                clear(outputData: outputData)
-                return
-            }
-            guard enter(playbackInCallback) else {
-                clear(outputData: outputData)
-                return
-            }
-            defer {
-                playbackInCallback.store(false, ordering: .releasing)
-            }
-
-            let outputBuffers = UnsafeMutableAudioBufferListPointer(outputData)
-            guard let frameCount = outputFrameCount(outputBuffers) else {
-                clear(outputData: outputData)
-                return
-            }
-            guard frameCount > 0 else {
-                return
-            }
-            updateMax(maxPlaybackCallbackFrames, frameCount)
-
-            if pendingOutputTimestampReset.exchange(false, ordering: .acquiringAndReleasing) {
-                outputTimestampTracker.reset()
-            }
-
-            if pendingPlaybackReset.exchange(false, ordering: .acquiringAndReleasing) {
-                _ = ringBuffer.reset()
-            }
-            if pendingPlaybackClockReset.exchange(false, ordering: .acquiringAndReleasing) {
-                pendingPlaybackTargetRetarget.store(false, ordering: .releasing)
-                playbackRateServo.reset(
-                    targetFrames: adaptivePlaybackTargetFrames.load(ordering: .acquiring)
-                )
-                playbackResampler.reset()
-                publishAdaptivePlaybackMetrics()
-            } else if pendingPlaybackTargetRetarget.exchange(false, ordering: .acquiringAndReleasing) {
-                playbackRateServo.retarget(
-                    adaptivePlaybackTargetFrames.load(ordering: .acquiring)
-                )
-                playbackResampler.reset()
-                publishAdaptivePlaybackMetrics()
-            }
-
-            if outputMutedForTransition.load(ordering: .acquiring) {
-                clear(outputData: outputData)
-                return
-            }
-
-            let inputDurationFrames = playbackSampleRatePlan.inputFrames(
-                forOutputFrames: frameCount
-            )
-
-            if outputTimestampTracker.observe(sampleTime: outputSampleTime, frameCount: frameCount) {
-                playbackTimestampDiscontinuities.wrappingAdd(1, ordering: .relaxed)
-                signalPlaybackInstability(.outputTimestampDiscontinuity)
-                beginPlaybackReprime()
-            } else if !playbackPriming.load(ordering: .acquiring),
-                      PlaybackOccupancyRecoveryPolicy.shouldReprime(
-                          occupancyFrames: ringBuffer.occupancyFrames(),
-                          targetFrames: adaptivePlaybackTargetFrames.load(ordering: .acquiring),
-                          outputFrames: inputDurationFrames
-                      ) {
-                signalPlaybackInstability(.excessiveBacklog)
-                beginPlaybackReprime()
-            }
-
-            if playbackPriming.load(ordering: .acquiring) {
-                playbackRateServo.beginPriming()
-                playbackResampler.reset()
-                publishAdaptivePlaybackMetrics()
-                let bufferedFrames = ringBuffer.occupancyFrames()
-                let primeFrames = playbackPrimeFrames.load(ordering: .acquiring)
-                updateMaxBufferedFrames(bufferedFrames)
-                guard bufferedFrames >= primeFrames else {
-                    clear(outputData: outputData)
-                    return
-                }
-                guard ringBuffer.trimToLatestFrames(primeFrames) else {
-                    clear(outputData: outputData)
-                    return
-                }
-                playbackRateServo.didPrime(occupancyFrames: primeFrames)
-                publishAdaptivePlaybackMetrics()
-                playbackPriming.store(false, ordering: .releasing)
-            }
-
-            let bufferedFrames = ringBuffer.occupancyFrames()
-            recordPlaybackBufferedFrames(bufferedFrames)
-
-            let (destinationLeftChannel, destinationRightChannel) = SystemTapAudioEngine.decodedPlaybackChannelPair(
-                playbackChannelPair.load(ordering: .acquiring)
-            )
-
-            let ratio = playbackRateServo.update(
-                occupancyFrames: bufferedFrames,
-                outputFrames: inputDurationFrames
-            )
-            publishAdaptivePlaybackMetrics()
-            let result = if playbackSampleRateConverter != nil {
-                renderSampleRateConvertedPlayback(
-                    outputBuffers: outputBuffers,
-                    frameCount: frameCount,
-                    ratio: ratio,
-                    destinationLeftChannel: destinationLeftChannel,
-                    destinationRightChannel: destinationRightChannel
-                )
-            } else {
-                renderAdaptivePlayback(
-                    outputBuffers: outputBuffers,
-                    frameCount: frameCount,
-                    ratio: ratio,
-                    destinationLeftChannel: destinationLeftChannel,
-                    destinationRightChannel: destinationRightChannel
-                )
-            }
-            var underrunFrames = 0
-            var adaptiveRenderFailed = false
-            switch result {
-            case .rendered:
-                adaptivePlaybackRenderFailureActive.store(false, ordering: .releasing)
-                adaptivePlaybackRenderHealthGeneration.wrappingAdd(1, ordering: .releasing)
-            case .underrun(let frames):
-                adaptivePlaybackRenderFailureActive.store(false, ordering: .releasing)
-                adaptivePlaybackRenderHealthGeneration.wrappingAdd(1, ordering: .releasing)
-                underrunFrames = frames
-            case .failed:
-                adaptiveRenderFailed = true
-            }
-
-            if underrunFrames > 0 {
-                playbackUnderrunFrames.wrappingAdd(UInt64(underrunFrames), ordering: .relaxed)
-                signalPlaybackInstability(.underrun)
-            } else if adaptiveRenderFailed {
-                adaptivePlaybackRenderFailures.wrappingAdd(1, ordering: .relaxed)
-                if !adaptivePlaybackRenderFailureActive.exchange(true, ordering: .acquiringAndReleasing) {
-                    signalPlaybackInstability(.adaptiveRenderFailure)
-                }
-            }
-            if underrunFrames > 0 || adaptiveRenderFailed {
-                beginPlaybackReprime()
-            }
-            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
-            playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
-        }
-
-        private func beginPlaybackReprime() {
-            playbackRateServo.beginPriming()
-            playbackResampler.reset()
-            publishAdaptivePlaybackMetrics()
-            playbackPriming.store(true, ordering: .releasing)
-        }
-
-        private func signalPlaybackInstability(_ reason: PlaybackBufferInstabilityReason) {
-            latestPlaybackInstabilityReason.store(reason.rawValue, ordering: .relaxed)
-            playbackInstabilityGeneration.wrappingAdd(1, ordering: .releasing)
-        }
-
-        private func renderAdaptivePlayback(
-            outputBuffers: UnsafeMutableAudioBufferListPointer,
-            frameCount: Int,
-            ratio: Double,
-            destinationLeftChannel: Int,
-            destinationRightChannel: Int
-        ) -> AdaptivePlaybackRenderResult {
-            guard frameCount <= adaptiveOutputSamples.count / channelCount else {
-                clear(outputBuffers: outputBuffers)
-                return .failed
-            }
-            let outputSamples = UnsafeMutableBufferPointer(
-                start: adaptiveOutputSamples.baseAddress,
-                count: frameCount * channelCount
-            )
-            let result = renderAdaptiveFrames(
-                into: outputSamples,
-                frameCount: frameCount,
-                ratio: ratio
-            )
-            guard case .rendered = result else {
-                clear(outputBuffers: outputBuffers)
-                return result
-            }
-            writeInterleaved(
-                UnsafeBufferPointer(outputSamples),
-                sourceFrameOffset: 0,
-                destinationFrameOffset: 0,
-                frameCount: frameCount,
-                sourceChannelCount: channelCount,
-                destinationLeftChannel: destinationLeftChannel,
-                destinationRightChannel: destinationRightChannel,
-                to: outputBuffers
-            )
-            return .rendered
-        }
-
-        private func renderAdaptiveFrames(
-            into outputSamples: UnsafeMutableBufferPointer<Float>,
-            frameCount: Int,
-            ratio: Double
-        ) -> AdaptivePlaybackRenderResult {
-            let inputFrameCapacity = adaptiveInputSamples.count / channelCount
-            let outputFrameCapacity = outputSamples.count / channelCount
-            let chunkFrameCapacity = max(inputFrameCapacity - 8, 1)
-            guard inputFrameCapacity > 8, outputFrameCapacity >= frameCount else {
-                return .failed
-            }
-
-            var outputFrameOffset = 0
-            while outputFrameOffset < frameCount {
-                let chunkFrames = min(frameCount - outputFrameOffset, chunkFrameCapacity)
-                let plan = playbackResampler.inputPlan(outputFrames: chunkFrames, ratio: ratio)
-                guard plan.combinedFrames <= inputFrameCapacity else {
-                    playbackResampler.reset()
-                    return .failed
-                }
-
-                var readFrames = 0
-                var copiedRetainedSamples = false
-                var rendered = false
-                adaptiveInputSamples.withUnsafeMutableBufferPointer { inputSamples in
-                    copiedRetainedSamples = playbackResampler.copyRetainedSamples(into: inputSamples, plan: plan)
-                    guard copiedRetainedSamples, let inputBase = inputSamples.baseAddress else {
-                        return
-                    }
-                    let newInputSamples = UnsafeMutableBufferPointer(
-                        start: inputBase.advanced(by: plan.prefixFrames * channelCount),
-                        count: plan.newFrames * channelCount
-                    )
-                    readFrames = ringBuffer.readInterleaved(
-                        into: newInputSamples,
-                        frameCount: plan.newFrames,
-                        destinationChannelCount: channelCount
-                    )
-                    guard readFrames == plan.newFrames else {
-                        return
-                    }
-
-                    let outputChunk = UnsafeMutableBufferPointer(
-                        start: outputSamples.baseAddress?.advanced(
-                            by: outputFrameOffset * channelCount
-                        ),
-                        count: chunkFrames * channelCount
-                    )
-                    rendered = playbackResampler.render(
-                        input: inputSamples,
-                        plan: plan,
-                        output: outputChunk,
-                        outputFrames: chunkFrames,
-                        ratio: ratio
-                    )
-                }
-
-                guard copiedRetainedSamples else {
-                    playbackResampler.reset()
-                    return .failed
-                }
-                guard readFrames == plan.newFrames else {
-                    playbackResampler.reset()
-                    return .underrun(frames: max(plan.newFrames - readFrames, 1))
-                }
-                guard rendered else {
-                    playbackResampler.reset()
-                    return .failed
-                }
-                outputFrameOffset += chunkFrames
-            }
-
-            return .rendered
-        }
-
-        private func renderSampleRateConvertedPlayback(
-            outputBuffers: UnsafeMutableAudioBufferListPointer,
-            frameCount: Int,
-            ratio: Double,
-            destinationLeftChannel: Int,
-            destinationRightChannel: Int
-        ) -> AdaptivePlaybackRenderResult {
-            guard let sampleRateConverter = playbackSampleRateConverter,
-                  frameCount <= adaptiveOutputSamples.count / channelCount,
-                  let outputBase = adaptiveOutputSamples.baseAddress else {
-                clear(outputBuffers: outputBuffers)
-                return .failed
-            }
-
-            sampleRateConverterInputRatio = ratio
-            sampleRateConverterInputResult = .rendered
-            var convertedFrameCount = UInt32(frameCount)
-            var convertedData = AudioBufferList(
-                mNumberBuffers: 1,
-                mBuffers: AudioBuffer(
-                    mNumberChannels: UInt32(channelCount),
-                    mDataByteSize: UInt32(frameCount * channelCount * MemoryLayout<Float>.size),
-                    mData: outputBase
-                )
-            )
-            let status = withUnsafeMutablePointer(to: &convertedData) { outputData in
-                sampleRateConverter.fill(
-                    inputProc: Self.sampleRateConverterInputProc,
-                    inputContext: Unmanaged.passUnretained(self).toOpaque(),
-                    outputFrames: &convertedFrameCount,
-                    outputData: outputData
-                )
-            }
-            guard status == noErr else {
-                clear(outputBuffers: outputBuffers)
-                return switch sampleRateConverterInputResult {
-                case .rendered:
-                    .failed
-                case .underrun(let frames):
-                    .underrun(frames: frames)
-                case .failed:
-                    .failed
-                }
-            }
-            guard convertedFrameCount == frameCount else {
-                clear(outputBuffers: outputBuffers)
-                return .failed
-            }
-
-            let outputSamples = UnsafeBufferPointer(
-                start: outputBase,
-                count: frameCount * channelCount
-            )
-            writeInterleaved(
-                outputSamples,
-                sourceFrameOffset: 0,
-                destinationFrameOffset: 0,
-                frameCount: frameCount,
-                sourceChannelCount: channelCount,
-                destinationLeftChannel: destinationLeftChannel,
-                destinationRightChannel: destinationRightChannel,
-                to: outputBuffers
-            )
-            return .rendered
-        }
-
-        private static let sampleRateConverterInputProc: AudioConverterComplexInputDataProcRealtimeSafe = {
-            _, requestedFrames, inputData, packetDescriptions, context in
-            guard let context else {
-                requestedFrames.pointee = 0
-                return kAudioConverterErr_UnspecifiedError
-            }
-            packetDescriptions?.pointee = nil
-            return Unmanaged<AudioRuntime>
-                .fromOpaque(context)
-                .takeUnretainedValue()
-                .provideSampleRateConverterInput(
-                    requestedFrames: requestedFrames,
-                    inputData: inputData
-                )
-        }
-
-        private func provideSampleRateConverterInput(
-            requestedFrames: UnsafeMutablePointer<UInt32>,
-            inputData: UnsafeMutablePointer<AudioBufferList>
-        ) -> OSStatus {
-            let frameCount = Int(requestedFrames.pointee)
-            guard frameCount > 0,
-                  frameCount <= sampleRateConverterInputSamples.count / channelCount,
-                  let inputBase = sampleRateConverterInputSamples.baseAddress else {
-                requestedFrames.pointee = 0
-                sampleRateConverterInputResult = .failed
-                return kAudioConverterErr_InvalidInputSize
-            }
-
-            let inputSamples = UnsafeMutableBufferPointer(
-                start: inputBase,
-                count: frameCount * channelCount
-            )
-            let result = renderAdaptiveFrames(
-                into: inputSamples,
-                frameCount: frameCount,
-                ratio: sampleRateConverterInputRatio
-            )
-            sampleRateConverterInputResult = result
-            guard case .rendered = result else {
-                requestedFrames.pointee = 0
-                return kAudioConverterErr_UnspecifiedError
-            }
-
-            inputData.pointee = AudioBufferList(
-                mNumberBuffers: 1,
-                mBuffers: AudioBuffer(
-                    mNumberChannels: UInt32(channelCount),
-                    mDataByteSize: UInt32(frameCount * channelCount * MemoryLayout<Float>.size),
-                    mData: inputBase
-                )
-            )
-            return noErr
-        }
-
-        private func publishAdaptivePlaybackMetrics() {
-            playbackRateCorrectionPartsPerBillion.store(
-                Int64((playbackRateServo.correctionPartsPerMillion * 1_000).rounded()),
-                ordering: .relaxed
-            )
-            playbackRateCorrectionSaturated.store(
-                playbackRateServo.correctionIsSaturated,
-                ordering: .relaxed
-            )
-            filteredPlaybackOccupancyMilliFrames.store(
-                Int64((playbackRateServo.filteredOccupancyFrames * 1_000).rounded()),
-                ordering: .relaxed
-            )
-        }
-
-        func clear(outputData: UnsafeMutablePointer<AudioBufferList>) {
-            clear(outputBuffers: UnsafeMutableAudioBufferListPointer(outputData))
-        }
-
-        private func clear(outputBuffers: UnsafeMutableAudioBufferListPointer) {
-            for buffer in outputBuffers {
-                guard let data = buffer.mData,
-                      let byteCount = validatedClearByteCount(for: buffer) else {
-                    continue
-                }
-                data.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
-            }
-        }
-
-        private func captureBypassed(
-            inputBuffers: UnsafeMutableAudioBufferListPointer,
-            frameCount: Int
-        ) {
-            if let inputSamples = contiguousInterleavedInputBuffer(
-                inputBuffers,
-                frameCount: frameCount,
-                channelCount: channelCount
-            ) {
-                recordWriteResult(
-                    ringBuffer.writeInterleaved(
-                        inputSamples,
-                        frameCount: frameCount,
-                        sourceChannelCount: channelCount
-                    )
-                )
-            } else {
-                captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
-                    let scratchFrames = max(scratch.count / channelCount, 1)
-                    var frameOffset = 0
-                    while frameOffset < frameCount {
-                        let chunkFrames = min(frameCount - frameOffset, scratchFrames)
-                        let chunkSamples = UnsafeMutableBufferPointer(
-                            start: scratch.baseAddress,
-                            count: chunkFrames * channelCount
-                        )
-                        copyInput(
-                            from: inputBuffers,
-                            sourceFrameOffset: frameOffset,
-                            into: chunkSamples,
-                            frameCount: chunkFrames,
-                            channelCount: channelCount
-                        )
-                        recordWriteResult(
-                            ringBuffer.writeInterleaved(
-                                UnsafeBufferPointer(chunkSamples),
-                                frameCount: chunkFrames,
-                                sourceChannelCount: channelCount
-                            )
-                        )
-                        frameOffset += chunkFrames
-                    }
-                }
-            }
-
-            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
-            capturedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
-        }
-
-        private func recordWriteResult(_ result: RingBufferWriteResult) {
-            if result.droppedInputFrames > 0 {
-                droppedInputFrames.wrappingAdd(UInt64(result.droppedInputFrames), ordering: .relaxed)
-            }
-            if result.droppedBufferedFrames > 0 {
-                droppedBufferedFrames.wrappingAdd(UInt64(result.droppedBufferedFrames), ordering: .relaxed)
-            }
-        }
-
         private func applyPendingDSPConfig() {
-            let rawPointer = pendingDSPConfigPointer.exchange(0, ordering: .acquiringAndReleasing)
-            guard rawPointer != 0 else {
+            let rawPointer = pendingDSPConfigPointer.exchange(
+                0,
+                ordering: .acquiringAndReleasing
+            )
+            guard rawPointer != 0,
+                  let pointer = UnsafeRawPointer(bitPattern: rawPointer) else {
                 return
             }
 
-            let pointer = UnsafeRawPointer(bitPattern: rawPointer)!
-            let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
-            box.retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(box.config)
+            let box = Unmanaged<PreparedDSPConfigBox>
+                .fromOpaque(pointer)
+                .takeUnretainedValue()
+            box.retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(
+                box.config
+            )
+            activeSystemSoundPreampGains = box.systemSoundPreampGains
             pushRetiredDSPConfigBox(rawPointer)
+        }
+
+        private func prepareDSPAndOutputFade() {
+            let requestedBypass = requestedBypassEnabled.load(ordering: .acquiring)
+            if pendingDSPConfigPointer.load(ordering: .acquiring) != 0
+                || requestedBypass != activeBypassEnabled {
+                dspTransitionInProgress = true
+            }
+
+            if dspTransitionInProgress, outputFade.isMuted {
+                // Changed biquads reset state. Apply them only while the output is silent.
+                applyPendingDSPConfig()
+                activeBypassEnabled = requestedBypassEnabled.load(ordering: .acquiring)
+                dspTransitionInProgress = pendingDSPConfigPointer.load(ordering: .acquiring) != 0
+                    || requestedBypassEnabled.load(ordering: .acquiring) != activeBypassEnabled
+            }
+
+            let shouldMute = outputMutedForTransition.load(ordering: .acquiring)
+                || dspTransitionInProgress
+            outputFade.setMuted(shouldMute)
         }
 
         private func pushRetiredDSPConfigBox(_ rawPointer: UInt) {
@@ -1187,7 +1004,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                   let pointer = UnsafeRawPointer(bitPattern: rawPointer) else {
                 return
             }
-            let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
+            let box = Unmanaged<PreparedDSPConfigBox>
+                .fromOpaque(pointer)
+                .takeUnretainedValue()
             var head = retiredDSPConfigHeadPointer.load(ordering: .acquiring)
             while true {
                 box.nextRetiredPointer = head
@@ -1211,8 +1030,346 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).release()
         }
 
-        private func updateMaxBufferedFrames(_ occupancy: Int) {
-            updateMax(maxBufferedFrames, occupancy)
+        private func frameCount(_ buffers: UnsafeMutableAudioBufferListPointer) -> Int? {
+            guard let buffer = buffers.first(where: { $0.mData != nil }),
+                  validatedByteCount(for: buffer) != nil else {
+                return buffers.allSatisfy { $0.mData == nil } ? 0 : nil
+            }
+            let channels = Int(buffer.mNumberChannels)
+            let frames = Int(buffer.mDataByteSize) / (channels * MemoryLayout<Float>.stride)
+            return frames <= maxCallbackFrames ? frames : nil
+        }
+
+        private func frameCount(
+            _ buffers: UnsafeMutableAudioBufferListPointer,
+            channelOffset: Int,
+            channelCount: Int
+        ) -> Int? {
+            guard channelOffset >= 0,
+                  channelCount > 0 else {
+                return nil
+            }
+
+            let requestedChannels = channelOffset..<(channelOffset + channelCount)
+            var currentChannelOffset = 0
+            var coveredChannelCount = 0
+            var minimumFrameCount = maxCallbackFrames
+
+            for buffer in buffers {
+                let channels = Int(buffer.mNumberChannels)
+                guard channels > 0,
+                      channels <= CoreAudioDeviceQuery.maxChannelCount else {
+                    return nil
+                }
+                let bufferChannels = currentChannelOffset..<(currentChannelOffset + channels)
+                let coveredChannels = bufferChannels.clamped(to: requestedChannels)
+                if !coveredChannels.isEmpty {
+                    guard let byteCount = validatedByteCount(for: buffer) else {
+                        return buffer.mData == nil ? 0 : nil
+                    }
+                    coveredChannelCount += coveredChannels.count
+                    minimumFrameCount = min(
+                        minimumFrameCount,
+                        byteCount / (channels * MemoryLayout<Float>.stride)
+                    )
+                }
+                currentChannelOffset = bufferChannels.upperBound
+            }
+
+            guard coveredChannelCount == channelCount else {
+                return nil
+            }
+            return minimumFrameCount
+        }
+
+        private func recordTimestampContinuity(
+            inputTime: AudioTimeStamp,
+            inputFrameCount: Int,
+            outputTime: AudioTimeStamp,
+            outputFrameCount: Int
+        ) {
+            let inputJump = recordTimestampContinuity(
+                time: inputTime,
+                frameCount: inputFrameCount,
+                state: &inputTimestampState,
+                discontinuities: inputTimestampDiscontinuities
+            )
+            let outputJump = recordTimestampContinuity(
+                time: outputTime,
+                frameCount: outputFrameCount,
+                state: &outputTimestampState,
+                discontinuities: outputTimestampDiscontinuities
+            )
+
+            if let inputJump {
+                lastInputTimestampJumpMilliFrames.store(
+                    Self.milliFrames(inputJump.sampleTimeDeltaFrames),
+                    ordering: .relaxed
+                )
+                lastInputHostIntervalErrorNanoseconds.store(
+                    inputJump.hostIntervalErrorNanoseconds,
+                    ordering: .relaxed
+                )
+            }
+            if let outputJump {
+                lastOutputTimestampJumpMilliFrames.store(
+                    Self.milliFrames(outputJump.sampleTimeDeltaFrames),
+                    ordering: .relaxed
+                )
+                lastOutputHostIntervalErrorNanoseconds.store(
+                    outputJump.hostIntervalErrorNanoseconds,
+                    ordering: .relaxed
+                )
+            }
+            if inputJump != nil, outputJump != nil {
+                recordPairedTimestampJump(inputTime: inputTime, outputTime: outputTime)
+                if inputJump?.precededByStableSlope == true,
+                   outputJump?.precededByStableSlope == true {
+                    qualifyingPairedTimestampDiscontinuities.wrappingAdd(
+                        1,
+                        ordering: .relaxed
+                    )
+                }
+            }
+            if inputJump != nil || outputJump != nil {
+                recordTimestampProbe(
+                    inputTime: inputTime,
+                    inputFrameCount: inputFrameCount,
+                    inputJump: inputJump,
+                    outputTime: outputTime,
+                    outputFrameCount: outputFrameCount,
+                    outputJump: outputJump
+                )
+            }
+        }
+
+        private func recordTimestampContinuity(
+            time: AudioTimeStamp,
+            frameCount: Int,
+            state: inout TimestampContinuityState,
+            discontinuities: borrowing Atomic<UInt64>
+        ) -> TimestampJump? {
+            let hostIntervalError = hostIntervalErrorNanoseconds(
+                time: time,
+                state: state
+            )
+            let precededByStableSlope = state.stableSlopeObservations >= 8
+            if time.mFlags.contains(.hostTimeValid) {
+                state.previousHostTime = time.mHostTime
+                state.previousFrameCount = frameCount
+            } else {
+                state.previousHostTime = nil
+                state.previousFrameCount = 0
+            }
+
+            guard time.mFlags.contains(.sampleTimeValid),
+                  time.mSampleTime.isFinite else {
+                state.expectedSampleTime = nil
+                state.stableSlopeObservations = 0
+                return nil
+            }
+            let sampleTimeDelta = state.expectedSampleTime.map {
+                time.mSampleTime - $0
+            }
+            state.expectedSampleTime = time.mSampleTime + Float64(frameCount)
+
+            if let sampleTimeDelta, abs(sampleTimeDelta) >= 0.5 {
+                state.stableSlopeObservations = 0
+                discontinuities.wrappingAdd(1, ordering: .relaxed)
+                return TimestampJump(
+                    sampleTimeDeltaFrames: sampleTimeDelta,
+                    hostIntervalErrorNanoseconds: hostIntervalError ?? 0,
+                    precededByStableSlope: precededByStableSlope
+                )
+            }
+            if timestampSlopeAgrees(
+                time: time,
+                frameCount: frameCount,
+                sampleTimeDelta: sampleTimeDelta,
+                hostIntervalErrorNanoseconds: hostIntervalError
+            ) {
+                state.stableSlopeObservations = min(
+                    state.stableSlopeObservations + 1,
+                    8
+                )
+            } else {
+                state.stableSlopeObservations = 0
+            }
+            return nil
+        }
+
+        private func timestampSlopeAgrees(
+            time: AudioTimeStamp,
+            frameCount: Int,
+            sampleTimeDelta: Double?,
+            hostIntervalErrorNanoseconds: Int64?
+        ) -> Bool {
+            guard frameCount > 0,
+                  time.mFlags.contains(.sampleTimeValid),
+                  time.mFlags.contains(.hostTimeValid),
+                  let sampleTimeDelta,
+                  let hostIntervalErrorNanoseconds else {
+                return false
+            }
+            return SystemTapAudioEngine.timestampSlopeAgrees(
+                frameCount: frameCount,
+                sampleRate: sampleRate,
+                sampleTimeDeltaFrames: sampleTimeDelta,
+                hostIntervalErrorNanoseconds: hostIntervalErrorNanoseconds,
+                rateScalar: time.mRateScalar,
+                rateScalarIsValid: time.mFlags.contains(.rateScalarValid)
+            )
+        }
+
+        private func hostIntervalErrorNanoseconds(
+            time: AudioTimeStamp,
+            state: TimestampContinuityState
+        ) -> Int64? {
+            guard time.mFlags.contains(.hostTimeValid),
+                  let previousHostTime = state.previousHostTime,
+                  state.previousFrameCount > 0,
+                  let actualInterval = Self.signedHostIntervalNanoseconds(
+                      from: previousHostTime,
+                      to: time.mHostTime
+                  ) else {
+                return nil
+            }
+            let expectedInterval = Self.clampedInt64(
+                Double(state.previousFrameCount) * 1_000_000_000 / sampleRate
+            )
+            let subtraction = actualInterval.subtractingReportingOverflow(expectedInterval)
+            if subtraction.overflow {
+                return actualInterval < 0 ? .min : .max
+            }
+            return subtraction.partialValue
+        }
+
+        private func recordPairedTimestampJump(
+            inputTime: AudioTimeStamp,
+            outputTime: AudioTimeStamp
+        ) {
+            pairedTimestampDiscontinuities.wrappingAdd(1, ordering: .relaxed)
+            let hostTime: UInt64?
+            if outputTime.mFlags.contains(.hostTimeValid) {
+                hostTime = outputTime.mHostTime
+            } else if inputTime.mFlags.contains(.hostTimeValid) {
+                hostTime = inputTime.mHostTime
+            } else {
+                hostTime = nil
+            }
+            guard let hostTime else {
+                lastPairedTimestampJumpHostTime = nil
+                return
+            }
+            defer {
+                lastPairedTimestampJumpHostTime = hostTime
+            }
+            guard let previousHostTime = lastPairedTimestampJumpHostTime,
+                  hostTime >= previousHostTime else {
+                return
+            }
+            let interval = AudioConvertHostTimeToNanos(hostTime - previousHostTime)
+            updateMinimum(minimumTimestampJumpIntervalNanoseconds, interval)
+            updateMaximum(maximumTimestampJumpIntervalNanoseconds, interval)
+            totalTimestampJumpIntervalNanoseconds.wrappingAdd(interval, ordering: .relaxed)
+            timestampJumpIntervalObservations.wrappingAdd(1, ordering: .relaxed)
+        }
+
+        private func recordTimestampProbe(
+            inputTime: AudioTimeStamp,
+            inputFrameCount: Int,
+            inputJump: TimestampJump?,
+            outputTime: AudioTimeStamp,
+            outputFrameCount: Int,
+            outputJump: TimestampJump?
+        ) {
+            timestampProbeSequence &+= 1
+            timestampProbeRecords[timestampProbeWriteIndex] = AudioTimestampProbeRecord(
+                sequence: timestampProbeSequence,
+                inputJumpDetected: inputJump != nil,
+                outputJumpDetected: outputJump != nil,
+                inputFrameCount: inputFrameCount,
+                outputFrameCount: outputFrameCount,
+                inputSampleTime: inputTime.mSampleTime,
+                inputHostTime: inputTime.mHostTime,
+                inputRateScalar: inputTime.mRateScalar,
+                inputFlags: inputTime.mFlags.rawValue,
+                outputSampleTime: outputTime.mSampleTime,
+                outputHostTime: outputTime.mHostTime,
+                outputRateScalar: outputTime.mRateScalar,
+                outputFlags: outputTime.mFlags.rawValue,
+                inputSampleTimeDeltaFrames: inputJump?.sampleTimeDeltaFrames ?? 0,
+                outputSampleTimeDeltaFrames: outputJump?.sampleTimeDeltaFrames ?? 0,
+                inputHostIntervalErrorNanoseconds:
+                    inputJump?.hostIntervalErrorNanoseconds ?? 0,
+                outputHostIntervalErrorNanoseconds:
+                    outputJump?.hostIntervalErrorNanoseconds ?? 0
+            )
+            timestampProbeWriteIndex = (timestampProbeWriteIndex + 1)
+                % timestampProbeRecords.count
+            timestampProbeRecordCount = min(
+                timestampProbeRecordCount + 1,
+                timestampProbeRecords.count
+            )
+        }
+
+        private static func milliFrames(_ frames: Double) -> Int64 {
+            clampedInt64(frames * 1_000)
+        }
+
+        private static func clampedInt64(_ value: Double) -> Int64 {
+            guard value.isFinite else {
+                return 0
+            }
+            if value >= Double(Int64.max) {
+                return .max
+            }
+            if value <= Double(Int64.min) {
+                return .min
+            }
+            return Int64(value.rounded())
+        }
+
+        private static func signedHostIntervalNanoseconds(
+            from start: UInt64,
+            to end: UInt64
+        ) -> Int64? {
+            let magnitude = end >= start
+                ? AudioConvertHostTimeToNanos(end - start)
+                : AudioConvertHostTimeToNanos(start - end)
+            guard magnitude <= UInt64(Int64.max) else {
+                return nil
+            }
+            return end >= start ? Int64(magnitude) : -Int64(magnitude)
+        }
+
+        private func validatedByteCount(for buffer: AudioBuffer) -> Int? {
+            guard buffer.mData != nil else {
+                return nil
+            }
+            let channels = Int(buffer.mNumberChannels)
+            guard channels > 0,
+                  channels <= CoreAudioDeviceQuery.maxChannelCount else {
+                return nil
+            }
+            let bytesPerFrame = channels * MemoryLayout<Float>.stride
+            let byteCount = Int(buffer.mDataByteSize)
+            guard byteCount >= 0,
+                  byteCount % bytesPerFrame == 0,
+                  byteCount / bytesPerFrame <= maxCallbackFrames else {
+                return nil
+            }
+            return byteCount
+        }
+
+        private func clear(_ buffers: UnsafeMutableAudioBufferListPointer) {
+            for buffer in buffers {
+                guard let data = buffer.mData,
+                      let byteCount = validatedByteCount(for: buffer) else {
+                    continue
+                }
+                data.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+            }
         }
 
         private func updateMax(_ counter: borrowing Atomic<Int>, _ value: Int) {
@@ -1230,16 +1387,47 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             }
         }
 
-        private func recordPlaybackBufferedFrames(_ frames: Int) {
-            totalPlaybackBufferedFrames.wrappingAdd(UInt64(max(frames, 0)), ordering: .relaxed)
-            playbackBufferObservations.wrappingAdd(1, ordering: .relaxed)
-            updateMax(maxPlaybackBufferedFrames, frames)
+        private func recordCallbackLatency(
+            inputTime: AudioTimeStamp,
+            callbackHostTime: UInt64,
+            outputTime: AudioTimeStamp
+        ) {
+            guard let latency = SystemTapAudioEngine.tapToOutputLatencyNanoseconds(
+                inputTime: inputTime,
+                outputTime: outputTime
+            ) else {
+                return
+            }
+            updateMinimum(minTapToOutputLatencyNanoseconds, latency)
+            updateMaximum(maxTapToOutputLatencyNanoseconds, latency)
+            totalTapToOutputLatencyNanoseconds.wrappingAdd(latency, ordering: .relaxed)
+            tapToOutputLatencyObservations.wrappingAdd(1, ordering: .relaxed)
 
-            var current = minPlaybackBufferedFrames.load(ordering: .relaxed)
-            while frames < current {
-                let result = minPlaybackBufferedFrames.compareExchange(
+            guard let timing = SystemTapAudioEngine.callbackTimingNanoseconds(
+                inputTime: inputTime,
+                callbackHostTime: callbackHostTime,
+                outputTime: outputTime
+            ) else {
+                return
+            }
+            updateMinimum(minInputAgeNanoseconds, timing.inputAge)
+            updateMaximum(maxInputAgeNanoseconds, timing.inputAge)
+            totalInputAgeNanoseconds.wrappingAdd(timing.inputAge, ordering: .relaxed)
+            updateMinimum(minOutputLeadNanoseconds, timing.outputLead)
+            updateMaximum(maxOutputLeadNanoseconds, timing.outputLead)
+            totalOutputLeadNanoseconds.wrappingAdd(timing.outputLead, ordering: .relaxed)
+            callbackTimingObservations.wrappingAdd(1, ordering: .relaxed)
+        }
+
+        private func updateMinimum(
+            _ counter: borrowing Atomic<UInt64>,
+            _ value: UInt64
+        ) {
+            var current = counter.load(ordering: .relaxed)
+            while value < current {
+                let result = counter.compareExchange(
                     expected: current,
-                    desired: frames,
+                    desired: value,
                     ordering: .relaxed
                 )
                 if result.exchanged {
@@ -1249,156 +1437,22 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             }
         }
 
-        private func inputFrameCount(_ buffers: UnsafeMutableAudioBufferListPointer) -> Int? {
-            guard let buffer = buffers.first else {
-                return 0
-            }
-            guard validatedClearByteCount(for: buffer) != nil else {
-                return nil
-            }
-            let channels = Int(buffer.mNumberChannels)
-            let bytesPerFrame = MemoryLayout<Float>.stride * channels
-            let frameCount = Int(buffer.mDataByteSize) / bytesPerFrame
-            guard frameCount <= maxCallbackFrames else {
-                return nil
-            }
-            return frameCount
-        }
-
-        private func outputFrameCount(_ buffers: UnsafeMutableAudioBufferListPointer) -> Int? {
-            guard let buffer = buffers.first else {
-                return 0
-            }
-            guard validatedClearByteCount(for: buffer) != nil else {
-                return nil
-            }
-            let channels = Int(buffer.mNumberChannels)
-            let bytesPerFrame = MemoryLayout<Float>.stride * channels
-            let frameCount = Int(buffer.mDataByteSize) / bytesPerFrame
-            guard frameCount <= maxCallbackFrames else {
-                return nil
-            }
-            return frameCount
-        }
-
-        private func validatedClearByteCount(for buffer: AudioBuffer) -> Int? {
-            guard buffer.mData != nil else {
-                return nil
-            }
-            let channels = Int(buffer.mNumberChannels)
-            guard channels > 0,
-                  channels <= CoreAudioDeviceQuery.maxChannelCount else {
-                return nil
-            }
-            let bytesPerFrame = MemoryLayout<Float>.stride * channels
-            let byteCount = Int(buffer.mDataByteSize)
-            guard byteCount >= 0,
-                  byteCount % bytesPerFrame == 0 else {
-                return nil
-            }
-            let frameCount = byteCount / bytesPerFrame
-            guard frameCount <= maxCallbackFrames else {
-                return nil
-            }
-            return byteCount
-        }
-
-        private func copyInput(
-            from buffers: UnsafeMutableAudioBufferListPointer,
-            sourceFrameOffset: Int,
-            into samples: UnsafeMutableBufferPointer<Float>,
-            frameCount: Int,
-            channelCount: Int
+        private func updateMaximum(
+            _ counter: borrowing Atomic<UInt64>,
+            _ value: UInt64
         ) {
-            if buffers.count == 1,
-               let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
-               Int(buffers[0].mNumberChannels) == channelCount,
-               frameCount > 0,
-               sourceFrameOffset >= 0 {
-                let sourceSampleStart = sourceFrameOffset * channelCount
-                let copySamples = frameCount * channelCount
-                let availableSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
-                if samples.count >= copySamples,
-                   sourceSampleStart + copySamples <= availableSamples,
-                   let destination = samples.baseAddress {
-                    destination.update(from: data.advanced(by: sourceSampleStart), count: copySamples)
+            var current = counter.load(ordering: .relaxed)
+            while value > current {
+                let result = counter.compareExchange(
+                    expected: current,
+                    desired: value,
+                    ordering: .relaxed
+                )
+                if result.exchanged {
                     return
                 }
+                current = result.original
             }
-
-            for frameIndex in 0..<frameCount {
-                let sourceFrame = sourceFrameOffset + frameIndex
-                let sampleBase = frameIndex * channelCount
-                for channel in 0..<channelCount {
-                    samples[sampleBase + channel] = sample(from: buffers, frame: sourceFrame, channel: channel)
-                }
-            }
-        }
-
-        private func contiguousInterleavedInputBuffer(
-            _ buffers: UnsafeMutableAudioBufferListPointer,
-            frameCount: Int,
-            channelCount: Int
-        ) -> UnsafeBufferPointer<Float>? {
-            guard buffers.count == 1,
-                  frameCount > 0,
-                  Int(buffers[0].mNumberChannels) == channelCount,
-                  let data = buffers[0].mData?.assumingMemoryBound(to: Float.self) else {
-                return nil
-            }
-            let sampleCount = frameCount * channelCount
-            guard sampleCount <= Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride else {
-                return nil
-            }
-            return UnsafeBufferPointer(start: data, count: sampleCount)
-        }
-
-        private func sample(
-            from buffers: UnsafeMutableAudioBufferListPointer,
-            frame: Int,
-            channel: Int
-        ) -> Float {
-            if buffers.count == 1,
-               let data = buffers[0].mData?.assumingMemoryBound(to: Float.self) {
-                let channelCount = max(Int(buffers[0].mNumberChannels), 1)
-                let index = frame * channelCount + min(channel, channelCount - 1)
-                guard index >= 0,
-                      index < Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride else {
-                    return 0
-                }
-                return data[index]
-            }
-
-            let bufferIndex = min(channel, buffers.count - 1)
-            guard bufferIndex >= 0,
-                  let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self),
-                  frame >= 0,
-                  frame < Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride else {
-                return 0
-            }
-            return data[frame]
-        }
-
-        private func writeInterleaved(
-            _ samples: UnsafeBufferPointer<Float>,
-            sourceFrameOffset: Int,
-            destinationFrameOffset: Int,
-            frameCount: Int,
-            sourceChannelCount: Int,
-            destinationLeftChannel: Int,
-            destinationRightChannel: Int,
-            to buffers: UnsafeMutableAudioBufferListPointer
-        ) {
-            SystemTapAudioEngine.copyInterleavedSamples(
-                samples,
-                sourceFrameOffset: sourceFrameOffset,
-                destinationFrameOffset: destinationFrameOffset,
-                frameCount: frameCount,
-                sourceChannelCount: sourceChannelCount,
-                destinationLeftChannel: destinationLeftChannel,
-                destinationRightChannel: destinationRightChannel,
-                to: buffers
-            )
         }
 
         private func enter(_ gate: borrowing Atomic<Bool>) -> Bool {
@@ -1411,162 +1465,260 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
     }
 
     private let control = Mutex(ControlState())
-    private let playbackBufferRenegotiationHandler = Mutex<(@Sendable (PlaybackBufferRenegotiation) -> Void)?>(nil)
-    private let runtimeFailureHandler = Mutex<(@Sendable (AudioEngineFailure) -> Void)?>(nil)
-    private let restorationStoreURL: URL
-    private let playbackBufferCalibrationStoreURL: URL
-    private let playbackBufferAdaptationQueue = DispatchQueue(
-        label: "com.glasseq.playback-buffer-adaptation",
-        qos: .userInitiated
-    )
-    private let playbackBufferAdaptationQueueKey = DispatchSpecificKey<Void>()
-    private let playbackBufferAdaptationTimer: DispatchSourceTimer
-    private let playbackBufferAdaptationTimerRunning = Mutex(false)
+    private let topologyOperation = Mutex(())
+    private let activeBackend = Mutex(ActiveBackend.combinedAggregate)
+    private let promotedHeadsetRoute = Mutex<PromotedHeadsetRoute?>(nil)
+    private let separateClockBackend: SeparateClockAudioBackend
 
     public var state: AudioEngineState {
-        control.withLock { $0.state }
+        switch activeBackend.withLock({ $0 }) {
+        case .combinedAggregate:
+            control.withLock { $0.state }
+        case .separateClock:
+            separateClockBackend.state
+        }
     }
 
     public var status: AudioEngineStatus {
-        control.withLock { $0.status }
+        switch activeBackend.withLock({ $0 }) {
+        case .combinedAggregate:
+            control.withLock { $0.status }
+        case .separateClock:
+            separateClockBackend.status
+        }
+    }
+
+    public var isUsingTransitionalHeadsetBackend: Bool {
+        guard activeBackend.withLock({ $0 }) == .separateClock,
+              case .running(let output) = separateClockBackend.state else {
+            return false
+        }
+        return Self.shouldUseSeparateClockBackend(for: output)
+    }
+
+    public var isUsingPromotedHeadsetAggregate: Bool {
+        guard activeBackend.withLock({ $0 }) == .combinedAggregate,
+              let output = control.withLock({ $0.activeOutput }) else {
+            return false
+        }
+        return promotedHeadsetRoute.withLock { route in
+            route == Self.promotedHeadsetRoute(for: output)
+        }
     }
 
     public init(restorationStoreURL: URL? = nil) {
-        let restorationStoreURL = restorationStoreURL ?? PersistedAudioDeviceRestorationStore.defaultURL()
-        self.restorationStoreURL = restorationStoreURL
-        self.playbackBufferCalibrationStoreURL = PersistedPlaybackBufferCalibrationStore.defaultURL(
-            nextTo: restorationStoreURL
+        let restorationStoreURL = restorationStoreURL
+            ?? PersistedAudioDeviceRestorationStore.defaultURL()
+        self.separateClockBackend = SeparateClockAudioBackend(
+            restorationStoreURL: restorationStoreURL
         )
-        let timer = DispatchSource.makeTimerSource(queue: playbackBufferAdaptationQueue)
-        self.playbackBufferAdaptationTimer = timer
-        playbackBufferAdaptationQueue.setSpecific(key: playbackBufferAdaptationQueueKey, value: ())
+        // Current buffer-size restorations belong to the separate-clock backend. This
+        // one-time pass only repairs settings persisted by older combined-backend builds.
         Self.restorePersistedDeviceSettings(at: restorationStoreURL)
-        timer.setEventHandler { [weak self] in
-            self?.serviceAdaptivePlaybackBuffering()
-        }
-        timer.schedule(deadline: .now() + .milliseconds(250), repeating: .milliseconds(250), leeway: .milliseconds(50))
     }
 
     deinit {
         stop()
-        playbackBufferAdaptationTimer.setEventHandler {}
-        playbackBufferAdaptationTimerRunning.withLock { isRunning in
-            if !isRunning {
-                playbackBufferAdaptationTimer.resume()
+    }
+
+    public func aggregateRouteFingerprint(
+        for output: AudioOutputDevice
+    ) throws -> AggregateAudioRouteFingerprint? {
+        if Self.shouldUseSeparateClockBackend(for: output) {
+            let isActivePromotedRoute = activeBackend.withLock { $0 } == .combinedAggregate
+                && control.withLock { state in
+                    state.activeOutput?.uid == output.uid
+                        && state.activeOutput?.nominalSampleRate == output.nominalSampleRate
+                }
+            guard isActivePromotedRoute else {
+                return nil
             }
-            isRunning = false
         }
-        playbackBufferAdaptationTimer.cancel()
+        let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
+        let preferredChannels = try? CoreAudioDeviceQuery.preferredStereoChannels(
+            objectID: freshOutput.id
+        )
+        let channelPair = Self.playbackStereoPair(
+            preferredChannels: preferredChannels,
+            outputChannelCount: freshOutput.outputChannelCount
+        )
+        let streamChannelCounts = try CoreAudioDeviceQuery.streamChannelCounts(
+            objectID: freshOutput.id,
+            scope: kAudioDevicePropertyScopeOutput
+        )
+        guard let streamIndex = Self.tapOutputStreamIndex(
+            streamChannelCounts: streamChannelCounts,
+            playbackChannels: channelPair
+        ) else {
+            throw AudioEngineInternalError(
+                message: "The selected stereo channels must belong to one mono or stereo output stream."
+            )
+        }
+        return AggregateAudioRouteFingerprint(
+            outputDeviceUID: freshOutput.uid,
+            nativeOutputStreamIndex: streamIndex,
+            nominalSampleRate: freshOutput.nominalSampleRate
+        )
     }
 
     public func start(output: AudioOutputDevice, profile: EQProfile) throws {
-        try start(output: output, profile: profile, expectation: nil)
+        try topologyOperation.withLock { _ in
+            try startSerialized(output: output, profile: profile)
+        }
     }
 
-    private func start(
-        output: AudioOutputDevice,
-        profile: EQProfile,
-        expectation: OutputRebuildExpectation?
-    ) throws {
-        pausePlaybackBufferAdaptation()
-        defer {
-            updatePlaybackBufferAdaptationTimer()
+    private func startSerialized(output: AudioOutputDevice, profile: EQProfile) throws {
+        let shouldUseSeparateClock = Self.shouldUseSeparateClockBackend(for: output)
+            && !promotedHeadsetRoute.withLock { route in
+                route == Self.promotedHeadsetRoute(for: output)
+            }
+        if shouldUseSeparateClock {
+            try startSeparateClockBackend(output: output, profile: profile)
+            return
         }
-        var previousState = AudioEngineState.stopped
-        var previousStatus = AudioEngineStatus.stopped
-        var activePreparation: OutputRebuildPreparation?
+
+        if !Self.shouldUseSeparateClockBackend(for: output) {
+            promotedHeadsetRoute.withLock { $0 = nil }
+        }
+
+        try startCombinedAggregate(output: output, profile: profile)
+    }
+
+    private func startSeparateClockBackend(
+        output: AudioOutputDevice,
+        profile: EQProfile
+    ) throws {
+        let combinedIsRunning = activeBackend.withLock { $0 } == .combinedAggregate
+            && control.withLock { state in
+                if case .running = state.state {
+                    return true
+                }
+                return false
+            }
+        guard combinedIsRunning else {
+            stopCombinedResourcesSerialized()
+            activeBackend.withLock { $0 = .separateClock }
+            try separateClockBackend.start(output: output, profile: profile)
+            return
+        }
+
+        try separateClockBackend.prepareOutputForHandoff(
+            output: output,
+            profile: profile
+        )
+        stopCombinedResourcesSerialized()
+        activeBackend.withLock { $0 = .separateClock }
+        _ = try separateClockBackend.activatePreparedOutputHandoff()
+    }
+
+    private func startCombinedAggregate(
+        output: AudioOutputDevice,
+        profile: EQProfile
+    ) throws {
+        let isSeparateClockHandoff = activeBackend.withLock { $0 } == .separateClock
+        control.withLock { state in
+            state.status = .starting
+        }
+
+        var taps: CombinedTapSet?
+        var preparedAggregate: PreparedCombinedAggregate?
 
         do {
-            var preparation = try control.withLock { state in
-                if let expectation {
-                    guard state.outputRebuildGeneration == expectation.generation,
-                          state.runtime === expectation.runtime,
-                          state.activeOutput?.uid == output.uid else {
-                        throw StaleOutputRebuild()
-                    }
-                }
-                guard let requestedProfile = Self.requestedOutputRebuildProfile(
-                    requestedProfile: profile,
-                    expectedProfileRevision: expectation?.profileRevision,
-                    activeProfile: state.activeProfile,
-                    activeProfileRevision: state.profileRevision
-                ) else {
-                    throw StaleProfileRequest()
-                }
-                previousState = state.state
-                previousStatus = state.status
-                state.status = .starting
-                // Keep capture alive across ordinary output switches. Leaving a low-rate route
-                // refreshes it under the same mute guard used for topology changes so normal
-                // outputs regain their full capture bandwidth without leaking dry audio.
-                try ensureCaptureHalfLocked(&state, output: output, profile: requestedProfile)
-                state.profileRevision &+= 1
-                return try prepareOutputRebuildLocked(
-                    &state,
-                    output: output,
-                    profile: requestedProfile,
-                    profileRevision: state.profileRevision
-                )
-            }
-            let refreshedOutput = try CoreAudioDeviceQuery.outputDevice(id: preparation.output.id)
-            preparation.output = refreshedOutput
-            preparation.originalBufferFrameSize = refreshedOutput.bufferFrameSize
-            activePreparation = preparation
-            try control.withLock { state in
-                guard state.outputRebuildGeneration == preparation.generation,
-                      state.runtime === preparation.runtime,
-                      state.captureRunning else {
-                    throw StaleOutputRebuild()
-                }
-                if Self.shouldRecordSampleRateRestoration(
-                    tapSampleRate: preparation.tapSampleRate,
-                    output: refreshedOutput
-                ) {
-                    try recordSampleRateRestorationIfNeeded(for: refreshedOutput, state: &state)
-                }
-            }
-            let matchedOutput = try preparePlaybackOutput(
-                tapSampleRate: preparation.tapSampleRate,
-                output: preparation.output
-            )
-            let calibrationProbe = try control.withLock { state -> PlaybackBufferCalibrationProbe? in
-                try finishOutputRebuildLocked(&state, preparation: preparation, matchedOutput: matchedOutput)
-                let active = state.activeOutput ?? output
-                state.state = .running(output: active)
-                state.status = .running(output: active)
-                return state.playbackBufferCalibrationProbe
-            }
-            if let calibrationProbe {
-                try? PersistedPlaybackBufferCalibrationStore.beginProbe(
-                    outputUID: calibrationProbe.outputUID,
-                    sampleRate: calibrationProbe.sampleRate,
-                    tapSampleRate: calibrationProbe.tapSampleRate,
-                    frameSize: calibrationProbe.frameSize,
-                    targetFrames: calibrationProbe.targetFrames,
-                    at: playbackBufferCalibrationStoreURL
-                )
-            }
-        } catch is StaleOutputRebuild {
-            return
-        } catch is StaleProfileRequest {
-            return
-        } catch {
-            var shouldRethrow = true
+            let route = try prepareCombinedRoute(output: output)
+            let targetFrameSize = control.withLock { $0.preferredAggregateBufferFrameSize }
+            var detachedAggregate: DetachedCombinedAggregate?
+            var staleTaps: CombinedTapSet?
+
             control.withLock { state in
-                if let activePreparation,
-                   state.outputRebuildGeneration != activePreparation.generation {
-                    shouldRethrow = false
-                    return
+                detachedAggregate = detachCombinedAggregateLocked(&state)
+                state.state = .stopped
+                state.lastTimestampProbeRecords.removeAll(keepingCapacity: true)
+
+                if state.tapOutputUID == route.output.uid,
+                   state.tapOutputStreamIndex == route.outputStreamIndex,
+                   state.tapID != kAudioObjectUnknown,
+                   state.systemSoundTapID != kAudioObjectUnknown {
+                    taps = CombinedTapSet(
+                        main: state.tapID,
+                        systemSounds: state.systemSoundTapID,
+                        outputUID: route.output.uid,
+                        outputStreamIndex: route.outputStreamIndex
+                    )
+                } else {
+                    staleTaps = detachTapSetLocked(&state)
                 }
-                if error is TopologyRebuildMuteGuardUnavailable {
-                    state.state = previousState
-                    state.status = previousStatus
-                    return
+            }
+
+            if let detachedAggregate {
+                let records = disposeDetachedCombinedAggregate(detachedAggregate)
+                control.withLock { state in
+                    state.lastTimestampProbeRecords = records
                 }
-                let failure = audioEngineFailure(from: error)
-                // Any failure tears the tap down too, so the system is never left muted
-                // with nothing replaying.
-                stopLocked(&state)
+            }
+            if let staleTaps {
+                destroyTapSet(staleTaps)
+            }
+
+            if taps == nil {
+                let createdTaps = try createSystemTaps(
+                    output: route.output,
+                    streamIndex: route.outputStreamIndex
+                )
+                taps = CombinedTapSet(
+                    main: createdTaps.main,
+                    systemSounds: createdTaps.systemSounds,
+                    outputUID: route.output.uid,
+                    outputStreamIndex: route.outputStreamIndex
+                )
+            }
+            guard let taps else {
+                throw AudioEngineInternalError(message: "Core Audio did not create the process taps.")
+            }
+
+            let prepared = try prepareCombinedAggregate(
+                taps: taps,
+                route: route,
+                profile: profile,
+                targetFrameSize: targetFrameSize
+            )
+            preparedAggregate = prepared
+
+            if isSeparateClockHandoff {
+                separateClockBackend.quiesceOutputForCombinedHandoff()
+            }
+            try checkOSStatus(
+                AudioDeviceStart(prepared.deviceID, prepared.ioProcID),
+                operation: "AudioDeviceStart(combined aggregate)"
+            )
+            prepared.runtime.waitForSilentWarmUp(minimumCallbacks: 32, timeout: 0.1)
+            prepared.runtime.activate()
+
+            control.withLock { state in
+                state.tapID = prepared.taps.main
+                state.systemSoundTapID = prepared.taps.systemSounds
+                state.tapOutputUID = prepared.taps.outputUID
+                state.tapOutputStreamIndex = prepared.taps.outputStreamIndex
+                state.aggregateDeviceID = prepared.deviceID
+                state.ioProcID = prepared.ioProcID
+                state.runtime = prepared.runtime
+                state.activeOutput = prepared.output
+                state.activeProfile = prepared.profile
+                state.state = .running(output: prepared.output)
+                state.status = .running(output: prepared.output)
+            }
+            preparedAggregate = nil
+            activeBackend.withLock { $0 = .combinedAggregate }
+            if isSeparateClockHandoff {
+                separateClockBackend.completeCombinedHandoff()
+            }
+        } catch {
+            let failure = audioEngineFailure(from: error)
+            var failedStateAggregate: DetachedCombinedAggregate?
+            var installedTaps: CombinedTapSet?
+            control.withLock { state in
+                failedStateAggregate = detachCombinedAggregateLocked(&state)
+                installedTaps = detachTapSetLocked(&state)
+                state.activeProfile = nil
                 state.state = .failed(failure.description)
                 if failure.category == .systemAudioCapturePermission {
                     state.status = .permissionRequired(failure)
@@ -1574,672 +1726,1005 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     state.status = .failed(failure)
                 }
             }
-            if shouldRethrow {
-                throw error
+
+            if let preparedAggregate {
+                _ = disposeDetachedCombinedAggregate(
+                    DetachedCombinedAggregate(
+                        deviceID: preparedAggregate.deviceID,
+                        ioProcID: preparedAggregate.ioProcID,
+                        runtime: preparedAggregate.runtime
+                    )
+                )
             }
+            let failedStateMatchesPrepared = failedStateAggregate?.deviceID
+                == preparedAggregate?.deviceID
+            if let failedStateAggregate, !failedStateMatchesPrepared {
+                let records = disposeDetachedCombinedAggregate(failedStateAggregate)
+                control.withLock { state in
+                    state.lastTimestampProbeRecords = records
+                }
+            }
+            if let installedTaps {
+                destroyTapSet(installedTaps)
+            }
+            let installedTapsMatch = installedTaps?.main == taps?.main
+                && installedTaps?.systemSounds == taps?.systemSounds
+            if let taps, !installedTapsMatch {
+                destroyTapSet(taps)
+            }
+            throw error
         }
     }
 
-    public func update(profile: EQProfile) throws {
-        // Prefer a lock-free hot-swap that leaves the persistent tap untouched.
-        if updateDSP(profile: profile) {
+    private func prepareCombinedRoute(output: AudioOutputDevice) throws -> CombinedRoutePreparation {
+        let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
+        _ = try Self.supportedRuntimeChannelCount(for: freshOutput)
+        try Self.validatePlaybackCallbackCapacity(for: freshOutput)
+        let preferredChannels = try? CoreAudioDeviceQuery.preferredStereoChannels(
+            objectID: freshOutput.id
+        )
+        let channelPair = Self.playbackStereoPair(
+            preferredChannels: preferredChannels,
+            outputChannelCount: freshOutput.outputChannelCount
+        )
+        let outputStreamChannelCounts = try CoreAudioDeviceQuery.streamChannelCounts(
+            objectID: freshOutput.id,
+            scope: kAudioDevicePropertyScopeOutput
+        )
+        guard let outputStreamIndex = Self.tapOutputStreamIndex(
+            streamChannelCounts: outputStreamChannelCounts,
+            playbackChannels: channelPair
+        ) else {
+            throw AudioEngineInternalError(
+                message: "The selected stereo channels must belong to one mono or stereo output stream."
+            )
+        }
+        return CombinedRoutePreparation(
+            output: freshOutput,
+            outputStreamIndex: outputStreamIndex,
+            outputStreamChannelCounts: outputStreamChannelCounts,
+            channelPair: channelPair
+        )
+    }
+
+    private func prepareCombinedAggregate(
+        taps: CombinedTapSet,
+        route: CombinedRoutePreparation,
+        profile: EQProfile,
+        targetFrameSize: UInt32
+    ) throws -> PreparedCombinedAggregate {
+        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        var ioProcID: AudioDeviceIOProcID?
+        var runtime: AudioRuntime?
+
+        do {
+            let aggregateCreation = try createCombinedAggregateDevice(
+                tapID: taps.main,
+                systemSoundTapID: taps.systemSounds,
+                output: route.output
+            )
+            aggregateDeviceID = aggregateCreation.deviceID
+            try waitUntilAggregateIsAlive(aggregateDeviceID)
+            let tapUIDOrder = try verifyAggregateComposition(
+                aggregateDeviceID,
+                output: route.output,
+                expectedTapDriftCompensation: [
+                    aggregateCreation.mainTapUID: true,
+                    aggregateCreation.systemSoundTapUID: true
+                ]
+            )
+
+            let aggregate = try tuneAggregateBufferFrameSize(
+                deviceID: aggregateDeviceID,
+                targetFrameSize: targetFrameSize
+            )
+            try Self.validatePlaybackCallbackCapacity(for: aggregate)
+            let mainTapChannelCount = try tapChannelCount(taps.main)
+            let systemSoundTapChannelCount = try tapChannelCount(taps.systemSounds)
+            guard mainTapChannelCount == route.outputStreamChannelCounts[route.outputStreamIndex],
+                  systemSoundTapChannelCount == mainTapChannelCount else {
+                throw AudioEngineInternalError(
+                    message: "The process-tap formats do not match the selected output stream."
+                )
+            }
+            let physicalInputChannelCount = try CoreAudioDeviceQuery.getChannelCount(
+                objectID: route.output.id,
+                scope: kAudioDevicePropertyScopeInput
+            )
+            let aggregateInputChannelCount = try CoreAudioDeviceQuery.getChannelCount(
+                objectID: aggregateDeviceID,
+                scope: kAudioDevicePropertyScopeInput
+            )
+            guard let mainTapIndex = tapUIDOrder.firstIndex(of: aggregateCreation.mainTapUID),
+                  let systemSoundTapIndex = tapUIDOrder.firstIndex(
+                      of: aggregateCreation.systemSoundTapUID
+                  ),
+                  let tapInputChannelOffsets = Self.tapInputChannelOffsets(
+                      physicalInputChannelCount: physicalInputChannelCount,
+                      aggregateInputChannelCount: aggregateInputChannelCount,
+                      mainTapChannelCount: mainTapChannelCount,
+                      systemSoundTapChannelCount: systemSoundTapChannelCount,
+                      mainTapIndex: mainTapIndex,
+                      systemSoundTapIndex: systemSoundTapIndex
+                  ) else {
+                throw AudioEngineInternalError(
+                    message: "The aggregate input layout does not match its physical output and process taps."
+                )
+            }
+
+            let preparedRuntime = AudioRuntime(
+                profile: profile,
+                sampleRate: aggregate.nominalSampleRate,
+                channelCount: mainTapChannelCount,
+                inputChannelOffset: tapInputChannelOffsets.main,
+                systemSoundInputChannelOffset: tapInputChannelOffsets.systemSounds,
+                maxCallbackFrames: Self.maximumSupportedCallbackFrames
+            )
+            runtime = preparedRuntime
+            preparedRuntime.setPlaybackChannelPair(
+                left: route.channelPair.left,
+                right: route.channelPair.right
+            )
+
+            guard let preparedIOProcID = try createCombinedIOProc(
+                deviceID: aggregateDeviceID,
+                runtime: preparedRuntime
+            ) else {
+                throw CoreAudioError(
+                    operation: "AudioDeviceCreateIOProcIDWithBlock(combined aggregate) returned nil",
+                    status: kAudioHardwareUnspecifiedError
+                )
+            }
+            ioProcID = preparedIOProcID
+            try configureInputStreamUsage(
+                deviceID: aggregateDeviceID,
+                ioProcID: preparedIOProcID,
+                tapInputChannelOffset: min(
+                    tapInputChannelOffsets.main,
+                    tapInputChannelOffsets.systemSounds
+                ),
+                tapChannelCount: mainTapChannelCount + systemSoundTapChannelCount
+            )
+
+            var activeOutput = route.output
+            activeOutput.bufferFrameSize = aggregate.bufferFrameSize
+            return PreparedCombinedAggregate(
+                taps: taps,
+                deviceID: aggregateDeviceID,
+                ioProcID: preparedIOProcID,
+                runtime: preparedRuntime,
+                output: activeOutput,
+                profile: profile
+            )
+        } catch {
+            if aggregateDeviceID != kAudioObjectUnknown, let ioProcID {
+                _ = AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProcID)
+            }
+            if aggregateDeviceID != kAudioObjectUnknown {
+                _ = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            }
+            runtime?.drainDSPConfigBoxes()
+            throw error
+        }
+    }
+
+    public func attemptHeadsetAggregatePromotion() throws -> HeadsetAggregatePromotionResult {
+        try topologyOperation.withLock { _ in
+            try attemptHeadsetAggregatePromotionSerialized()
+        }
+    }
+
+    private func attemptHeadsetAggregatePromotionSerialized() throws
+        -> HeadsetAggregatePromotionResult {
+        guard activeBackend.withLock({ $0 }) == .separateClock,
+              let context = separateClockBackend.activeOutputAndProfile(),
+              Self.shouldUseSeparateClockBackend(for: context.output) else {
+            return .notApplicable
+        }
+        let currentDefault = try CoreAudioDeviceQuery.defaultOutputDevice()
+        guard currentDefault.uid == context.output.uid,
+              currentDefault.nominalSampleRate == context.output.nominalSampleRate else {
+            return .notApplicable
+        }
+        guard try Self.deviceClockSlopeIsStable(
+            deviceID: currentDefault.id,
+            nominalSampleRate: currentDefault.nominalSampleRate,
+            observationDuration: Self.headsetClockProbeDuration
+        ) else {
+            return .clockUnstable
+        }
+
+        do {
+            try startCombinedAggregate(output: currentDefault, profile: context.profile)
+        } catch {
+            let promotionError = error
+            do {
+                try restoreSeparateClockBackend(afterRejectedPromotion: context)
+            } catch let rollbackError {
+                throw AudioEngineInternalError(
+                    message: "Headset aggregate promotion failed and the compatibility path could not be restored: \(promotionError.localizedDescription); rollback: \(rollbackError.localizedDescription)"
+                )
+            }
+            return .aggregateUnstable
+        }
+
+        Thread.sleep(forTimeInterval: Self.headsetAggregateValidationDuration)
+        let metrics = snapshotMetrics()
+        guard metrics.pairedTimestampDiscontinuities == 0,
+              case .running(let output) = state else {
+            try restoreSeparateClockBackend(afterRejectedPromotion: context)
+            return .aggregateUnstable
+        }
+        promotedHeadsetRoute.withLock {
+            $0 = Self.promotedHeadsetRoute(for: output)
+        }
+        return .promoted(output)
+    }
+
+    private func restoreSeparateClockBackend(
+        afterRejectedPromotion context: (output: AudioOutputDevice, profile: EQProfile)
+    ) throws {
+        promotedHeadsetRoute.withLock { $0 = nil }
+        if activeBackend.withLock({ $0 }) == .separateClock,
+           separateClockBackend.activeOutputAndProfile() != nil {
             return
         }
-        // Topology-incompatible change: rebuild around the persistent tap (the tap rate is
-        // constant, so start() keeps the capture half and only swaps the DSP graph + output).
-        let output = try Self.profileUpdateOutput(control.withLock { $0.activeOutput })
-        let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
-        try start(output: freshOutput, profile: profile)
-        let didApplyProfile = control.withLock { state in
-            state.activeProfile == profile
-        }
-        guard didApplyProfile else {
-            throw TopologyRebuildMuteGuardUnavailable(
-                underlyingError: AudioEngineInternalError(message: "Profile rebuild was not applied.")
+        try startSeparateClockBackend(
+            output: CoreAudioDeviceQuery.outputDevice(id: context.output.id),
+            profile: context.profile
+        )
+    }
+
+    public func rejectHeadsetAggregatePromotion() {
+        promotedHeadsetRoute.withLock { $0 = nil }
+    }
+
+    public func update(profile: EQProfile) throws {
+        try topologyOperation.withLock { _ in
+            if activeBackend.withLock({ $0 }) == .separateClock {
+                try separateClockBackend.update(profile: profile)
+                return
+            }
+            if updateDSP(profile: profile) {
+                return
+            }
+            let output = try Self.profileUpdateOutput(
+                control.withLock { $0.activeOutput }
+            )
+            try startSerialized(
+                output: CoreAudioDeviceQuery.outputDevice(id: output.id),
+                profile: profile
             )
         }
     }
 
     @discardableResult
     public func updateDSP(profile: EQProfile) -> Bool {
-        control.withLock { state in
-            updateDSPLocked(&state, profile: profile)
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            return separateClockBackend.updateDSP(profile: profile)
         }
-    }
-
-    private func updateDSPLocked(
-        _ state: inout ControlState,
-        profile: EQProfile,
-        incrementsProfileRevision: Bool = true
-    ) -> Bool {
-        guard let runtime = state.runtime,
-              let activeProfile = state.activeProfile else {
-            return false
-        }
-        let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
-            sampleRate: state.activeOutput?.nominalSampleRate ?? runtime.sampleRate
-        )
-
-        guard Self.canHotSwapDSP(
-            from: activeProfile,
-            to: profile,
-            sampleRate: runtime.sampleRate,
-            channelCount: runtime.channelCount,
-            maximumUsableFrequency: maximumUsableFrequency
-        ) else {
-            return false
-        }
-
-        let preparedConfig = EQRenderConfiguration(
-            profile: Self.dspProfile(from: profile),
-            sampleRate: runtime.sampleRate,
-            channelCount: runtime.channelCount,
-            maximumUsableFrequency: maximumUsableFrequency
-        )
-        runtime.drainDSPConfigBoxes()
-        runtime.publishPendingDSPConfig(preparedConfig)
-        runtime.setBypassed(profile.isBypassed)
-        state.activeProfile = profile
-        if incrementsProfileRevision {
-            state.profileRevision &+= 1
-        }
-        return true
-    }
-
-    static func canHotSwapDSP(
-        from activeProfile: EQProfile,
-        to nextProfile: EQProfile,
-        sampleRate: Double,
-        channelCount: Int,
-        maximumUsableFrequency: Double? = nil
-    ) -> Bool {
-        guard activeProfile.mode == nextProfile.mode,
-              activeProfile.channelMode == nextProfile.channelMode else {
-            return false
-        }
-
-        return EQRenderConfiguration(
-            profile: Self.dspProfile(from: nextProfile),
-            sampleRate: sampleRate,
-            channelCount: channelCount,
-            maximumUsableFrequency: maximumUsableFrequency
-        ).hasRealtimeCompatibleTopology(
-            with: EQRenderConfiguration(
-                profile: Self.dspProfile(from: activeProfile),
-                sampleRate: sampleRate,
-                channelCount: channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
+        return control.withLock { state in
+            guard let runtime = state.runtime,
+                  let activeProfile = state.activeProfile else {
+                return false
+            }
+            let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+                sampleRate: runtime.sampleRate
             )
-        )
+            guard Self.canHotSwapDSP(
+                from: activeProfile,
+                to: profile,
+                sampleRate: runtime.sampleRate,
+                channelCount: runtime.channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            ) else {
+                return false
+            }
+            runtime.drainDSPConfigBoxes()
+            runtime.publishPendingDSPConfig(
+                EQRenderConfiguration(
+                    profile: Self.dspProfile(from: profile),
+                    sampleRate: runtime.sampleRate,
+                    channelCount: runtime.channelCount,
+                    maximumUsableFrequency: maximumUsableFrequency
+                )
+            )
+            runtime.setBypassed(profile.isBypassed)
+            state.activeProfile = profile
+            return true
+        }
     }
 
     public func setBypassed(_ isBypassed: Bool) {
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            separateClockBackend.setBypassed(isBypassed)
+            return
+        }
         control.withLock { state in
             state.runtime?.setBypassed(isBypassed)
             state.activeProfile?.isBypassed = isBypassed
-            state.profileRevision &+= 1
+        }
+    }
+
+    public func setPreferredAggregateBufferFrameSize(_ frameSize: UInt32) {
+        guard frameSize > 0 else {
+            return
+        }
+        control.withLock { state in
+            state.preferredAggregateBufferFrameSize = frameSize
         }
     }
 
     public func muteOutputForTransition() {
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            separateClockBackend.muteOutputForTransition()
+            return
+        }
         control.withLock { state in
             state.runtime?.muteOutputForTransition()
         }
     }
 
     public func stop() {
-        pausePlaybackBufferAdaptation()
-        control.withLock { state in
-            stopLocked(&state)
+        topologyOperation.withLock { _ in
+            promotedHeadsetRoute.withLock { $0 = nil }
+            separateClockBackend.stop()
+            stopCombinedResourcesSerialized()
+            activeBackend.withLock { $0 = .combinedAggregate }
         }
-        updatePlaybackBufferAdaptationTimer()
     }
 
     public func snapshotMetrics() -> AudioEngineMetrics {
-        let runtime = control.withLock { $0.runtime }
-        return runtime?.snapshotMetrics() ?? AudioEngineMetrics()
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            return separateClockBackend.snapshotMetrics()
+        }
+        return control.withLock { $0.runtime }?.snapshotMetrics() ?? AudioEngineMetrics()
+    }
+
+    public func snapshotTimestampProbeRecords() -> [AudioTimestampProbeRecord] {
+        control.withLock { $0.lastTimestampProbeRecords }
+    }
+
+    public func snapshotLatencyMetadata() -> AudioEngineLatencyMetadata? {
+        guard activeBackend.withLock({ $0 }) == .combinedAggregate else {
+            return nil
+        }
+        let route = control.withLock { state -> (AudioObjectID, AudioObjectID)? in
+            guard let output = state.activeOutput,
+                  state.aggregateDeviceID != kAudioObjectUnknown else {
+                return nil
+            }
+            return (output.id, state.aggregateDeviceID)
+        }
+        guard let route else {
+            return nil
+        }
+        return AudioEngineLatencyMetadata(
+            physicalDevice: Self.latencyMetadata(deviceID: route.0),
+            aggregateDevice: Self.latencyMetadata(deviceID: route.1)
+        )
     }
 
     public func resetDiagnostics() {
-        let runtime = control.withLock { $0.runtime }
-        runtime?.resetMetrics()
-    }
-
-    public func resetPlaybackBufferCalibration(forOutputUID outputUID: String) throws {
-        guard !outputUID.isEmpty else {
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            separateClockBackend.resetDiagnostics()
             return
         }
-        pausePlaybackBufferAdaptation()
-        defer {
-            updatePlaybackBufferAdaptationTimer()
-        }
-        try PersistedPlaybackBufferCalibrationStore.removeCalibrations(
-            outputUID: outputUID,
-            at: playbackBufferCalibrationStoreURL
-        )
-        let activeOutputAndProfile = control.withLock {
-            state -> (AudioOutputDevice, EQProfile, OutputRebuildExpectation)? in
-            if state.playbackBufferCalibrationProbe?.outputUID == outputUID {
-                state.playbackBufferCalibrationProbe = nil
-            }
-            state.playbackBufferInstabilityPersistenceGate.reset(outputUID: outputUID)
-            state.attemptedPlaybackTargetDownProbes = Set(
-                state.attemptedPlaybackTargetDownProbes.filter { $0.outputUID != outputUID }
-            )
-            state.attemptedPlaybackFrameSizeDownProbes = Set(
-                state.attemptedPlaybackFrameSizeDownProbes.filter { $0.outputUID != outputUID }
-            )
-            guard let output = state.activeOutput,
-                  output.uid == outputUID,
-                  let profile = state.activeProfile else {
-                return nil
-            }
-            guard let runtime = state.runtime else {
-                return nil
-            }
-            return (
-                output,
-                profile,
-                OutputRebuildExpectation(
-                    generation: state.outputRebuildGeneration,
-                    runtime: runtime,
-                    profileRevision: state.profileRevision
-                )
-            )
-        }
-        if let (activeOutput, activeProfile, expectation) = activeOutputAndProfile {
-            let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: activeOutput.id)
-            try start(
-                output: freshOutput,
-                profile: activeProfile,
-                expectation: expectation
-            )
-        }
-    }
-
-    public func setPlaybackBufferRenegotiationHandler(
-        _ handler: (@Sendable (PlaybackBufferRenegotiation) -> Void)?
-    ) {
-        playbackBufferRenegotiationHandler.withLock { currentHandler in
-            currentHandler = handler
-        }
+        control.withLock { $0.runtime }?.resetMetrics()
     }
 
     public func setRuntimeFailureHandler(
         _ handler: (@Sendable (AudioEngineFailure) -> Void)?
     ) {
-        runtimeFailureHandler.withLock { currentHandler in
-            currentHandler = handler
+        separateClockBackend.setRuntimeFailureHandler(handler)
+    }
+
+    private func stopCombinedResourcesSerialized() {
+        var detachedAggregate: DetachedCombinedAggregate?
+        var detachedTaps: CombinedTapSet?
+        control.withLock { state in
+            detachedAggregate = detachCombinedAggregateLocked(&state)
+            detachedTaps = detachTapSetLocked(&state)
+            state.activeProfile = nil
+            state.state = .stopped
+            state.status = .stopped
         }
-    }
-
-    private func stopLocked(_ state: inout ControlState) {
-        state.runtime?.markStopping()
-        stopOutputHalfLocked(&state)
-        stopCaptureHalfLocked(&state)
-        state.activeProfile = nil
-        state.profileRevision &+= 1
-        state.handledPlaybackInstabilityGeneration = 0
-        state.adaptivePlaybackRenderRecoveryAttempts = 0
-        state.adaptivePlaybackRenderRecoveryHealthGeneration = nil
-        state.playbackBufferInstabilityPersistenceGate.reset()
-        state.attemptedPlaybackTargetDownProbes.removeAll()
-        state.attemptedPlaybackFrameSizeDownProbes.removeAll()
-        state.state = .stopped
-        state.status = .stopped
-    }
-
-    // MARK: - Capture half (persistent global muted tap @ the tap rate)
-
-    private func ensureCaptureHalfLocked(
-        _ state: inout ControlState,
-        output: AudioOutputDevice,
-        profile: EQProfile
-    ) throws {
-        if state.captureRunning, state.runtime != nil {
-            let shouldRefreshCapture = Self.shouldRefreshCaptureForOutput(
-                tapSampleRate: state.tapSampleRate,
-                output: output
-            )
-            if !shouldRefreshCapture,
-               updateDSPLocked(&state, profile: profile, incrementsProfileRevision: false) {
-                return
+        if let detachedAggregate {
+            let records = disposeDetachedCombinedAggregate(detachedAggregate)
+            control.withLock { state in
+                state.lastTimestampProbeRecords = records
             }
-            // Hold a second global muted tap while capture is recreated, so HAL-level muting
-            // never lapses during topology changes or low-rate capture refreshes.
-            try Self.performTopologyRebuild(
-                acquireMuteGuard: { try createTopologyRebuildMuteGuard() }
-            ) {
-                stopOutputHalfLocked(&state)
-                stopCaptureHalfLocked(&state)
-                try createCaptureHalfLocked(&state, profile: profile)
-            }
-            return
         }
-        try createCaptureHalfLocked(&state, profile: profile)
+        if let detachedTaps {
+            destroyTapSet(detachedTaps)
+        }
     }
 
-    private func createCaptureHalfLocked(_ state: inout ControlState, profile: EQProfile) throws {
-        let tapID = try createSystemTap()
-        state.tapID = tapID
-
-        let format = try tapStreamFormat(tapID)
-        let tapSampleRate = format.mSampleRate > 0 ? format.mSampleRate : 48_000
-        let tapChannelCount = min(max(Int(format.mChannelsPerFrame), 1), 2)
-        state.tapSampleRate = tapSampleRate
-        state.tapChannelCount = tapChannelCount
-
-        let runtimeBufferFrameSize = Int(Self.maximumRuntimeBufferFrameSize)
-        // Low-latency tuning: a 128-frame prime (~2.7 ms @ 48k) — about 2x the tap's callback
-        // once we request a 64-frame capture buffer below. Capacity is sized from the largest
-        // runtime output callback so every supported prime retains equal drift headroom.
-        let playbackPrimeFrames = Self.preferredPlaybackPrimeFrames
-        let ringCapacityFrames = Self.runtimeRingCapacityFrames
-        let scratchFrames = max(runtimeBufferFrameSize, Self.minimumRingBufferFrames)
-
-        state.aggregateDeviceID = try createPrivateAggregateDevice(tapID: tapID)
-        // Ask the capture aggregate for small callbacks to cut latency. The write is best-effort,
-        // so size the initial playback reservoir from the value the aggregate actually reports.
-        try? CoreAudioDeviceQuery.setBufferFrameSize(
-            Self.preferredCaptureBufferFrameSize,
-            objectID: state.aggregateDeviceID
+    private func detachCombinedAggregateLocked(
+        _ state: inout ControlState
+    ) -> DetachedCombinedAggregate? {
+        let detached = DetachedCombinedAggregate(
+            deviceID: state.aggregateDeviceID,
+            ioProcID: state.ioProcID,
+            runtime: state.runtime
         )
-        let reportedCaptureCallbackFrames = try? CoreAudioDeviceQuery.getUInt32Property(
-            objectID: state.aggregateDeviceID,
-            selector: kAudioDevicePropertyBufferFrameSize,
-            scope: kAudioObjectPropertyScopeGlobal
-        )
-        let captureCallbackFrames = Self.startupCaptureCallbackFrames(
-            reportedFrames: reportedCaptureCallbackFrames
-        )
-
-        let runtime = AudioRuntime(
-            profile: profile,
-            sampleRate: tapSampleRate,
-            channelCount: tapChannelCount,
-            ringCapacityFrames: ringCapacityFrames,
-            scratchFrames: scratchFrames,
-            captureCallbackFrames: captureCallbackFrames,
-            playbackPrimeFrames: playbackPrimeFrames
-        )
-        state.runtime = runtime
-        state.activeProfile = profile
-
-        state.captureIOProcID = try createCaptureIOProc(deviceID: state.aggregateDeviceID, runtime: runtime)
-        try checkOSStatus(
-            AudioDeviceStart(state.aggregateDeviceID, state.captureIOProcID),
-            operation: "AudioDeviceStart(capture tap)"
-        )
-        state.captureRunning = true
-    }
-
-    private func stopCaptureHalfLocked(_ state: inout ControlState) {
-        state.runtime?.markStopping()
-
-        if state.aggregateDeviceID != kAudioObjectUnknown, let captureIOProcID = state.captureIOProcID {
-            _ = AudioDeviceStop(state.aggregateDeviceID, captureIOProcID)
-            _ = AudioDeviceDestroyIOProcID(state.aggregateDeviceID, captureIOProcID)
-        }
-        if state.aggregateDeviceID != kAudioObjectUnknown {
-            _ = AudioHardwareDestroyAggregateDevice(state.aggregateDeviceID)
-        }
-        if state.tapID != kAudioObjectUnknown {
-            _ = AudioHardwareDestroyProcessTap(state.tapID)
-        }
-
-        state.runtime?.drainDSPConfigBoxes()
-        state.captureIOProcID = nil
         state.aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
-        state.tapID = AudioObjectID(kAudioObjectUnknown)
+        state.ioProcID = nil
         state.runtime = nil
-        state.tapSampleRate = 0
-        state.tapChannelCount = 0
-        state.captureRunning = false
+        state.activeOutput = nil
+        guard detached.deviceID != kAudioObjectUnknown
+                || detached.ioProcID != nil
+                || detached.runtime != nil else {
+            return nil
+        }
+        return detached
     }
 
-    // MARK: - Output half (swappable; direct-rate or converted low-rate playback)
+    private func disposeDetachedCombinedAggregate(
+        _ detached: DetachedCombinedAggregate
+    ) -> [AudioTimestampProbeRecord] {
+        detached.runtime?.fadeOutForStop()
+        detached.runtime?.markStopping()
+        if detached.deviceID != kAudioObjectUnknown, let ioProcID = detached.ioProcID {
+            _ = AudioDeviceStop(detached.deviceID, ioProcID)
+            _ = AudioDeviceDestroyIOProcID(detached.deviceID, ioProcID)
+        }
+        let records = detached.runtime?.snapshotTimestampProbeRecords() ?? []
+        if detached.deviceID != kAudioObjectUnknown {
+            _ = AudioHardwareDestroyAggregateDevice(detached.deviceID)
+        }
+        detached.runtime?.drainDSPConfigBoxes()
+        return records
+    }
 
-    private func prepareOutputRebuildLocked(
-        _ state: inout ControlState,
+    private func detachTapSetLocked(_ state: inout ControlState) -> CombinedTapSet? {
+        let tapSet: CombinedTapSet?
+        if state.tapID != kAudioObjectUnknown || state.systemSoundTapID != kAudioObjectUnknown {
+            tapSet = CombinedTapSet(
+                main: state.tapID,
+                systemSounds: state.systemSoundTapID,
+                outputUID: state.tapOutputUID ?? "",
+                outputStreamIndex: state.tapOutputStreamIndex ?? 0
+            )
+        } else {
+            tapSet = nil
+        }
+        state.tapID = AudioObjectID(kAudioObjectUnknown)
+        state.systemSoundTapID = AudioObjectID(kAudioObjectUnknown)
+        state.tapOutputUID = nil
+        state.tapOutputStreamIndex = nil
+        return tapSet
+    }
+
+    private func destroyTapSet(_ taps: CombinedTapSet) {
+        if taps.main != kAudioObjectUnknown {
+            _ = AudioHardwareDestroyProcessTap(taps.main)
+        }
+        if taps.systemSounds != kAudioObjectUnknown {
+            _ = AudioHardwareDestroyProcessTap(taps.systemSounds)
+        }
+    }
+
+    private func createSystemTaps(
         output: AudioOutputDevice,
-        profile: EQProfile,
-        profileRevision: UInt64
-    ) throws -> OutputRebuildPreparation {
-        guard let runtime = state.runtime else {
-            throw CoreAudioError(operation: "rebuildOutputHalf(missing runtime)", status: kAudioHardwareNotRunningError)
-        }
-        // Mismatched low-rate endpoints keep their device-owned rates and receive realtime
-        // sample-rate conversion in the playback callback.
-        let originalBufferFrameSize = output.bufferFrameSize
-        _ = try Self.supportedRuntimeChannelCount(for: output)
-        stopOutputHalfLocked(&state)
-        return OutputRebuildPreparation(
-            generation: state.outputRebuildGeneration,
-            output: output,
-            profile: profile,
-            runtime: runtime,
-            tapSampleRate: state.tapSampleRate,
-            originalBufferFrameSize: originalBufferFrameSize,
-            profileRevision: profileRevision
+        streamIndex: Int
+    ) throws -> (main: AudioObjectID, systemSounds: AudioObjectID) {
+        let ownProcess = try currentAudioProcessObjectID()
+        let mainDescription = Self.makeSystemTapDescription(
+            excluding: [ownProcess],
+            outputUID: output.uid,
+            streamIndex: streamIndex
         )
-    }
-
-    private func finishOutputRebuildLocked(
-        _ state: inout ControlState,
-        preparation: OutputRebuildPreparation,
-        matchedOutput: AudioOutputDevice
-    ) throws {
-        guard state.outputRebuildGeneration == preparation.generation,
-              state.runtime === preparation.runtime,
-              state.captureRunning else {
-            throw StaleOutputRebuild()
-        }
-        let runtime = preparation.runtime
-        let output = preparation.output
-        let effectiveProfile = Self.effectiveOutputRebuildProfile(
-            preparedProfile: preparation.profile,
-            preparedProfileRevision: preparation.profileRevision,
-            activeProfile: state.activeProfile,
-            activeProfileRevision: state.profileRevision
+        let systemSoundDescription = Self.makeSystemSoundTapDescription(
+            outputUID: output.uid,
+            streamIndex: streamIndex
         )
-        _ = try Self.supportedRuntimeChannelCount(for: matchedOutput)
-        if state.bufferFrameSizeRestorations[output.uid] == nil {
-            let restoration = BufferFrameSizeRestoration(
-                uid: output.uid,
-                originalFrameSize: preparation.originalBufferFrameSize
-            )
-            try PersistedAudioDeviceRestorationStore.recordBufferFrameSize(
-                uid: restoration.uid,
-                originalFrameSize: restoration.originalFrameSize,
-                at: restorationStoreURL
-            )
-            state.bufferFrameSizeRestorations[output.uid] = restoration
-        }
 
-        // Keep our replay muted while we claim and reconfigure the device. The ORDER matters:
-        // start our output IOProc (so GlassEQ owns the device) BEFORE writing the buffer size.
-        // Writing the buffer size restarts the device's hardware stream; doing it after we own
-        // the device means that restart re-engages our (muted) IOProc instead of briefly
-        // replaying the un-muted system mix. The buffer write's own property-change notification
-        // is ignored via CoreAudioSelfChangeGuard, so it no longer triggers a rebuild loop.
-        runtime.muteOutputForTransition()
-
-        // Multi-channel devices play the stereo stream on their preferred stereo pair (the same
-        // channels macOS routes system audio to); every other channel receives silence. The pair
-        // must be stored before AudioDeviceStart so the first callback already maps correctly.
-        let preferredChannels = try? CoreAudioDeviceQuery.preferredStereoChannels(objectID: matchedOutput.id)
-        let channelPair = Self.playbackStereoPair(
-            preferredChannels: preferredChannels,
-            outputChannelCount: matchedOutput.outputChannelCount
+        var mainTapID = AudioObjectID(kAudioObjectUnknown)
+        try checkOSStatus(
+            AudioHardwareCreateProcessTap(mainDescription, &mainTapID),
+            operation: "AudioHardwareCreateProcessTap(main)"
         )
-        runtime.setPlaybackChannelPair(left: channelPair.left, right: channelPair.right)
-
-        guard let outputIOProcID = try createOutputIOProc(deviceID: matchedOutput.id, runtime: runtime) else {
-            throw CoreAudioError(operation: "AudioDeviceCreateIOProcID(default output)", status: kAudioHardwareUnspecifiedError)
-        }
         do {
+            var systemSoundTapID = AudioObjectID(kAudioObjectUnknown)
             try checkOSStatus(
-                AudioDeviceStart(matchedOutput.id, outputIOProcID),
-                operation: "AudioDeviceStart(default output)"
+                AudioHardwareCreateProcessTap(systemSoundDescription, &systemSoundTapID),
+                operation: "AudioHardwareCreateProcessTap(system sounds)"
             )
+            return (mainTapID, systemSoundTapID)
         } catch {
-            _ = AudioDeviceDestroyIOProcID(matchedOutput.id, outputIOProcID)
+            _ = AudioHardwareDestroyProcessTap(mainTapID)
             throw error
         }
-        state.outputIOProcID = outputIOProcID
-        // Keep IOProc ownership paired with its device so failure cleanup can stop it.
-        state.activeOutput = matchedOutput
-
-        // Now that our output owns the device, apply the low-latency buffer size. The stream
-        // restart it triggers happens under our muted IOProc, so it plays silence, not dry audio.
-        let allowsFrameSizeDownwardProbe = state.attemptedPlaybackFrameSizeDownProbes.insert(
-            PlaybackBufferRouteKey(output: matchedOutput)
-        ).inserted
-        let tunedOutput = tuneBufferFrameSize(
-            for: matchedOutput,
-            tapSampleRate: runtime.sampleRate,
-            allowsDownwardProbe: allowsFrameSizeDownwardProbe
-        )
-        try Self.validatePlaybackCallbackCapacity(for: tunedOutput)
-        try Self.validatePlaybackConversionCapacity(
-            for: tunedOutput,
-            tapSampleRate: runtime.sampleRate,
-            captureCallbackFrames: runtime.maximumKnownCaptureCallbackFrames()
-        )
-        state.activeOutput = tunedOutput
-        let operatingPointKey = PlaybackBufferOperatingPointKey(
-            output: tunedOutput,
-            tapSampleRate: runtime.sampleRate
-        )
-        let allowsDownwardProbe = state.attemptedPlaybackTargetDownProbes.insert(
-            operatingPointKey
-        ).inserted
-        let targetFrames = preferredPlaybackTargetFrames(
-            for: tunedOutput,
-            tapSampleRate: runtime.sampleRate,
-            captureCallbackFrames: runtime.maximumKnownCaptureCallbackFrames(),
-            allowsDownwardProbe: allowsDownwardProbe
-        )
-        // Capture applies prepared configs and retires their boxes. Output switches are a safe
-        // control-path opportunity to release those boxes before publishing the next config.
-        runtime.drainDSPConfigBoxes()
-        runtime.publishPendingDSPConfig(EQRenderConfiguration(
-            profile: Self.dspProfile(from: effectiveProfile),
-            sampleRate: runtime.sampleRate,
-            channelCount: runtime.channelCount,
-            maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
-                sampleRate: tunedOutput.nominalSampleRate
-            )
-        ))
-        // Build the converter and its exact Core Audio input scratch on this control path while
-        // the new IOProc is muted. reprimePlayback() release-publishes both before the callback's
-        // acquiring mute check.
-        try runtime.configurePlayback(
-            primeFrames: targetFrames,
-            outputSampleRate: tunedOutput.nominalSampleRate
-        )
-        state.handledPlaybackInstabilityGeneration = runtime.playbackInstabilitySnapshot().generation
-        state.playbackBufferCalibrationProbe = playbackBufferCalibrationProbe(
-            for: tunedOutput,
-            tapSampleRate: runtime.sampleRate,
-            targetFrames: targetFrames
-        )
-
-        // Unmute and re-anchor playback to the freshest captured audio on the new device.
-        runtime.reprimePlayback()
-
-        state.activeProfile = effectiveProfile
     }
 
-    private func stopOutputHalfLocked(_ state: inout ControlState) {
-        state.outputRebuildGeneration += 1
-        if let output = state.activeOutput, let outputIOProcID = state.outputIOProcID {
-            _ = AudioDeviceStop(output.id, outputIOProcID)
-            _ = AudioDeviceDestroyIOProcID(output.id, outputIOProcID)
-        }
-        state.outputIOProcID = nil
-        restoreDeviceSettingsIfNeeded(&state)
-        state.activeOutput = nil
-        state.playbackBufferCalibrationProbe = nil
-    }
-
-    private func forceSampleRate(
-        _ sampleRate: Double,
-        on output: AudioOutputDevice
-    ) throws -> AudioOutputDevice {
-        guard sampleRate > 0, abs(output.nominalSampleRate - sampleRate) >= 1 else {
-            return output
-        }
-        try CoreAudioDeviceQuery.setNominalSampleRate(sampleRate, objectID: output.id)
-        for _ in 0..<3 {
-            let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
-            if abs(freshOutput.nominalSampleRate - sampleRate) < 1 {
-                return freshOutput
-            }
-            Thread.sleep(forTimeInterval: 0.01)
-        }
-        let freshOutput = try CoreAudioDeviceQuery.outputDevice(id: output.id)
-        throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
-            output.id,
-            "output sample rate \(freshOutput.nominalSampleRate) does not match tap sample rate \(sampleRate)"
+    static func makeSystemTapDescription(
+        excluding processes: [AudioObjectID],
+        outputUID: String,
+        streamIndex: Int
+    ) -> CATapDescription {
+        let description = CATapDescription(
+            excludingProcesses: processes,
+            deviceUID: outputUID,
+            stream: UInt(streamIndex)
         )
+        description.name = "GlassEQ System Output Tap"
+        description.uuid = UUID()
+        description.isPrivate = true
+        description.muteBehavior = .muted
+        description.isMixdown = false
+        description.bundleIDs = [Self.systemSoundServerBundleID]
+        description.isProcessRestoreEnabled = true
+        return description
     }
 
-    private func preparePlaybackOutput(
-        tapSampleRate: Double,
+    static func makeSystemSoundTapDescription(
+        outputUID: String,
+        streamIndex: Int
+    ) -> CATapDescription {
+        let description = CATapDescription(
+            processes: [],
+            deviceUID: outputUID,
+            stream: UInt(streamIndex)
+        )
+        description.name = "GlassEQ System Sounds Tap"
+        description.uuid = UUID()
+        description.isPrivate = true
+        description.muteBehavior = .muted
+        description.isMixdown = false
+        description.bundleIDs = [Self.systemSoundServerBundleID]
+        description.isProcessRestoreEnabled = true
+        return description
+    }
+
+    private func createCombinedAggregateDevice(
+        tapID: AudioObjectID,
+        systemSoundTapID: AudioObjectID,
         output: AudioOutputDevice
-    ) throws -> AudioOutputDevice {
-        if Self.shouldUseSampleRateConversion(tapSampleRate: tapSampleRate, output: output) {
-            return output
+    ) throws -> CombinedAggregateCreation {
+        let tapUID = try CoreAudioDeviceQuery.getStringProperty(
+            objectID: tapID,
+            selector: kAudioTapPropertyUID,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+        let systemSoundTapUID = try CoreAudioDeviceQuery.getStringProperty(
+            objectID: systemSoundTapID,
+            selector: kAudioTapPropertyUID,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+        let tapDescription: (String, Bool) -> [String: Any] = { uid, driftCompensation in
+            var description: [String: Any] = [
+                kAudioSubTapUIDKey: uid,
+                kAudioSubTapDriftCompensationKey: driftCompensation
+            ]
+            if driftCompensation {
+                description[kAudioSubTapDriftCompensationQualityKey] =
+                    kAudioAggregateDriftCompensationHighQuality
+            }
+            return description
         }
-        return try forceSampleRate(tapSampleRate, on: output)
+        let description: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "GlassEQ Private Output Device",
+            kAudioAggregateDeviceUIDKey: "com.glasseq.aggregate.\(UUID().uuidString)",
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceMainSubDeviceKey: output.uid,
+            kAudioAggregateDeviceSubDeviceListKey: [
+                [
+                    kAudioSubDeviceUIDKey: output.uid,
+                    kAudioSubDeviceInputChannelsKey: 0,
+                    kAudioSubDeviceOutputChannelsKey: output.outputChannelCount,
+                    kAudioSubDeviceDriftCompensationKey: false
+                ]
+            ],
+            kAudioAggregateDeviceTapListKey: [
+                tapDescription(tapUID, true),
+                tapDescription(systemSoundTapUID, true)
+            ]
+        ]
+
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        try checkOSStatus(
+            AudioHardwareCreateAggregateDevice(description as CFDictionary, &deviceID),
+            operation: "AudioHardwareCreateAggregateDevice(combined)"
+        )
+        return CombinedAggregateCreation(
+            deviceID: deviceID,
+            mainTapUID: tapUID,
+            systemSoundTapUID: systemSoundTapUID
+        )
     }
 
-    private func recordSampleRateRestorationIfNeeded(
-        for output: AudioOutputDevice,
-        state: inout ControlState
-    ) throws {
-        guard state.sampleRateRestorations[output.uid] == nil else {
-            return
-        }
-        let restoration = SampleRateRestoration(
-            uid: output.uid,
-            originalSampleRate: output.nominalSampleRate
+    private func tapChannelCount(_ tapID: AudioObjectID) throws -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
         )
-        try PersistedAudioDeviceRestorationStore.recordSampleRate(
-            uid: restoration.uid,
-            originalSampleRate: restoration.originalSampleRate,
-            at: restorationStoreURL
+        var format = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(
+                tapID,
+                &address,
+                0,
+                nil,
+                &size,
+                &format
+            ),
+            operation: "AudioObjectGetPropertyData(tap format)"
         )
-        state.sampleRateRestorations[output.uid] = restoration
-    }
-
-    static func setSampleRateAfterRecordingRestoration(
-        _ sampleRate: Double,
-        on output: AudioOutputDevice,
-        needsRestoration: Bool,
-        recordRestoration: (SampleRateRestoration) throws -> Void,
-        installRestoration: (SampleRateRestoration) -> Void,
-        setSampleRate: (Double, AudioObjectID) throws -> Void
-    ) throws {
-        if needsRestoration {
-            let restoration = SampleRateRestoration(
-                uid: output.uid,
-                originalSampleRate: output.nominalSampleRate
+        guard size == UInt32(MemoryLayout<AudioStreamBasicDescription>.size) else {
+            throw AudioEngineInternalError(
+                message: "Core Audio returned an invalid process-tap format."
             )
-            try recordRestoration(restoration)
-            installRestoration(restoration)
         }
-        try setSampleRate(sampleRate, output.id)
+        guard format.mFormatID == kAudioFormatLinearPCM,
+              format.mFormatFlags & kAudioFormatFlagIsFloat != 0,
+              format.mBitsPerChannel == 32 else {
+            throw AudioEngineInternalError(
+                message: "Core Audio returned an unsupported process-tap sample format."
+            )
+        }
+        return Int(format.mChannelsPerFrame)
     }
 
-    private func restoreDeviceSettingsIfNeeded(_ state: inout ControlState) {
-        var restoredSampleRateUIDs: [String] = []
-        for (uid, restoration) in state.sampleRateRestorations {
-            if Self.restoreSampleRateRestoration(restoration) {
-                try? PersistedAudioDeviceRestorationStore.clearSampleRate(uid: uid, at: restorationStoreURL)
-                restoredSampleRateUIDs.append(uid)
+    private func waitUntilAggregateIsAlive(_ deviceID: AudioObjectID) throws {
+        let deadline = Date().addingTimeInterval(3)
+        var lastError: Error?
+        repeat {
+            do {
+                if try CoreAudioDeviceQuery.isDeviceAlive(id: deviceID) {
+                    return
+                }
+            } catch {
+                lastError = error
             }
-        }
-        for uid in restoredSampleRateUIDs {
-            state.sampleRateRestorations.removeValue(forKey: uid)
-        }
+            Thread.sleep(forTimeInterval: 0.1)
+        } while Date() < deadline
 
-        var restoredBufferFrameSizeUIDs: [String] = []
-        for (uid, restoration) in state.bufferFrameSizeRestorations {
-            if Self.restoreBufferFrameSizeRestoration(restoration) {
-                try? PersistedAudioDeviceRestorationStore.clearBufferFrameSize(uid: uid, at: restorationStoreURL)
-                restoredBufferFrameSizeUIDs.append(uid)
-            }
+        if let lastError {
+            throw lastError
         }
-        for uid in restoredBufferFrameSizeUIDs {
-            state.bufferFrameSizeRestorations.removeValue(forKey: uid)
-        }
+        throw CoreAudioError(
+            operation: "combined aggregate did not become alive",
+            status: kAudioHardwareNotRunningError
+        )
     }
 
-    static func restoreSampleRateRestoration(
-        _ restoration: SampleRateRestoration,
-        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
-        setSampleRate: (Double, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:)
-    ) -> Bool {
+    private func tuneAggregateBufferFrameSize(
+        deviceID: AudioObjectID,
+        targetFrameSize: UInt32
+    ) throws -> AudioOutputDevice {
+        var aggregate = try CoreAudioDeviceQuery.outputDevice(id: deviceID)
+        let range = try CoreAudioDeviceQuery.bufferFrameSizeRangeValue(objectID: deviceID)
+        let requested = min(max(targetFrameSize, range.minimum), range.maximum)
+        guard aggregate.bufferFrameSize != requested else {
+            return aggregate
+        }
         do {
-            guard let output = try outputForUID(restoration.uid) else {
-                return false
+            try CoreAudioDeviceQuery.setBufferFrameSize(requested, objectID: deviceID)
+            for attempt in 0..<3 {
+                aggregate = try CoreAudioDeviceQuery.outputDevice(id: deviceID)
+                if aggregate.bufferFrameSize == requested {
+                    return aggregate
+                }
+                if attempt < 2 {
+                    Thread.sleep(forTimeInterval: 0.01)
+                }
             }
-            guard abs(output.nominalSampleRate - restoration.originalSampleRate) >= 1 else {
-                return true
-            }
-            try setSampleRate(restoration.originalSampleRate, output.id)
-            guard let verifiedOutput = try outputForUID(restoration.uid) else {
-                return false
-            }
-            return abs(verifiedOutput.nominalSampleRate - restoration.originalSampleRate) < 1
         } catch {
-            return false
+            return aggregate
+        }
+        return aggregate
+    }
+
+    private func verifyAggregateComposition(
+        _ deviceID: AudioObjectID,
+        output: AudioOutputDevice,
+        expectedTapDriftCompensation: [String: Bool]
+    ) throws -> [String] {
+        let mainUID = try CoreAudioDeviceQuery.getStringProperty(
+            objectID: deviceID,
+            selector: kAudioAggregateDevicePropertyMainSubDevice,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+        guard mainUID == output.uid else {
+            throw AudioEngineInternalError(
+                message: "The aggregate clock source does not match the selected output."
+            )
+        }
+
+        let composition = try dictionaryProperty(
+            objectID: deviceID,
+            selector: kAudioAggregateDevicePropertyComposition
+        )
+        guard let tapEntries = composition[kAudioAggregateDeviceTapListKey]
+            as? [NSDictionary],
+            let tapUIDOrder = Self.validatedAggregateTapUIDOrder(
+                tapEntries,
+                expectedTapDriftCompensation: expectedTapDriftCompensation
+            ) else {
+            throw AudioEngineInternalError(
+                message: "Core Audio returned an invalid process-tap composition."
+            )
+        }
+        return tapUIDOrder
+    }
+
+    static func validatedAggregateTapUIDOrder(
+        _ tapEntries: [NSDictionary],
+        expectedTapDriftCompensation: [String: Bool]
+    ) -> [String]? {
+        guard tapEntries.count == expectedTapDriftCompensation.count else {
+            return nil
+        }
+        var tapUIDOrder: [String] = []
+        tapUIDOrder.reserveCapacity(tapEntries.count)
+        for entry in tapEntries {
+            guard let uid = entry[kAudioSubTapUIDKey] as? String,
+                  let drift = entry[kAudioSubTapDriftCompensationKey] as? NSNumber,
+                  let expectedDrift = expectedTapDriftCompensation[uid],
+                  drift.boolValue == expectedDrift else {
+                return nil
+            }
+            if expectedDrift {
+                guard let quality = entry[kAudioSubTapDriftCompensationQualityKey]
+                    as? NSNumber,
+                      quality.uint32Value == kAudioAggregateDriftCompensationHighQuality else {
+                    return nil
+                }
+            }
+            tapUIDOrder.append(uid)
+        }
+        guard Set(tapUIDOrder) == Set(expectedTapDriftCompensation.keys) else {
+            return nil
+        }
+        return tapUIDOrder
+    }
+
+    private func createCombinedIOProc(
+        deviceID: AudioObjectID,
+        runtime: AudioRuntime
+    ) throws -> AudioDeviceIOProcID? {
+        var ioProcID: AudioDeviceIOProcID?
+        try checkOSStatus(
+            AudioDeviceCreateIOProcIDWithBlock(
+                &ioProcID,
+                deviceID,
+                nil
+            ) { _, inputData, inputTime, outputData, outputTime in
+                runtime.render(
+                    inputData: inputData,
+                    inputTime: inputTime.pointee,
+                    outputData: outputData,
+                    outputTime: outputTime.pointee
+                )
+            },
+            operation: "AudioDeviceCreateIOProcIDWithBlock(combined aggregate)"
+        )
+        return ioProcID
+    }
+
+    private func configureInputStreamUsage(
+        deviceID: AudioObjectID,
+        ioProcID: AudioDeviceIOProcID,
+        tapInputChannelOffset: Int,
+        tapChannelCount: Int
+    ) throws {
+        let streamChannelCounts = try CoreAudioDeviceQuery.streamChannelCounts(
+            objectID: deviceID,
+            scope: kAudioDevicePropertyScopeInput
+        )
+        guard let usage = Self.inputStreamUsage(
+            streamChannelCounts: streamChannelCounts,
+            tapChannelOffset: tapInputChannelOffset,
+            tapChannelCount: tapChannelCount
+        ) else {
+            throw AudioEngineInternalError(
+                message: "The aggregate input streams cannot isolate the process tap from physical input."
+            )
+        }
+        try setIOProcStreamUsage(
+            usage,
+            deviceID: deviceID,
+            ioProcID: ioProcID
+        )
+        let appliedUsage = try ioProcStreamUsage(
+            streamCount: usage.count,
+            deviceID: deviceID,
+            ioProcID: ioProcID
+        )
+        guard appliedUsage == usage else {
+            throw AudioEngineInternalError(
+                message: "Core Audio did not disable the aggregate's physical input streams."
+            )
         }
     }
 
-    static func restoreBufferFrameSizeRestoration(
-        _ restoration: BufferFrameSizeRestoration,
-        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
-        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
-    ) -> Bool {
-        do {
-            guard let output = try outputForUID(restoration.uid) else {
-                return false
-            }
-            guard output.bufferFrameSize != restoration.originalFrameSize else {
-                return true
-            }
-            try setBufferFrameSize(restoration.originalFrameSize, output.id)
-            guard let verifiedOutput = try outputForUID(restoration.uid) else {
-                return false
-            }
-            return verifiedOutput.bufferFrameSize == restoration.originalFrameSize
-        } catch {
-            return false
-        }
+    private func setIOProcStreamUsage(
+        _ usage: [UInt32],
+        deviceID: AudioObjectID,
+        ioProcID: AudioDeviceIOProcID
+    ) throws {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyIOProcStreamUsage,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let storage = ioProcStreamUsageStorage(usage, ioProcID: ioProcID)
+        defer { storage.deallocate() }
+        let size = UInt32(Self.ioProcStreamUsageByteCount(streamCount: usage.count))
+        try checkOSStatus(
+            AudioObjectSetPropertyData(
+                deviceID,
+                &address,
+                0,
+                nil,
+                size,
+                storage
+            ),
+            operation: "AudioObjectSetPropertyData(input IOProc stream usage)"
+        )
     }
 
-    static func restorePersistedDeviceSettings(
-        at url: URL,
-        outputForUID: (String) throws -> AudioOutputDevice? = CoreAudioDeviceQuery.outputDevice(uid:),
-        setSampleRate: (Double, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:),
-        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
-    ) {
-        var records = PersistedAudioDeviceRestorationStore.load(from: url)
-        guard !records.isEmpty else {
-            return
+    private func ioProcStreamUsage(
+        streamCount: Int,
+        deviceID: AudioObjectID,
+        ioProcID: AudioDeviceIOProcID
+    ) throws -> [UInt32] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyIOProcStreamUsage,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let storage = ioProcStreamUsageStorage(
+            Array(repeating: 0, count: streamCount),
+            ioProcID: ioProcID
+        )
+        defer { storage.deallocate() }
+        let expectedSize = Self.ioProcStreamUsageByteCount(streamCount: streamCount)
+        var size = UInt32(expectedSize)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(
+                deviceID,
+                &address,
+                0,
+                nil,
+                &size,
+                storage
+            ),
+            operation: "AudioObjectGetPropertyData(input IOProc stream usage)"
+        )
+        guard size == UInt32(expectedSize) else {
+            throw AudioEngineInternalError(
+                message: "Core Audio returned invalid input stream-usage metadata."
+            )
         }
-
-        for (uid, record) in records {
-            var updated = record
-            if let originalSampleRate = record.originalSampleRate,
-               restoreSampleRateRestoration(
-                   SampleRateRestoration(uid: uid, originalSampleRate: originalSampleRate),
-                   outputForUID: outputForUID,
-                   setSampleRate: setSampleRate
-               ) {
-                updated.originalSampleRate = nil
-            }
-            if let originalBufferFrameSize = record.originalBufferFrameSize,
-               restoreBufferFrameSizeRestoration(
-                   BufferFrameSizeRestoration(uid: uid, originalFrameSize: originalBufferFrameSize),
-                   outputForUID: outputForUID,
-                   setBufferFrameSize: setBufferFrameSize
-               ) {
-                updated.originalBufferFrameSize = nil
-            }
-            records[uid] = updated.isEmpty ? nil : updated
+        let header = storage.assumingMemoryBound(to: AudioHardwareIOProcStreamUsage.self)
+        guard Int(header.pointee.mNumberStreams) == streamCount else {
+            throw AudioEngineInternalError(
+                message: "Core Audio returned the wrong number of input stream-usage entries."
+            )
         }
+        let values = storage
+            .advanced(by: Self.ioProcStreamUsageValuesOffset)
+            .assumingMemoryBound(to: UInt32.self)
+        return (0..<streamCount).map { values[$0] }
+    }
 
-        try? PersistedAudioDeviceRestorationStore.save(records, to: url)
+    private func ioProcStreamUsageStorage(
+        _ usage: [UInt32],
+        ioProcID: AudioDeviceIOProcID
+    ) -> UnsafeMutableRawPointer {
+        let byteCount = Self.ioProcStreamUsageByteCount(streamCount: usage.count)
+        let storage = UnsafeMutableRawPointer.allocate(
+            byteCount: byteCount,
+            alignment: MemoryLayout<AudioHardwareIOProcStreamUsage>.alignment
+        )
+        storage.initializeMemory(
+            as: UInt8.self,
+            repeating: 0,
+            count: byteCount
+        )
+        let header = storage.assumingMemoryBound(to: AudioHardwareIOProcStreamUsage.self)
+        header.pointee.mIOProc = unsafeBitCast(ioProcID, to: UnsafeMutableRawPointer.self)
+        header.pointee.mNumberStreams = UInt32(usage.count)
+        let values = storage
+            .advanced(by: Self.ioProcStreamUsageValuesOffset)
+            .assumingMemoryBound(to: UInt32.self)
+        for (index, enabled) in usage.enumerated() {
+            values[index] = enabled
+        }
+        return storage
+    }
+
+    private static let ioProcStreamUsageValuesOffset =
+        MemoryLayout<AudioHardwareIOProcStreamUsage>.offset(of: \.mStreamIsOn)!
+
+    private static func ioProcStreamUsageByteCount(streamCount: Int) -> Int {
+        ioProcStreamUsageValuesOffset + streamCount * MemoryLayout<UInt32>.stride
+    }
+
+    private func dictionaryProperty(
+        objectID: AudioObjectID,
+        selector: AudioObjectPropertySelector
+    ) throws -> NSDictionary {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let pointer = UnsafeMutablePointer<CFDictionary?>.allocate(capacity: 1)
+        pointer.initialize(to: nil)
+        defer {
+            pointer.deinitialize(count: 1)
+            pointer.deallocate()
+        }
+        var size = UInt32(MemoryLayout<CFDictionary?>.size)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(
+                objectID,
+                &address,
+                0,
+                nil,
+                &size,
+                UnsafeMutableRawPointer(pointer)
+            ),
+            operation: "AudioObjectGetPropertyData(aggregate composition)"
+        )
+        guard let value = pointer.pointee else {
+            throw CoreAudioError(
+                operation: "AudioObjectGetPropertyData(aggregate composition) returned nil",
+                status: kAudioHardwareBadObjectError
+            )
+        }
+        return value as NSDictionary
+    }
+
+    private func currentAudioProcessObjectID() throws -> AudioObjectID {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var pid = getpid()
+        var processID = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                UInt32(MemoryLayout<pid_t>.size),
+                &pid,
+                &size,
+                &processID
+            ),
+            operation: "AudioObjectGetPropertyData(translate pid)"
+        )
+        guard processID != kAudioObjectUnknown else {
+            throw AudioEngineInternalError(
+                message: "Core Audio did not publish the GlassEQ process object."
+            )
+        }
+        return processID
     }
 
     private static func dspProfile(from profile: EQProfile) -> EQProfile {
         var profile = profile
         profile.isBypassed = false
         return profile
+    }
+
+    static func systemSoundPreampGains(
+        for configuration: EQRenderConfiguration
+    ) -> (left: Float, right: Float) {
+        let channels = configuration.configuration.channelConfigurations
+        let left = channels.first?.preampLinearGain
+            ?? configuration.configuration.preampLinearGain
+        let right = channels.count > 1
+            ? channels[1].preampLinearGain
+            : left
+        return (left, right)
     }
 
     private func audioEngineFailure(from error: Error) -> AudioEngineFailure {
@@ -2249,8 +2734,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         if let availabilityError = error as? AudioDeviceAvailabilityError {
             switch availabilityError {
             case .unsupportedOutputChannelCount,
-                 .unsupportedOutputBufferFrameSize,
-                 .unsupportedPlaybackConversionBuffer:
+                 .unsupportedOutputBufferFrameSize:
                 return AudioEngineFailure(
                     category: .deviceFormatUnsupported,
                     userMessage: availabilityError.description,
@@ -2271,19 +2755,50 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         )
     }
 
-    static func supportedRuntimeChannelCount(for output: AudioOutputDevice) throws -> Int {
+    static func canHotSwapDSP(
+        from activeProfile: EQProfile,
+        to nextProfile: EQProfile,
+        sampleRate: Double,
+        channelCount: Int,
+        maximumUsableFrequency: Double? = nil
+    ) -> Bool {
+        guard activeProfile.mode == nextProfile.mode,
+              activeProfile.channelMode == nextProfile.channelMode else {
+            return false
+        }
+        return EQRenderConfiguration(
+            profile: dspProfile(from: nextProfile),
+            sampleRate: sampleRate,
+            channelCount: channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ).hasRealtimeCompatibleTopology(
+            with: EQRenderConfiguration(
+                profile: dspProfile(from: activeProfile),
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            )
+        )
+    }
+
+    static func supportedRuntimeChannelCount(
+        for output: AudioOutputDevice
+    ) throws -> Int {
         guard output.outputChannelCount > 0 else {
             throw AudioDeviceAvailabilityError.outputDeviceHasNoOutputChannels(output.id)
         }
-        // getChannelCount sums per-buffer mNumberChannels without bounding them, so a broken
-        // device can still report absurd counts; the playback mapper handles anything below this.
         guard output.outputChannelCount <= CoreAudioDeviceQuery.maxChannelCount else {
-            throw AudioDeviceAvailabilityError.unsupportedOutputChannelCount(output.id, output.outputChannelCount)
+            throw AudioDeviceAvailabilityError.unsupportedOutputChannelCount(
+                output.id,
+                output.outputChannelCount
+            )
         }
         return output.outputChannelCount
     }
 
-    static func validatePlaybackCallbackCapacity(for output: AudioOutputDevice) throws {
+    static func validatePlaybackCallbackCapacity(
+        for output: AudioOutputDevice
+    ) throws {
         guard output.bufferFrameSize <= UInt32(maximumSupportedCallbackFrames) else {
             throw AudioDeviceAvailabilityError.unsupportedOutputBufferFrameSize(
                 output.id,
@@ -2293,33 +2808,6 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         }
     }
 
-    static func validatePlaybackConversionCapacity(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double,
-        captureCallbackFrames: Int = preferredLowSampleRatePlaybackReservoirFrames
-    ) throws {
-        guard shouldUseSampleRateConversion(tapSampleRate: tapSampleRate, output: output) else {
-            return
-        }
-        let requiredPrimeFrames = preferredPlaybackPrimeFrames(
-            for: output,
-            tapSampleRate: tapSampleRate,
-            captureCallbackFrames: captureCallbackFrames
-        )
-        let maximumPrimeFrames = runtimeRingCapacityFrames / playbackRingPullCount
-        guard requiredPrimeFrames <= maximumPrimeFrames else {
-            throw AudioDeviceAvailabilityError.unsupportedPlaybackConversionBuffer(
-                output.id,
-                requiredPrimeFrames: requiredPrimeFrames,
-                maximumPrimeFrames: maximumPrimeFrames
-            )
-        }
-    }
-
-    /// Normalizes a device-reported preferred stereo pair (1-based channel numbers; the HAL
-    /// reports zeros when the pair was never configured) into 0-based destination channel
-    /// indices. Falls back to the first two channels whenever the report is missing or
-    /// inconsistent; mono devices collapse to (0, 0).
     static func playbackStereoPair(
         preferredChannels: (left: UInt32, right: UInt32)?,
         outputChannelCount: Int
@@ -2335,7 +2823,34 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
               preferredChannels.right <= UInt32(outputChannelCount) else {
             return (0, 1)
         }
-        return (Int(preferredChannels.left) - 1, Int(preferredChannels.right) - 1)
+        return (
+            Int(preferredChannels.left) - 1,
+            Int(preferredChannels.right) - 1
+        )
+    }
+
+    static func tapOutputStreamIndex(
+        streamChannelCounts: [Int],
+        playbackChannels: (left: Int, right: Int)
+    ) -> Int? {
+        guard !streamChannelCounts.isEmpty,
+              streamChannelCounts.allSatisfy({ $0 > 0 }),
+              playbackChannels.left >= 0,
+              playbackChannels.right >= 0 else {
+            return nil
+        }
+        var channelOffset = 0
+        for (streamIndex, channelCount) in streamChannelCounts.enumerated() {
+            let upperBound = channelOffset + channelCount
+            if playbackChannels.left >= channelOffset,
+               playbackChannels.left < upperBound,
+               playbackChannels.right >= channelOffset,
+               playbackChannels.right < upperBound {
+                return channelCount <= 2 ? streamIndex : nil
+            }
+            channelOffset = upperBound
+        }
+        return nil
     }
 
     static func encodedPlaybackChannelPair(left: Int, right: Int) -> UInt64 {
@@ -2345,16 +2860,243 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         return (clampedLeft << 32) | clampedRight
     }
 
-    static func decodedPlaybackChannelPair(_ encoded: UInt64) -> (left: Int, right: Int) {
+    static func decodedPlaybackChannelPair(
+        _ encoded: UInt64
+    ) -> (left: Int, right: Int) {
         (Int(encoded >> 32), Int(encoded & 0xFFFF_FFFF))
     }
 
-    static func performAfterRuntimeChannelValidation<T>(
-        for output: AudioOutputDevice,
-        _ operation: () throws -> T
-    ) throws -> T {
-        _ = try supportedRuntimeChannelCount(for: output)
-        return try operation()
+    static func tapToOutputLatencyNanoseconds(
+        inputTime: AudioTimeStamp,
+        outputTime: AudioTimeStamp
+    ) -> UInt64? {
+        guard inputTime.mFlags.contains(.hostTimeValid),
+              outputTime.mFlags.contains(.hostTimeValid),
+              outputTime.mHostTime >= inputTime.mHostTime else {
+            return nil
+        }
+        return AudioConvertHostTimeToNanos(outputTime.mHostTime - inputTime.mHostTime)
+    }
+
+    static func callbackTimingNanoseconds(
+        inputTime: AudioTimeStamp,
+        callbackHostTime: UInt64,
+        outputTime: AudioTimeStamp
+    ) -> (inputAge: UInt64, outputLead: UInt64)? {
+        guard inputTime.mFlags.contains(.hostTimeValid),
+              outputTime.mFlags.contains(.hostTimeValid),
+              callbackHostTime >= inputTime.mHostTime,
+              outputTime.mHostTime >= callbackHostTime else {
+            return nil
+        }
+        return (
+            inputAge: AudioConvertHostTimeToNanos(callbackHostTime - inputTime.mHostTime),
+            outputLead: AudioConvertHostTimeToNanos(outputTime.mHostTime - callbackHostTime)
+        )
+    }
+
+    static func tapInputChannelOffset(
+        physicalInputChannelCount: Int,
+        aggregateInputChannelCount: Int,
+        tapChannelCount: Int
+    ) -> Int? {
+        guard physicalInputChannelCount >= 0,
+              tapChannelCount > 0,
+              aggregateInputChannelCount == physicalInputChannelCount + tapChannelCount else {
+            return nil
+        }
+        return physicalInputChannelCount
+    }
+
+    static func tapInputChannelOffsets(
+        physicalInputChannelCount: Int,
+        aggregateInputChannelCount: Int,
+        mainTapChannelCount: Int,
+        systemSoundTapChannelCount: Int,
+        mainTapIndex: Int = 0,
+        systemSoundTapIndex: Int = 1
+    ) -> (main: Int, systemSounds: Int)? {
+        guard physicalInputChannelCount >= 0,
+              mainTapChannelCount > 0,
+              systemSoundTapChannelCount == mainTapChannelCount,
+              Set([mainTapIndex, systemSoundTapIndex]) == Set([0, 1]),
+              aggregateInputChannelCount == physicalInputChannelCount
+                + mainTapChannelCount
+                + systemSoundTapChannelCount else {
+            return nil
+        }
+        return (
+            main: physicalInputChannelCount
+                + (mainTapIndex == 0 ? 0 : systemSoundTapChannelCount),
+            systemSounds: physicalInputChannelCount
+                + (systemSoundTapIndex == 0 ? 0 : mainTapChannelCount)
+        )
+    }
+
+    static func inputStreamUsage(
+        streamChannelCounts: [Int],
+        tapChannelOffset: Int,
+        tapChannelCount: Int
+    ) -> [UInt32]? {
+        guard tapChannelOffset >= 0,
+              tapChannelCount > 0 else {
+            return nil
+        }
+        let tapRange = tapChannelOffset..<(tapChannelOffset + tapChannelCount)
+        var channelOffset = 0
+        var enabledChannelCount = 0
+        var usage: [UInt32] = []
+        usage.reserveCapacity(streamChannelCounts.count)
+
+        for channelCount in streamChannelCounts {
+            guard channelCount > 0 else {
+                return nil
+            }
+            let streamRange = channelOffset..<(channelOffset + channelCount)
+            if streamRange.clamped(to: tapRange).isEmpty {
+                usage.append(0)
+            } else if tapRange.contains(streamRange.lowerBound),
+                      tapRange.contains(streamRange.upperBound - 1) {
+                usage.append(1)
+                enabledChannelCount += channelCount
+            } else {
+                return nil
+            }
+            channelOffset = streamRange.upperBound
+        }
+
+        guard enabledChannelCount == tapChannelCount,
+              channelOffset == tapRange.upperBound else {
+            return nil
+        }
+        return usage
+    }
+
+    static func copyInputSamples(
+        from buffers: UnsafeMutableAudioBufferListPointer,
+        into samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int,
+        sourceChannelOffset: Int
+    ) {
+        guard frameCount > 0,
+              channelCount > 0,
+              sourceChannelOffset >= 0,
+              frameCount * channelCount <= samples.count else {
+            return
+        }
+        if sourceChannelOffset == 0,
+           buffers.count == 1,
+           let data = buffers[0].mData?.assumingMemoryBound(to: Float.self),
+           Int(buffers[0].mNumberChannels) == channelCount {
+            let sampleCount = frameCount * channelCount
+            if sampleCount <= Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride,
+               let destination = samples.baseAddress {
+                destination.update(from: data, count: sampleCount)
+                return
+            }
+        }
+
+        for frame in 0..<frameCount {
+            let sampleBase = frame * channelCount
+            for channel in 0..<channelCount {
+                samples[sampleBase + channel] = inputSample(
+                    from: buffers,
+                    frame: frame,
+                    channel: sourceChannelOffset + channel
+                )
+            }
+        }
+    }
+
+    @discardableResult
+    static func mixInputSamples(
+        from buffers: UnsafeMutableAudioBufferListPointer,
+        into samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int,
+        sourceChannelOffset: Int,
+        preampGains: (left: Float, right: Float)
+    ) -> UInt64 {
+        guard frameCount > 0,
+              channelCount > 0,
+              sourceChannelOffset >= 0,
+              frameCount * channelCount <= samples.count else {
+            return 0
+        }
+
+        var saturatedSamples: UInt64 = 0
+        for frame in 0..<frameCount {
+            let sampleBase = frame * channelCount
+            for channel in 0..<channelCount {
+                let gain = channel == 1 ? preampGains.right : preampGains.left
+                let additionalSample = inputSample(
+                    from: buffers,
+                    frame: frame,
+                    channel: sourceChannelOffset + channel
+                ) * gain
+                guard additionalSample != 0 else {
+                    continue
+                }
+                let mixed = samples[sampleBase + channel] + additionalSample
+                let output = saturateOutputSample(mixed)
+                samples[sampleBase + channel] = output.sample
+                if output.saturated {
+                    saturatedSamples += 1
+                }
+            }
+        }
+        return saturatedSamples
+    }
+
+    private static func saturateOutputSample(
+        _ value: Float
+    ) -> (sample: Float, saturated: Bool) {
+        guard value.isFinite else {
+            return (0, true)
+        }
+        let threshold: Float = 0.98
+        if value > threshold {
+            return (
+                threshold + (1 - threshold) * tanh((value - threshold) / (1 - threshold)),
+                true
+            )
+        }
+        if value < -threshold {
+            return (
+                -threshold + (1 - threshold) * tanh((value + threshold) / (1 - threshold)),
+                true
+            )
+        }
+        return (value, false)
+    }
+
+    private static func inputSample(
+        from buffers: UnsafeMutableAudioBufferListPointer,
+        frame: Int,
+        channel: Int
+    ) -> Float {
+        var remainingChannel = channel
+        for buffer in buffers {
+            let channels = Int(buffer.mNumberChannels)
+            guard channels > 0 else {
+                continue
+            }
+            guard remainingChannel < channels else {
+                remainingChannel -= channels
+                continue
+            }
+            guard let data = buffer.mData?.assumingMemoryBound(to: Float.self) else {
+                return 0
+            }
+            let index = frame * channels + remainingChannel
+            guard index >= 0,
+                  index < Int(buffer.mDataByteSize) / MemoryLayout<Float>.stride else {
+                return 0
+            }
+            return data[index]
+        }
+        return 0
     }
 
     static func monoDownmix(
@@ -2366,13 +3108,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             return 0
         }
         let sourceChannelCount = max(sourceChannelCount, 1)
-        let sampleBaseResult = frame.multipliedReportingOverflow(by: sourceChannelCount)
+        let sampleBaseResult = frame.multipliedReportingOverflow(
+            by: sourceChannelCount
+        )
         guard !sampleBaseResult.overflow else {
             return 0
         }
         let sampleBase = sampleBaseResult.partialValue
-        guard sampleBase >= 0,
-              sampleBase < samples.count else {
+        guard sampleBase >= 0, sampleBase < samples.count else {
             return 0
         }
         guard sourceChannelCount > 1,
@@ -2400,8 +3143,10 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
            frameCount > 0,
            sourceFrameOffset >= 0,
            destinationFrameOffset >= 0 {
-            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
-            for frameIndex in 0..<frameCount where destinationFrameOffset + frameIndex < destinationSamples {
+            let destinationSamples = Int(buffers[0].mDataByteSize)
+                / MemoryLayout<Float>.stride
+            for frameIndex in 0..<frameCount
+            where destinationFrameOffset + frameIndex < destinationSamples {
                 data[destinationFrameOffset + frameIndex] = monoDownmix(
                     samples,
                     frame: sourceFrameOffset + frameIndex,
@@ -2422,22 +3167,22 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             let copySamples = frameCount * sourceChannelCount
             let sourceSampleStart = sourceFrameOffset * sourceChannelCount
             let destinationSampleStart = destinationFrameOffset * sourceChannelCount
-            let destinationSamples = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.stride
+            let destinationSamples = Int(buffers[0].mDataByteSize)
+                / MemoryLayout<Float>.stride
             if sourceSampleStart + copySamples <= samples.count,
                destinationSampleStart + copySamples <= destinationSamples,
                let source = samples.baseAddress {
-                data.advanced(by: destinationSampleStart)
-                    .update(from: source.advanced(by: sourceSampleStart), count: copySamples)
+                data.advanced(by: destinationSampleStart).update(
+                    from: source.advanced(by: sourceSampleStart),
+                    count: copySamples
+                )
                 return
             }
         }
 
-        // General mapped case: the destination pair channels receive source L/R (mono sources
-        // feed both); every other channel gets explicit zeros. Never trust HAL pre-zeroing —
-        // stray signal would leak into a multi-channel interface's DAW/loopback channels.
-        // Walks the AudioBufferList with a running global channel offset so interleaved,
-        // multi-stream, and per-channel-buffer layouts all map correctly.
-        guard frameCount > 0, sourceFrameOffset >= 0, destinationFrameOffset >= 0 else {
+        guard frameCount > 0,
+              sourceFrameOffset >= 0,
+              destinationFrameOffset >= 0 else {
             return
         }
         let sourceRightChannel = min(1, sourceChannelCount - 1)
@@ -2445,15 +3190,23 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         for bufferIndex in buffers.indices {
             let bufferChannels = Int(buffers[bufferIndex].mNumberChannels)
             guard bufferChannels > 0,
-                  let data = buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self) else {
+                  let data = buffers[bufferIndex].mData?
+                    .assumingMemoryBound(to: Float.self) else {
                 globalChannelOffset += max(bufferChannels, 0)
                 continue
             }
-            let destinationSampleCount = Int(buffers[bufferIndex].mDataByteSize) / MemoryLayout<Float>.stride
+            let destinationSampleCount = Int(buffers[bufferIndex].mDataByteSize)
+                / MemoryLayout<Float>.stride
             let zeroStart = destinationFrameOffset * bufferChannels
-            let zeroEnd = min((destinationFrameOffset + frameCount) * bufferChannels, destinationSampleCount)
+            let zeroEnd = min(
+                (destinationFrameOffset + frameCount) * bufferChannels,
+                destinationSampleCount
+            )
             if zeroStart < zeroEnd {
-                data.advanced(by: zeroStart).update(repeating: 0, count: zeroEnd - zeroStart)
+                data.advanced(by: zeroStart).update(
+                    repeating: 0,
+                    count: zeroEnd - zeroStart
+                )
             }
             scatterMappedChannel(
                 samples,
@@ -2499,11 +3252,13 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             return
         }
         for frameIndex in 0..<frameCount {
-            let sourceIndex = (sourceFrameOffset + frameIndex) * sourceChannelCount + sourceChannel
+            let sourceIndex = (sourceFrameOffset + frameIndex)
+                * sourceChannelCount + sourceChannel
             guard sourceIndex < samples.count else {
                 continue
             }
-            let destinationIndex = (destinationFrameOffset + frameIndex) * bufferChannels + localChannel
+            let destinationIndex = (destinationFrameOffset + frameIndex)
+                * bufferChannels + localChannel
             guard destinationIndex < destinationSampleCount else {
                 continue
             }
@@ -2511,918 +3266,282 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         }
     }
 
-    static func performTopologyRebuild<T>(
-        acquireMuteGuard: () throws -> any TopologyRebuildMuteGuarding,
-        rebuild: () throws -> T
-    ) throws -> T {
-        let muteGuard: any TopologyRebuildMuteGuarding
-        do {
-            muteGuard = try acquireMuteGuard()
-        } catch {
-            throw TopologyRebuildMuteGuardUnavailable(underlyingError: error)
-        }
-        defer {
-            muteGuard.release()
-        }
-        return try rebuild()
+    static func preferredBufferFrameSize(for _: AudioOutputDevice) -> UInt32 {
+        preferredAggregateBufferFrameSize
     }
 
-    private func tuneBufferFrameSize(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double,
-        allowsDownwardProbe: Bool
-    ) -> AudioOutputDevice {
-        do {
-            let range = try CoreAudioDeviceQuery.bufferFrameSizeRangeValue(objectID: output.id)
-            let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
-                outputUID: output.uid,
-                sampleRate: output.nominalSampleRate,
-                tapSampleRate: tapSampleRate,
-                from: playbackBufferCalibrationStoreURL
-            )
-            let requested = AdaptivePlaybackBufferPolicy.startupFrameSize(
-                preferredFrameSize: Self.preferredBufferFrameSize(for: output),
-                calibration: calibration,
-                supportedRange: range,
-                allowsDownwardProbe: allowsDownwardProbe
-            )
-            guard requested != output.bufferFrameSize else {
-                return output
-            }
-            try CoreAudioDeviceQuery.setBufferFrameSize(requested, objectID: output.id)
-            return try CoreAudioDeviceQuery.outputDevice(id: output.id)
-        } catch {
-            return output
-        }
-    }
-
-    private func playbackBufferCalibrationProbe(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double,
-        targetFrames: Int,
-        startedAt: ContinuousClock.Instant = ContinuousClock().now
-    ) -> PlaybackBufferCalibrationProbe? {
-        guard Self.shouldAdaptPlaybackBuffer(for: output) else {
-            return nil
-        }
-        let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
-            outputUID: output.uid,
-            sampleRate: output.nominalSampleRate,
-            tapSampleRate: tapSampleRate,
-            from: playbackBufferCalibrationStoreURL
-        )
-        guard PlaybackBufferCalibrationPolicy.shouldProbe(
-            frameSize: output.bufferFrameSize,
-            targetFrames: targetFrames,
-            calibration: calibration
-        ) else {
-            return nil
-        }
-        return PlaybackBufferCalibrationProbe(
-            outputUID: output.uid,
-            sampleRate: output.nominalSampleRate,
-            tapSampleRate: tapSampleRate,
-            frameSize: output.bufferFrameSize,
-            targetFrames: targetFrames,
-            startedAt: startedAt
-        )
-    }
-
-    private func preferredPlaybackTargetFrames(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double,
-        captureCallbackFrames: Int,
-        allowsDownwardProbe: Bool
-    ) -> Int {
-        let baseline = Self.preferredPlaybackPrimeFrames(
-            for: output,
-            tapSampleRate: tapSampleRate,
-            captureCallbackFrames: captureCallbackFrames
-        )
-        guard Self.shouldAdaptPlaybackBuffer(for: output) else {
-            return baseline
-        }
-        let calibration = PersistedPlaybackBufferCalibrationStore.calibration(
-            outputUID: output.uid,
-            sampleRate: output.nominalSampleRate,
-            tapSampleRate: tapSampleRate,
-            from: playbackBufferCalibrationStoreURL
-        )
-        let targetFrames = AdaptivePlaybackBufferPolicy.startupTargetFrames(
-            callbackFrames: Self.playbackInputCallbackFrames(
-                for: output,
-                tapSampleRate: tapSampleRate
-            ),
-            baselineTargetFrames: baseline,
-            operatingPoint: calibration?.operatingPoint(for: output.bufferFrameSize),
-            allowsDownwardProbe: allowsDownwardProbe
-        )
-        return min(targetFrames, Self.runtimeRingCapacityFrames / 2)
-    }
-
-    private func updatePlaybackBufferAdaptationTimer() {
-        let shouldRun = control.withLock { state in
-            guard case .running = state.state,
-                  let output = state.activeOutput else {
-                return false
-            }
-            return Self.shouldAdaptPlaybackBuffer(for: output)
-        }
-        setPlaybackBufferAdaptationTimerRunning(shouldRun)
-    }
-
-    private func pausePlaybackBufferAdaptation() {
-        setPlaybackBufferAdaptationTimerRunning(false)
-        if DispatchQueue.getSpecific(key: playbackBufferAdaptationQueueKey) == nil {
-            playbackBufferAdaptationQueue.sync {}
-        }
-    }
-
-    private func setPlaybackBufferAdaptationTimerRunning(_ shouldRun: Bool) {
-        playbackBufferAdaptationTimerRunning.withLock { isRunning in
-            guard isRunning != shouldRun else {
-                return
-            }
-            isRunning = shouldRun
-            if shouldRun {
-                playbackBufferAdaptationTimer.resume()
-            } else {
-                playbackBufferAdaptationTimer.suspend()
-            }
-        }
-    }
-
-    private func serviceAdaptivePlaybackBuffering() {
-        let now = ContinuousClock().now
-        guard let action = control.withLock({ state -> PlaybackBufferAdaptationAction? in
-            guard let runtime = state.runtime,
-                  let output = state.activeOutput,
-                  Self.shouldAdaptPlaybackBuffer(for: output) else {
-                return nil
-            }
-
-            if let recoveryGeneration = state.adaptivePlaybackRenderRecoveryHealthGeneration,
-               runtime.playbackRenderHealthGeneration() != recoveryGeneration {
-                state.adaptivePlaybackRenderRecoveryAttempts = 0
-                state.adaptivePlaybackRenderRecoveryHealthGeneration = nil
-            }
-
-            let instability = runtime.playbackInstabilitySnapshot()
-            if instability.generation == state.handledPlaybackInstabilityGeneration {
-                guard let probe = state.playbackBufferCalibrationProbe,
-                      probe.hasCompletedProbation(at: now) else {
-                    return nil
-                }
-                return .stabilize(probe)
-            }
-            state.handledPlaybackInstabilityGeneration = instability.generation
-            return .renegotiate(PlaybackBufferRenegotiationPreparation(
-                outputRebuildGeneration: state.outputRebuildGeneration,
-                reason: instability.reason,
-                output: output,
-                runtime: runtime
-            ))
-        }) else {
-            return
-        }
-
-        let preparation: PlaybackBufferRenegotiationPreparation
-        switch action {
-        case .stabilize(let probe):
-            do {
-                try PersistedPlaybackBufferCalibrationStore.recordStable(
-                    outputUID: probe.outputUID,
-                    sampleRate: probe.sampleRate,
-                    tapSampleRate: probe.tapSampleRate,
-                    frameSize: probe.frameSize,
-                    targetFrames: probe.targetFrames,
-                    at: playbackBufferCalibrationStoreURL
-                )
-            } catch {
-                return
-            }
-            control.withLock { state in
-                if state.playbackBufferCalibrationProbe == probe {
-                    state.playbackBufferCalibrationProbe = nil
-                    state.playbackBufferInstabilityPersistenceGate.reset(outputUID: probe.outputUID)
-                }
-            }
-            return
-        case .renegotiate(let pendingRenegotiation):
-            preparation = pendingRenegotiation
-        }
-
-        if preparation.reason == .adaptiveRenderFailure {
-            recoverAdaptivePlaybackRenderFailure(preparation)
-            return
-        }
-
-        if increasePlaybackTargetIfPossible(preparation) {
-            return
-        }
-        guard AdaptivePlaybackBufferPolicy.shouldIncreaseCallback(for: preparation.reason) else {
-            continueCalibrationAfterUnresolvedInstability(preparation)
-            return
-        }
-
-        let range: AudioBufferFrameSizeRange
-        do {
-            range = try CoreAudioDeviceQuery.bufferFrameSizeRangeValue(objectID: preparation.output.id)
-        } catch {
-            continueCalibrationAfterUnresolvedInstability(preparation)
-            return
-        }
-        guard let nextFrameSize = AdaptivePlaybackBufferPolicy.nextFrameSize(
-            after: preparation.output.bufferFrameSize,
-            supportedRange: range
-        ) else {
-            continueCalibrationAfterUnresolvedInstability(preparation)
-            return
-        }
-        var proposedOutput = preparation.output
-        proposedOutput.bufferFrameSize = nextFrameSize
-        do {
-            try Self.validatePlaybackConversionCapacity(
-                for: proposedOutput,
-                tapSampleRate: preparation.runtime.sampleRate,
-                captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames()
-            )
-        } catch {
-            continueCalibrationAfterUnresolvedInstability(preparation)
-            return
-        }
-
-        let didBeginRenegotiation = control.withLock { state in
-            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
-                  state.runtime === preparation.runtime,
-                  state.activeOutput == preparation.output else {
-                return false
-            }
-            preparation.runtime.muteOutputForTransition()
-            return true
-        }
-        guard didBeginRenegotiation else {
-            return
-        }
-
-        let updatedOutput: AudioOutputDevice
-        do {
-            guard let result = try Self.renegotiatedPlaybackOutput(
-                preparation.output,
-                supportedRange: range
-            ) else {
-                recoverFailedPlaybackBufferRenegotiation(preparation)
-                continueCalibrationAfterUnresolvedInstability(preparation)
-                return
-            }
-            updatedOutput = result
-        } catch {
-            recoverFailedPlaybackBufferRenegotiation(preparation)
-            continueCalibrationAfterUnresolvedInstability(preparation)
-            return
-        }
-
-        let completedRenegotiation = control.withLock { state -> PlaybackBufferRenegotiation? in
-            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
-                  state.runtime === preparation.runtime,
-                  state.activeOutput == preparation.output else {
-                return nil
-            }
-
-            let previousTargetFrames = preparation.runtime.playbackTargetFrames()
-            let targetFrames = preferredPlaybackTargetFrames(
-                for: updatedOutput,
-                tapSampleRate: preparation.runtime.sampleRate,
-                captureCallbackFrames: preparation.runtime.maximumKnownCaptureCallbackFrames(),
-                allowsDownwardProbe: false
-            )
-            preparation.runtime.retargetPlayback(
-                primeFrames: targetFrames
-            )
-            preparation.runtime.recordPlaybackBufferRenegotiation()
-            preparation.runtime.reprimePlayback()
-
-            state.activeOutput = updatedOutput
-            state.state = .running(output: updatedOutput)
-            state.status = .running(output: updatedOutput)
-            state.handledPlaybackInstabilityGeneration = preparation.runtime.playbackInstabilitySnapshot().generation
-            state.attemptedPlaybackTargetDownProbes.insert(
-                PlaybackBufferOperatingPointKey(
-                    output: updatedOutput,
-                    tapSampleRate: preparation.runtime.sampleRate
-                )
-            )
-            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
-                outputUID: updatedOutput.uid,
-                sampleRate: updatedOutput.nominalSampleRate,
-                tapSampleRate: preparation.runtime.sampleRate,
-                frameSize: updatedOutput.bufferFrameSize,
-                targetFrames: targetFrames,
-                startedAt: ContinuousClock().now
-            )
-            return PlaybackBufferRenegotiation(
-                outputName: updatedOutput.name,
-                outputUID: updatedOutput.uid,
-                sampleRate: updatedOutput.nominalSampleRate,
-                previousFrameSize: preparation.output.bufferFrameSize,
-                frameSize: updatedOutput.bufferFrameSize,
-                previousPlaybackTargetFrames: previousTargetFrames,
-                playbackTargetFrames: targetFrames,
-                reason: preparation.reason
-            )
-        }
-        guard let completedRenegotiation else {
-            return
-        }
-        try? PersistedPlaybackBufferCalibrationStore.recordInstability(
-            outputUID: completedRenegotiation.outputUID,
-            sampleRate: completedRenegotiation.sampleRate,
-            tapSampleRate: preparation.runtime.sampleRate,
-            previousFrameSize: completedRenegotiation.previousFrameSize,
-            resultingFrameSize: completedRenegotiation.frameSize,
-            previousTargetFrames: completedRenegotiation.previousPlaybackTargetFrames,
-            resultingTargetFrames: completedRenegotiation.playbackTargetFrames,
-            reason: completedRenegotiation.reason,
-            at: playbackBufferCalibrationStoreURL
-        )
-        let handler = playbackBufferRenegotiationHandler.withLock { $0 }
-        handler?(completedRenegotiation)
-    }
-
-    private func increasePlaybackTargetIfPossible(
-        _ preparation: PlaybackBufferRenegotiationPreparation
+    static func timestampSlopeAgrees(
+        frameCount: Int,
+        sampleRate: Double,
+        sampleTimeDeltaFrames: Double,
+        hostIntervalErrorNanoseconds: Int64,
+        rateScalar: Double,
+        rateScalarIsValid: Bool
     ) -> Bool {
-        let adjustment = control.withLock { state -> PlaybackBufferTargetAdjustment? in
-            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
-                  state.runtime === preparation.runtime,
-                  state.activeOutput == preparation.output else {
-                return nil
-            }
-            let previousTargetFrames = preparation.runtime.playbackTargetFrames()
-            guard let targetFrames = AdaptivePlaybackBufferPolicy.nextTargetFrames(
-                for: preparation.reason,
-                callbackFrames: Self.playbackInputCallbackFrames(
-                    for: preparation.output,
-                    tapSampleRate: preparation.runtime.sampleRate
-                ),
-                after: previousTargetFrames,
-                maximumReservoirFrames: Self.maximumPlaybackReservoirFrames(
-                    for: preparation.output,
-                    tapSampleRate: preparation.runtime.sampleRate,
-                    maximumKnownCaptureCallbackFrames: preparation.runtime
-                        .maximumKnownCaptureCallbackFrames()
-                )
-            ) else {
-                return nil
-            }
-
-            preparation.runtime.retargetPlayback(
-                primeFrames: targetFrames
-            )
-            preparation.runtime.recordPlaybackBufferRenegotiation()
-            preparation.runtime.reprimePlayback()
-            state.handledPlaybackInstabilityGeneration = preparation.runtime.playbackInstabilitySnapshot().generation
-            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
-                outputUID: preparation.output.uid,
-                sampleRate: preparation.output.nominalSampleRate,
-                tapSampleRate: preparation.runtime.sampleRate,
-                frameSize: preparation.output.bufferFrameSize,
-                targetFrames: targetFrames,
-                startedAt: ContinuousClock().now
-            )
-            return PlaybackBufferTargetAdjustment(
-                output: preparation.output,
-                tapSampleRate: preparation.runtime.sampleRate,
-                previousTargetFrames: previousTargetFrames,
-                targetFrames: targetFrames,
-                reason: preparation.reason
-            )
-        }
-        guard let adjustment else {
+        guard frameCount > 0,
+              sampleRate.isFinite,
+              sampleRate > 0,
+              abs(sampleTimeDeltaFrames) < 0.5 else {
             return false
         }
+        if rateScalarIsValid,
+           (!rateScalar.isFinite || abs(rateScalar - 1) > 0.01) {
+            return false
+        }
+        let callbackPeriodNanoseconds = Double(frameCount) * 1_000_000_000 / sampleRate
+        let toleranceNanoseconds = max(callbackPeriodNanoseconds * 0.25, 50_000)
+        return abs(Double(hostIntervalErrorNanoseconds)) <= toleranceNanoseconds
+    }
 
-        try? PersistedPlaybackBufferCalibrationStore.recordInstability(
-            outputUID: adjustment.output.uid,
-            sampleRate: adjustment.output.nominalSampleRate,
-            tapSampleRate: adjustment.tapSampleRate,
-            previousFrameSize: adjustment.output.bufferFrameSize,
-            resultingFrameSize: adjustment.output.bufferFrameSize,
-            previousTargetFrames: adjustment.previousTargetFrames,
-            resultingTargetFrames: adjustment.targetFrames,
-            reason: adjustment.reason,
-            at: playbackBufferCalibrationStoreURL
+    static func deviceClockSlopeAgrees(
+        sampleTimeDeltaFrames: Double,
+        hostTimeDeltaNanoseconds: UInt64,
+        nominalSampleRate: Double,
+        rateScalar: Double,
+        rateScalarIsValid: Bool
+    ) -> Bool {
+        guard sampleTimeDeltaFrames.isFinite,
+              sampleTimeDeltaFrames > 0,
+              hostTimeDeltaNanoseconds > 0,
+              nominalSampleRate.isFinite,
+              nominalSampleRate > 0 else {
+            return false
+        }
+        if rateScalarIsValid,
+           (!rateScalar.isFinite || abs(rateScalar - 1) > 0.02) {
+            return false
+        }
+        let expectedFrames = Double(hostTimeDeltaNanoseconds)
+            * nominalSampleRate / 1_000_000_000
+        guard expectedFrames >= 1 else {
+            return false
+        }
+        return abs(sampleTimeDeltaFrames - expectedFrames) / expectedFrames <= 0.02
+    }
+
+    private static func deviceClockSlopeIsStable(
+        deviceID: AudioObjectID,
+        nominalSampleRate: Double,
+        observationDuration: TimeInterval
+    ) throws -> Bool {
+        let first = try currentDeviceTime(deviceID: deviceID)
+        Thread.sleep(forTimeInterval: observationDuration)
+        let second = try currentDeviceTime(deviceID: deviceID)
+        guard first.mFlags.contains(.sampleTimeValid),
+              first.mFlags.contains(.hostTimeValid),
+              second.mFlags.contains(.sampleTimeValid),
+              second.mFlags.contains(.hostTimeValid),
+              second.mHostTime > first.mHostTime else {
+            return false
+        }
+        return deviceClockSlopeAgrees(
+            sampleTimeDeltaFrames: second.mSampleTime - first.mSampleTime,
+            hostTimeDeltaNanoseconds: AudioConvertHostTimeToNanos(
+                second.mHostTime - first.mHostTime
+            ),
+            nominalSampleRate: nominalSampleRate,
+            rateScalar: second.mRateScalar,
+            rateScalarIsValid: second.mFlags.contains(.rateScalarValid)
         )
-        return true
     }
 
-    private func continueCalibrationAfterUnresolvedInstability(
-        _ preparation: PlaybackBufferRenegotiationPreparation
-    ) {
-        let targetFrames = preparation.runtime.playbackTargetFrames()
-        let instability = UnresolvedPlaybackBufferInstability(
-            outputUID: preparation.output.uid,
-            sampleRate: preparation.output.nominalSampleRate,
-            tapSampleRate: preparation.runtime.sampleRate,
-            frameSize: preparation.output.bufferFrameSize,
-            targetFrames: targetFrames,
-            reason: preparation.reason
+    private static func currentDeviceTime(deviceID: AudioObjectID) throws -> AudioTimeStamp {
+        var time = AudioTimeStamp()
+        time.mFlags = [
+            .sampleTimeValid,
+            .hostTimeValid,
+            .rateScalarValid
+        ]
+        try checkOSStatus(
+            AudioDeviceGetCurrentTime(deviceID, &time),
+            operation: "AudioDeviceGetCurrentTime(headset promotion)"
         )
-        let shouldPersist = control.withLock { state -> Bool? in
-            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
-                  state.runtime === preparation.runtime,
-                  state.activeOutput == preparation.output else {
-                return nil
-            }
-            state.playbackBufferCalibrationProbe = PlaybackBufferCalibrationProbe(
-                outputUID: preparation.output.uid,
-                sampleRate: preparation.output.nominalSampleRate,
-                tapSampleRate: preparation.runtime.sampleRate,
-                frameSize: preparation.output.bufferFrameSize,
-                targetFrames: targetFrames,
-                startedAt: ContinuousClock().now
-            )
-            return state.playbackBufferInstabilityPersistenceGate.shouldPersist(instability)
-        }
-        guard shouldPersist == true else {
-            return
-        }
-        do {
-            try PersistedPlaybackBufferCalibrationStore.recordInstability(
-                outputUID: preparation.output.uid,
-                sampleRate: preparation.output.nominalSampleRate,
-                tapSampleRate: preparation.runtime.sampleRate,
-                previousFrameSize: preparation.output.bufferFrameSize,
-                resultingFrameSize: preparation.output.bufferFrameSize,
-                previousTargetFrames: targetFrames,
-                resultingTargetFrames: targetFrames,
-                reason: preparation.reason,
-                at: playbackBufferCalibrationStoreURL
-            )
-        } catch {
-            control.withLock { state in
-                state.playbackBufferInstabilityPersistenceGate.persistenceFailed(for: instability)
-            }
-        }
+        return time
     }
 
-    private func recoverFailedPlaybackBufferRenegotiation(
-        _ preparation: PlaybackBufferRenegotiationPreparation
-    ) {
-        control.withLock { state in
-            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
-                  state.runtime === preparation.runtime,
-                  state.activeOutput == preparation.output else {
-                return
-            }
-            preparation.runtime.reprimePlayback()
-        }
+    public static func shouldUseSeparateClockBackend(for output: AudioOutputDevice) -> Bool {
+#if GLASSEQ_FORCE_COMBINED_HEADSET
+        false
+#else
+        output.isBluetoothTransport && output.nominalSampleRate <= 24_000
+#endif
     }
 
-    private func recoverAdaptivePlaybackRenderFailure(
-        _ preparation: PlaybackBufferRenegotiationPreparation
-    ) {
-        let action = control.withLock { state -> AdaptivePlaybackRenderRecoveryAction? in
-            guard state.outputRebuildGeneration == preparation.outputRebuildGeneration,
-                  state.runtime === preparation.runtime,
-                  state.activeOutput == preparation.output,
-                  preparation.runtime.hasActiveAdaptivePlaybackRenderFailure(),
-                  let profile = state.activeProfile else {
-                return nil
-            }
-            if AdaptivePlaybackRenderRecoveryPolicy.shouldRestart(
-                afterCompletedAttempts: state.adaptivePlaybackRenderRecoveryAttempts
-            ) {
-                state.adaptivePlaybackRenderRecoveryAttempts += 1
-                state.adaptivePlaybackRenderRecoveryHealthGeneration = preparation.runtime
-                    .playbackRenderHealthGeneration()
-                return .restart(
-                    output: preparation.output,
-                    profile: profile,
-                    expectation: OutputRebuildExpectation(
-                        generation: state.outputRebuildGeneration,
-                        runtime: preparation.runtime,
-                        profileRevision: state.profileRevision
-                    )
-                )
-            }
+    private static func promotedHeadsetRoute(
+        for output: AudioOutputDevice
+    ) -> PromotedHeadsetRoute {
+        PromotedHeadsetRoute(
+            outputUID: output.uid,
+            nominalSampleRate: Int64(output.nominalSampleRate.rounded())
+        )
+    }
 
-            let failure = AudioEngineFailure(
-                category: .coreAudioOperationFailed,
-                userMessage: "Adaptive playback rendering repeatedly failed, so GlassEQ stopped processing audio.",
-                operation: "AdaptivePlaybackRender"
+    private static func latencyMetadata(deviceID: AudioObjectID) -> AudioDeviceLatencyMetadata {
+        AudioDeviceLatencyMetadata(
+            objectID: deviceID,
+            bufferFrameSize: try? CoreAudioDeviceQuery.getUInt32Property(
+                objectID: deviceID,
+                selector: kAudioDevicePropertyBufferFrameSize,
+                scope: kAudioObjectPropertyScopeGlobal
+            ),
+            inputStreamChannelCounts: try? CoreAudioDeviceQuery.streamChannelCounts(
+                objectID: deviceID,
+                scope: kAudioDevicePropertyScopeInput
+            ),
+            outputStreamChannelCounts: try? CoreAudioDeviceQuery.streamChannelCounts(
+                objectID: deviceID,
+                scope: kAudioDevicePropertyScopeOutput
+            ),
+            inputLatencyFrames: try? CoreAudioDeviceQuery.getUInt32Property(
+                objectID: deviceID,
+                selector: kAudioDevicePropertyLatency,
+                scope: kAudioDevicePropertyScopeInput
+            ),
+            inputSafetyOffsetFrames: try? CoreAudioDeviceQuery.getUInt32Property(
+                objectID: deviceID,
+                selector: kAudioDevicePropertySafetyOffset,
+                scope: kAudioDevicePropertyScopeInput
+            ),
+            inputSafetyOffsetSettable: propertyIsSettable(
+                objectID: deviceID,
+                selector: kAudioDevicePropertySafetyOffset,
+                scope: kAudioDevicePropertyScopeInput
+            ),
+            outputLatencyFrames: try? CoreAudioDeviceQuery.getUInt32Property(
+                objectID: deviceID,
+                selector: kAudioDevicePropertyLatency,
+                scope: kAudioDevicePropertyScopeOutput
+            ),
+            outputSafetyOffsetFrames: try? CoreAudioDeviceQuery.getUInt32Property(
+                objectID: deviceID,
+                selector: kAudioDevicePropertySafetyOffset,
+                scope: kAudioDevicePropertyScopeOutput
+            ),
+            outputSafetyOffsetSettable: propertyIsSettable(
+                objectID: deviceID,
+                selector: kAudioDevicePropertySafetyOffset,
+                scope: kAudioDevicePropertyScopeOutput
             )
-            stopLocked(&state)
-            state.state = .failed(failure.description)
-            state.status = .failed(failure)
-            return .fail(failure)
-        }
-        guard let action else {
-            return
-        }
-
-        switch action {
-        case .restart(let output, let profile, let expectation):
-            do {
-                try start(
-                    output: output,
-                    profile: profile,
-                    expectation: expectation
-                )
-            } catch {
-                let failure = control.withLock { state in
-                    if case .failed(let failure) = state.status {
-                        return failure
-                    }
-                    return audioEngineFailure(from: error)
-                }
-                runtimeFailureHandler.withLock { $0 }?(failure)
-            }
-        case .fail(let failure):
-            updatePlaybackBufferAdaptationTimer()
-            runtimeFailureHandler.withLock { $0 }?(failure)
-        }
+        )
     }
 
-    static func renegotiatedPlaybackOutput(
-        _ output: AudioOutputDevice,
-        supportedRange: AudioBufferFrameSizeRange,
-        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void = CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:),
-        queryOutput: (AudioObjectID) throws -> AudioOutputDevice = CoreAudioDeviceQuery.outputDevice(id:),
-        waitForPropertySettlement: () -> Void = { Thread.sleep(forTimeInterval: 0.01) }
-    ) throws -> AudioOutputDevice? {
-        guard let requestedFrameSize = AdaptivePlaybackBufferPolicy.nextFrameSize(
-            after: output.bufferFrameSize,
-            supportedRange: supportedRange
-        ) else {
+    private static func propertyIsSettable(
+        objectID: AudioObjectID,
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope
+    ) -> Bool? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var isSettable = DarwinBoolean(false)
+        guard AudioObjectIsPropertySettable(objectID, &address, &isSettable) == noErr else {
             return nil
         }
-
-        try setBufferFrameSize(requestedFrameSize, output.id)
-        for attempt in 0..<3 {
-            let updatedOutput = try queryOutput(output.id)
-            if updatedOutput.id == output.id,
-               updatedOutput.bufferFrameSize > output.bufferFrameSize {
-                return updatedOutput
-            }
-            if attempt < 2 {
-                waitForPropertySettlement()
-            }
-        }
-        return nil
+        return isSettable.boolValue
     }
 
-    static func preferredBufferFrameSize(for output: AudioOutputDevice) -> UInt32 {
-        if isLowSampleRateRoute(output) {
-            return Self.preferredLowSampleRateBufferFrameSize
-        }
-        if output.isBluetoothTransport {
-            return Self.preferredBluetoothBufferFrameSize
-        }
-        // Low-latency: request a small output buffer rather than keeping the device's larger
-        // default. Clamped to the device's supported range by the caller (tuneBufferFrameSize).
-        return Self.preferredBufferFrameSize
-    }
-
-    static func preferredPlaybackPrimeFrames(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double? = nil,
-        captureCallbackFrames: Int = preferredLowSampleRatePlaybackReservoirFrames
-    ) -> Int {
-        let outputCallbackFrames = max(Int(output.bufferFrameSize), 1)
-        if hasLowSampleRateEndpoint(
-            tapSampleRate: tapSampleRate ?? output.nominalSampleRate,
-            output: output
-        ) {
-            let sampleRatePlan = PlaybackSampleRatePlan(
-                inputSampleRate: tapSampleRate ?? output.nominalSampleRate,
-                outputSampleRate: output.nominalSampleRate
-            )
-            let reservoirFrames = min(
-                max(captureCallbackFrames, Self.preferredLowSampleRatePlaybackReservoirFrames),
-                Self.maximumSupportedCallbackFrames
-            )
-            return max(
-                sampleRatePlan.inputFrames(forOutputFrames: Int(Self.preferredLowSampleRateBufferFrameSize)),
-                sampleRatePlan.inputFrames(forOutputFrames: outputCallbackFrames)
-                    + reservoirFrames
-            )
-        }
-        if output.isBluetoothTransport {
-            return max(
-                Self.preferredBluetoothPlaybackTargetFrames,
-                outputCallbackFrames + Self.preferredBluetoothPlaybackReservoirFrames
-            )
-        }
-        return max(
-            Self.preferredPlaybackPrimeFrames,
-            outputCallbackFrames + Int(Self.preferredCaptureBufferFrameSize)
-        )
-    }
-
-    static func shouldAdaptPlaybackBuffer(for output: AudioOutputDevice) -> Bool {
-        output.nominalSampleRate > 0
-    }
-
-    static func playbackInputCallbackFrames(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double
-    ) -> UInt32 {
-        UInt32(clamping: PlaybackSampleRatePlan(
-            inputSampleRate: tapSampleRate,
-            outputSampleRate: output.nominalSampleRate
-        ).inputFrames(forOutputFrames: Int(output.bufferFrameSize)))
-    }
-
-    static func startupCaptureCallbackFrames(reportedFrames: UInt32?) -> Int {
-        guard let reportedFrames,
-              reportedFrames > 0,
-              reportedFrames <= UInt32(maximumSupportedCallbackFrames) else {
-            return maximumSupportedCallbackFrames
-        }
-        return Int(reportedFrames)
-    }
-
-    static func shouldUseSampleRateConversion(
-        tapSampleRate: Double,
-        output: AudioOutputDevice
-    ) -> Bool {
-        abs(tapSampleRate - output.nominalSampleRate) >= 1
-            && hasLowSampleRateEndpoint(tapSampleRate: tapSampleRate, output: output)
-    }
-
-    static func shouldRecordSampleRateRestoration(
-        tapSampleRate: Double,
-        output: AudioOutputDevice
-    ) -> Bool {
-        tapSampleRate > 0
-            && abs(output.nominalSampleRate - tapSampleRate) >= 1
-            && !shouldUseSampleRateConversion(tapSampleRate: tapSampleRate, output: output)
-    }
-
-    static func effectiveOutputRebuildProfile(
-        preparedProfile: EQProfile,
-        preparedProfileRevision: UInt64,
-        activeProfile: EQProfile?,
-        activeProfileRevision: UInt64
-    ) -> EQProfile {
-        guard activeProfileRevision != preparedProfileRevision,
-              let activeProfile else {
-            return preparedProfile
-        }
-        return activeProfile
-    }
-
-    static func requestedOutputRebuildProfile(
-        requestedProfile: EQProfile,
-        expectedProfileRevision: UInt64?,
-        activeProfile: EQProfile?,
-        activeProfileRevision: UInt64
-    ) -> EQProfile? {
-        guard let expectedProfileRevision,
-              activeProfileRevision != expectedProfileRevision else {
-            return requestedProfile
-        }
-        return activeProfile
-    }
-
-    static func profileUpdateOutput(_ output: AudioOutputDevice?) throws -> AudioOutputDevice {
+    static func profileUpdateOutput(
+        _ output: AudioOutputDevice?
+    ) throws -> AudioOutputDevice {
         guard let output else {
             throw AudioEngineProfileUpdateUnavailable()
         }
         return output
     }
 
-    static func shouldRefreshCaptureForOutput(
-        tapSampleRate: Double,
-        output: AudioOutputDevice
+    static func restoreSampleRateRestoration(
+        _ restoration: SampleRateRestoration,
+        outputForUID: (String) throws -> AudioOutputDevice? =
+            CoreAudioDeviceQuery.outputDevice(uid:),
+        setSampleRate: (Double, AudioObjectID) throws -> Void =
+            CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:)
     ) -> Bool {
-        isLowSampleRate(tapSampleRate)
-            && output.nominalSampleRate - tapSampleRate >= 1
-    }
-
-    static func maximumPlaybackReservoirFrames(
-        for output: AudioOutputDevice,
-        tapSampleRate: Double,
-        maximumKnownCaptureCallbackFrames: Int
-    ) -> Int {
-        guard hasLowSampleRateEndpoint(tapSampleRate: tapSampleRate, output: output) else {
-            return AdaptivePlaybackBufferPolicy.maximumReservoirFrames
-        }
-        return max(
-            Self.preferredLowSampleRatePlaybackReservoirFrames,
-            maximumKnownCaptureCallbackFrames
-        )
-    }
-
-    private static func isLowSampleRateRoute(_ output: AudioOutputDevice) -> Bool {
-        isLowSampleRate(output.nominalSampleRate)
-    }
-
-    private static func isLowSampleRate(_ sampleRate: Double) -> Bool {
-        sampleRate > 0 && sampleRate <= Self.lowSampleRateThreshold
-    }
-
-    private static func hasLowSampleRateEndpoint(
-        tapSampleRate: Double,
-        output: AudioOutputDevice
-    ) -> Bool {
-        isLowSampleRate(tapSampleRate) || isLowSampleRateRoute(output)
-    }
-
-    private func createTopologyRebuildMuteGuard() throws -> any TopologyRebuildMuteGuarding {
-        let tapID = try createSystemTap(name: "GlassEQ Profile Rebuild Mute Tap")
-        var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
-        var ioProcID: AudioDeviceIOProcID?
-
         do {
-            aggregateDeviceID = try createPrivateAggregateDevice(tapID: tapID)
-            ioProcID = try createSilenceIOProc(deviceID: aggregateDeviceID)
-            try checkOSStatus(
-                AudioDeviceStart(aggregateDeviceID, ioProcID),
-                operation: "AudioDeviceStart(profile rebuild mute tap)"
-            )
-            return CoreAudioTopologyRebuildMuteGuard(
-                tapID: tapID,
-                aggregateDeviceID: aggregateDeviceID,
-                ioProcID: ioProcID
-            )
+            guard let output = try outputForUID(restoration.uid) else {
+                return false
+            }
+            guard abs(output.nominalSampleRate - restoration.originalSampleRate) >= 1 else {
+                return true
+            }
+            try setSampleRate(restoration.originalSampleRate, output.id)
+            guard let verifiedOutput = try outputForUID(restoration.uid) else {
+                return false
+            }
+            return abs(
+                verifiedOutput.nominalSampleRate - restoration.originalSampleRate
+            ) < 1
         } catch {
-            if aggregateDeviceID != kAudioObjectUnknown, let ioProcID {
-                _ = AudioDeviceStop(aggregateDeviceID, ioProcID)
-                _ = AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProcID)
-            }
-            if aggregateDeviceID != kAudioObjectUnknown {
-                _ = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
-            }
-            _ = AudioHardwareDestroyProcessTap(tapID)
-            throw error
+            return false
         }
     }
 
-    private func createSystemTap(name: String = "GlassEQ System Output Tap") throws -> AudioObjectID {
-        let ownProcess = try currentAudioProcessObjectID()
-        // Global tap (not bound to a device): one muted tap removes the dry system mix from
-        // every output device and survives default-output switches without rebuild, so dry
-        // audio never leaks to a newly selected device during the route handoff. Verified on
-        // hardware across built-in / USB / Bluetooth / HDMI and 44.1k–192k device rates.
-        let description = CATapDescription(stereoGlobalTapButExcludeProcesses: [ownProcess])
-        description.name = name
-        description.uuid = UUID()
-        description.isPrivate = true
-        description.muteBehavior = CATapMuteBehavior.muted
-
-        var tapID = AudioObjectID(kAudioObjectUnknown)
-        try checkOSStatus(
-            AudioHardwareCreateProcessTap(description, &tapID),
-            operation: "AudioHardwareCreateProcessTap"
-        )
-        return tapID
-    }
-
-    private func tapStreamFormat(_ tapID: AudioObjectID) throws -> AudioStreamBasicDescription {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioTapPropertyFormat,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var asbd = AudioStreamBasicDescription()
-        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-        try checkOSStatus(
-            AudioObjectGetPropertyData(tapID, &address, 0, nil, &size, &asbd),
-            operation: "AudioObjectGetPropertyData(tap format)"
-        )
-        try CoreAudioDeviceQuery.validatePropertySize(
-            actual: size,
-            expected: UInt32(MemoryLayout<AudioStreamBasicDescription>.size),
-            operation: "AudioObjectGetPropertyData(tap format)",
-            objectID: tapID
-        )
-        return asbd
-    }
-
-    private func createPrivateAggregateDevice(tapID: AudioObjectID) throws -> AudioObjectID {
-        let tapUID = try tapUID(tapID)
-        let aggregateUID = "com.glasseq.aggregate.\(UUID().uuidString)"
-        let description: [String: Any] = [
-            kAudioAggregateDeviceNameKey: "GlassEQ Private Tap Device",
-            kAudioAggregateDeviceUIDKey: aggregateUID,
-            kAudioAggregateDeviceIsPrivateKey: true,
-            kAudioAggregateDeviceTapListKey: [
-                [
-                    kAudioSubTapUIDKey: tapUID
-                ]
-            ]
-        ]
-
-        var deviceID = AudioObjectID(kAudioObjectUnknown)
-        try checkOSStatus(
-            AudioHardwareCreateAggregateDevice(description as CFDictionary, &deviceID),
-            operation: "AudioHardwareCreateAggregateDevice"
-        )
-        return deviceID
-    }
-
-    private func createCaptureIOProc(deviceID: AudioObjectID, runtime: AudioRuntime) throws -> AudioDeviceIOProcID? {
-        var ioProcID: AudioDeviceIOProcID?
-
-        try checkOSStatus(
-            AudioDeviceCreateIOProcIDWithBlock(&ioProcID, deviceID, nil) { _, inputData, _, outputData, _ in
-                runtime.capture(inputData: inputData)
-                runtime.clear(outputData: outputData)
-            },
-            operation: "AudioDeviceCreateIOProcIDWithBlock(capture)"
-        )
-
-        return ioProcID
-    }
-
-    private func createSilenceIOProc(deviceID: AudioObjectID) throws -> AudioDeviceIOProcID? {
-        var ioProcID: AudioDeviceIOProcID?
-
-        try checkOSStatus(
-            AudioDeviceCreateIOProcIDWithBlock(&ioProcID, deviceID, nil) { _, _, _, outputData, _ in
-                Self.clear(outputData: outputData)
-            },
-            operation: "AudioDeviceCreateIOProcIDWithBlock(profile rebuild mute tap)"
-        )
-
-        return ioProcID
-    }
-
-    private func createOutputIOProc(deviceID: AudioObjectID, runtime: AudioRuntime) throws -> AudioDeviceIOProcID? {
-        var ioProcID: AudioDeviceIOProcID?
-
-        try checkOSStatus(
-            AudioDeviceCreateIOProcIDWithBlock(&ioProcID, deviceID, nil) { _, _, _, outputData, outputTime in
-                let outputTimestamp = outputTime.pointee
-                let sampleTime: Double? = if outputTimestamp.mFlags.contains(.sampleTimeValid) {
-                    outputTimestamp.mSampleTime
-                } else {
-                    nil
-                }
-                runtime.playback(outputData: outputData, outputSampleTime: sampleTime)
-            },
-            operation: "AudioDeviceCreateIOProcIDWithBlock(output)"
-        )
-
-        return ioProcID
-    }
-
-    private static func clear(outputData: UnsafeMutablePointer<AudioBufferList>) {
-        for buffer in UnsafeMutableAudioBufferListPointer(outputData) {
-            guard let data = buffer.mData else {
-                continue
+    static func restoreBufferFrameSizeRestoration(
+        _ restoration: BufferFrameSizeRestoration,
+        outputForUID: (String) throws -> AudioOutputDevice? =
+            CoreAudioDeviceQuery.outputDevice(uid:),
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void =
+            CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
+    ) -> Bool {
+        do {
+            guard let output = try outputForUID(restoration.uid) else {
+                return false
             }
-            let byteCount = Int(buffer.mDataByteSize)
-            let maxByteCount = Int(CoreAudioDeviceQuery.maxBufferFrameSize)
-                * CoreAudioDeviceQuery.maxChannelCount
-                * MemoryLayout<Float>.stride
-            guard byteCount >= 0,
-                  byteCount <= maxByteCount else {
-                continue
+            guard output.bufferFrameSize != restoration.originalFrameSize else {
+                return true
             }
-            data.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+            try setBufferFrameSize(restoration.originalFrameSize, output.id)
+            guard let verifiedOutput = try outputForUID(restoration.uid) else {
+                return false
+            }
+            return verifiedOutput.bufferFrameSize == restoration.originalFrameSize
+        } catch {
+            return false
         }
     }
 
-    private func tapUID(_ tapID: AudioObjectID) throws -> String {
-        try CoreAudioDeviceQuery.getStringProperty(
-            objectID: tapID,
-            selector: kAudioTapPropertyUID,
-            scope: kAudioObjectPropertyScopeGlobal
-        )
-    }
-
-    private func currentAudioProcessObjectID() throws -> AudioObjectID {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var pid = getpid()
-        var processID = AudioObjectID(kAudioObjectUnknown)
-        var size = UInt32(MemoryLayout<AudioObjectID>.size)
-        let qualifierSize = UInt32(MemoryLayout<pid_t>.size)
-
-        try checkOSStatus(
-            AudioObjectGetPropertyData(
-                AudioObjectID(kAudioObjectSystemObject),
-                &address,
-                qualifierSize,
-                &pid,
-                &size,
-                &processID
-            ),
-            operation: "AudioObjectGetPropertyData(translate pid)"
-        )
-
-        guard processID != kAudioObjectUnknown else {
-            throw AudioDeviceAvailabilityError.invalidDeviceMetadata(
-                AudioObjectID(kAudioObjectSystemObject),
-                "current audio process object is unknown"
-            )
+    static func restorePersistedDeviceSettings(
+        at url: URL,
+        outputForUID: (String) throws -> AudioOutputDevice? =
+            CoreAudioDeviceQuery.outputDevice(uid:),
+        setSampleRate: (Double, AudioObjectID) throws -> Void =
+            CoreAudioDeviceQuery.setNominalSampleRate(_:objectID:),
+        setBufferFrameSize: (UInt32, AudioObjectID) throws -> Void =
+            CoreAudioDeviceQuery.setBufferFrameSize(_:objectID:)
+    ) {
+        var records = PersistedAudioDeviceRestorationStore.load(from: url)
+        guard !records.isEmpty else {
+            return
         }
-        return processID
+
+        for (uid, record) in records {
+            var updated = record
+            if let originalSampleRate = record.originalSampleRate,
+               restoreSampleRateRestoration(
+                   SampleRateRestoration(
+                       uid: uid,
+                       originalSampleRate: originalSampleRate
+                   ),
+                   outputForUID: outputForUID,
+                   setSampleRate: setSampleRate
+               ) {
+                updated.originalSampleRate = nil
+            }
+            if let originalBufferFrameSize = record.originalBufferFrameSize,
+               restoreBufferFrameSizeRestoration(
+                   BufferFrameSizeRestoration(
+                       uid: uid,
+                       originalFrameSize: originalBufferFrameSize
+                   ),
+                   outputForUID: outputForUID,
+                   setBufferFrameSize: setBufferFrameSize
+               ) {
+                updated.originalBufferFrameSize = nil
+            }
+            records[uid] = updated.isEmpty ? nil : updated
+        }
+        try? PersistedAudioDeviceRestorationStore.save(records, to: url)
     }
+
 }

--- a/Sources/GlassEQDiagnostics/AggregateClockSourceProbe.swift
+++ b/Sources/GlassEQDiagnostics/AggregateClockSourceProbe.swift
@@ -1,0 +1,615 @@
+import CoreAudio
+import Darwin
+import Foundation
+import GlassEQAudio
+
+private enum AggregateClockProbeError: Error, CustomStringConvertible {
+    case coreAudio(operation: String, status: OSStatus)
+    case timedOut(String)
+    case unavailable(String)
+
+    var description: String {
+        switch self {
+        case .coreAudio(let operation, let status):
+            return "\(operation) failed with OSStatus \(status)"
+        case .timedOut(let operation):
+            return "Timed out waiting for \(operation)"
+        case .unavailable(let message):
+            return message
+        }
+    }
+}
+
+private enum AggregateClockProbeSource: CaseIterable {
+    case physicalDevice
+    case deviceClock
+    case tap
+
+    var label: String {
+        switch self {
+        case .physicalDevice:
+            return "physical device"
+        case .deviceClock:
+            return "physical device clock object"
+        case .tap:
+            return "device-scoped tap"
+        }
+    }
+}
+
+private struct RunningTapSelection {
+    var activeSubtapIDs: [AudioObjectID]
+    var activeSubtapApplied: Bool
+    var activeSubtapError: String?
+    var originalTapApplied: Bool
+}
+
+func runAggregateClockSourceProbe(output: AudioOutputDevice) -> Int32 {
+    print("Mode: aggregate clock-source probe")
+    print("The probe creates private aggregates and briefly starts silent IO for live clock-source checks.")
+
+    var tapID = AudioObjectID(kAudioObjectUnknown)
+    do {
+        let tapDescription = CATapDescription(
+            excludingProcesses: [],
+            deviceUID: output.uid,
+            stream: 0
+        )
+        tapDescription.name = "GlassEQ Clock Source Probe"
+        tapDescription.uuid = UUID()
+        tapDescription.isPrivate = true
+        tapDescription.muteBehavior = .unmuted
+        tapDescription.isMixdown = false
+
+        try check(
+            AudioHardwareCreateProcessTap(tapDescription, &tapID),
+            operation: "AudioHardwareCreateProcessTap(clock-source probe)"
+        )
+        defer {
+            if tapID != kAudioObjectUnknown {
+                _ = AudioHardwareDestroyProcessTap(tapID)
+            }
+        }
+
+        let tap = AudioHardwareTap(id: tapID)
+        let physicalDevice = AudioHardwareDevice(id: output.id)
+        let deviceClock = try? physicalDevice.clock
+
+        print("Physical device object ID: \(physicalDevice.id)")
+        if let deviceClock {
+            print("Physical device clock object ID: \(deviceClock.id)")
+        } else {
+            print("Physical device clock object ID: unavailable")
+        }
+        print("Tap object ID: \(tap.id)")
+
+        for source in AggregateClockProbeSource.allCases {
+            do {
+                try runProbe(
+                    source: source,
+                    output: output,
+                    physicalDevice: physicalDevice,
+                    deviceClock: deviceClock,
+                    tap: tap
+                )
+            } catch {
+                print("")
+                print("Clock source: \(source.label)")
+                print("  Result: rejected")
+                print("  Error: \(error)")
+            }
+        }
+        for probe in [
+            { try runTapOnlyProbe(tap: tap) },
+            {
+                try runTapFirstOutputProbe(
+                    physicalDevice: physicalDevice,
+                    tap: tap
+                )
+            },
+            {
+                try runTapMainUIDProbe(
+                    output: output,
+                    physicalDevice: physicalDevice,
+                    tap: tap
+                )
+            }
+        ] {
+            do {
+                try probe()
+            } catch {
+                print("")
+                print("Additional clock-source probe rejected: \(error)")
+            }
+        }
+        return 0
+    } catch {
+        print("Aggregate clock-source probe failed: \(error)")
+        return 1
+    }
+}
+
+private func runTapMainUIDProbe(
+    output: AudioOutputDevice,
+    physicalDevice: AudioHardwareDevice,
+    tap: AudioHardwareTap
+) throws {
+    let tapUID = try stringProperty(
+        objectID: tap.id,
+        selector: kAudioTapPropertyUID
+    )
+    let description: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "GlassEQ Clock Probe tap master UID",
+        kAudioAggregateDeviceUIDKey: "com.glasseq.clock-probe.\(UUID().uuidString)",
+        kAudioAggregateDeviceIsPrivateKey: true,
+        kAudioAggregateDeviceMainSubDeviceKey: tapUID,
+        kAudioAggregateDeviceSubDeviceListKey: [
+            [
+                kAudioSubDeviceUIDKey: output.uid,
+                kAudioSubDeviceInputChannelsKey: 0,
+                kAudioSubDeviceOutputChannelsKey: output.outputChannelCount,
+                kAudioSubDeviceDriftCompensationKey: true,
+                kAudioSubDeviceDriftCompensationQualityKey:
+                    kAudioAggregateDriftCompensationHighQuality
+            ]
+        ],
+        kAudioAggregateDeviceTapListKey: [
+            [
+                kAudioSubTapUIDKey: tapUID,
+                kAudioSubTapDriftCompensationKey: false
+            ]
+        ]
+    ]
+
+    var aggregateID = AudioObjectID(kAudioObjectUnknown)
+    try check(
+        AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateID),
+        operation: "AudioHardwareCreateAggregateDevice(tap master UID)"
+    )
+    defer { _ = AudioHardwareDestroyAggregateDevice(aggregateID) }
+    let aggregate = AudioHardwareAggregateDevice(id: aggregateID)
+    try waitUntilAlive(aggregate)
+    let composition = try aggregate.composition
+
+    print("")
+    print("Clock source: tap UID in master composition")
+    print("  Aggregate object ID: \(aggregate.id)")
+    print("  Published source: \(describe(try aggregate.clockSource))")
+    print("  Main subdevice UID: \(composition[kAudioAggregateDeviceMainSubDeviceKey] ?? "unavailable")")
+    print("  Input safety offset: \(try aggregate.inputSafetyOffset) frames")
+    print("  Output safety offset: \(try aggregate.outputSafetyOffset) frames")
+
+    let physicalInputStreamCount = try physicalDevice.inputStreamConfiguration.count
+    var runningSource = "unavailable"
+    var runningSelectionApplied = false
+    var runningActiveSubtaps: [AudioObjectID] = []
+    var runningActiveSubtapError: String?
+    try withRunningSilentIO(
+        on: aggregate,
+        disabledInputStreamCount: physicalInputStreamCount
+    ) {
+        let selection = try selectRunningTapClockSource(
+            aggregate: aggregate,
+            tap: tap
+        )
+        runningActiveSubtaps = selection.activeSubtapIDs
+        runningActiveSubtapError = selection.activeSubtapError
+        runningSelectionApplied = selection.activeSubtapApplied
+            || selection.originalTapApplied
+        runningSource = describe(try aggregate.clockSource)
+    }
+    print("  Selection applied while running: \(runningSelectionApplied)")
+    print("  Running source: \(runningSource)")
+    print("  Active subtaps while running: \(runningActiveSubtaps)")
+    if let runningActiveSubtapError {
+        print("  Active sub-tap selection error: \(runningActiveSubtapError)")
+    }
+}
+
+private func runProbe(
+    source: AggregateClockProbeSource,
+    output: AudioOutputDevice,
+    physicalDevice: AudioHardwareDevice,
+    deviceClock: AudioHardwareClock?,
+    tap: AudioHardwareTap
+) throws {
+    let tapUID = try stringProperty(
+        objectID: tap.id,
+        selector: kAudioTapPropertyUID
+    )
+    let description: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "GlassEQ Clock Probe \(source.label)",
+        kAudioAggregateDeviceUIDKey: "com.glasseq.clock-probe.\(UUID().uuidString)",
+        kAudioAggregateDeviceIsPrivateKey: true,
+        kAudioAggregateDeviceMainSubDeviceKey: output.uid,
+        kAudioAggregateDeviceSubDeviceListKey: [
+            [
+                kAudioSubDeviceUIDKey: output.uid,
+                kAudioSubDeviceInputChannelsKey: 0,
+                kAudioSubDeviceOutputChannelsKey: output.outputChannelCount,
+                kAudioSubDeviceDriftCompensationKey: false
+            ]
+        ],
+        kAudioAggregateDeviceTapListKey: [
+            [
+                kAudioSubTapUIDKey: tapUID,
+                kAudioSubTapDriftCompensationKey: true,
+                kAudioSubTapDriftCompensationQualityKey:
+                    kAudioAggregateDriftCompensationHighQuality
+            ]
+        ]
+    ]
+
+    var aggregateID = AudioObjectID(kAudioObjectUnknown)
+    try check(
+        AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateID),
+        operation: "AudioHardwareCreateAggregateDevice(\(source.label))"
+    )
+    defer {
+        if aggregateID != kAudioObjectUnknown {
+            _ = AudioHardwareDestroyAggregateDevice(aggregateID)
+        }
+    }
+
+    let aggregate = AudioHardwareAggregateDevice(id: aggregateID)
+    try waitUntilAlive(aggregate)
+
+    let requestedSource: AudioHardwareObject
+    switch source {
+    case .physicalDevice:
+        requestedSource = physicalDevice
+    case .deviceClock:
+        guard let deviceClock else {
+            throw AggregateClockProbeError.unavailable(
+                "The physical device does not publish a separate AudioHardwareClock"
+            )
+        }
+        requestedSource = deviceClock
+    case .tap:
+        requestedSource = tap
+    }
+    try aggregate.setClockSource(requestedSource)
+    let sourceApplied = try waitForClockSource(requestedSource.id, aggregate: aggregate)
+    var runningSelectionApplied: Bool?
+    var runningSource: String?
+    var runningActiveSubtaps: [AudioObjectID]?
+    var runningActiveSubtapError: String?
+    if source == .tap {
+        let physicalInputStreamCount = try physicalDevice.inputStreamConfiguration.count
+        try withRunningSilentIO(
+            on: aggregate,
+            disabledInputStreamCount: physicalInputStreamCount
+        ) {
+            let selection = try selectRunningTapClockSource(
+                aggregate: aggregate,
+                tap: tap
+            )
+            runningActiveSubtaps = selection.activeSubtapIDs
+            runningActiveSubtapError = selection.activeSubtapError
+            runningSelectionApplied = selection.activeSubtapApplied
+                || selection.originalTapApplied
+            runningSource = describe(try aggregate.clockSource)
+        }
+    }
+
+    let publishedSource = try aggregate.clockSource
+    let composition = try aggregate.composition
+
+    print("")
+    print("Clock source: \(source.label)")
+    print("  Aggregate object ID: \(aggregate.id)")
+    print("  Requested object ID: \(requestedSource.id)")
+    print("  Selection applied: \(sourceApplied)")
+    if let runningSelectionApplied, let runningSource, let runningActiveSubtaps {
+        print("  Selection applied while running: \(runningSelectionApplied)")
+        print("  Running source: \(runningSource)")
+        print("  Active subtaps while running: \(runningActiveSubtaps)")
+        if let runningActiveSubtapError {
+            print("  Active sub-tap selection error: \(runningActiveSubtapError)")
+        }
+    }
+    print("  Published source: \(describe(publishedSource))")
+    print("  Main subdevice UID: \(composition[kAudioAggregateDeviceMainSubDeviceKey] ?? "unavailable")")
+    print("  Input safety offset: \(try aggregate.inputSafetyOffset) frames")
+    print("  Output safety offset: \(try aggregate.outputSafetyOffset) frames")
+    print("  Input latency: \(try aggregate.inputLatency) frames")
+    print("  Output latency: \(try aggregate.outputLatency) frames")
+    print("  Subdevices: \(try aggregate.subdevices.map(\.id))")
+    print("  Subtaps: \(try aggregate.subtaps.map(\.id))")
+}
+
+private func runTapOnlyProbe(tap: AudioHardwareTap) throws {
+    let aggregate = try createEmptyAggregate(label: "tap only")
+    defer { _ = AudioHardwareDestroyAggregateDevice(aggregate.id) }
+
+    try aggregate.setSubtaps([tap])
+    try waitUntilAlive(aggregate)
+    let automaticSource = try aggregate.clockSource
+    let explicitSelectionApplied: Bool
+    if automaticSource?.id == tap.id {
+        explicitSelectionApplied = true
+    } else {
+        try aggregate.setClockSource(tap)
+        explicitSelectionApplied = try waitForClockSource(tap.id, aggregate: aggregate)
+    }
+    var runningSource = "unavailable"
+    var runningActiveSubtaps: [AudioObjectID] = []
+    var runningActiveSubtapError: String?
+    try withRunningSilentIO(on: aggregate) {
+        let selection = try selectRunningTapClockSource(
+            aggregate: aggregate,
+            tap: tap
+        )
+        runningActiveSubtaps = selection.activeSubtapIDs
+        runningActiveSubtapError = selection.activeSubtapError
+        runningSource = describe(try aggregate.clockSource)
+    }
+
+    print("")
+    print("Clock source: tap-only aggregate")
+    print("  Aggregate object ID: \(aggregate.id)")
+    print("  Automatic source: \(describe(automaticSource))")
+    print("  Tap selection applied: \(explicitSelectionApplied)")
+    print("  Running source: \(runningSource)")
+    print("  Active subtaps while running: \(runningActiveSubtaps)")
+    if let runningActiveSubtapError {
+        print("  Active sub-tap selection error: \(runningActiveSubtapError)")
+    }
+    print("  Published source: \(describe(try aggregate.clockSource))")
+    print("  Input safety offset: \(try aggregate.inputSafetyOffset) frames")
+    print("  Output safety offset: \(try aggregate.outputSafetyOffset) frames")
+    print("  Subdevices: \(try aggregate.subdevices.map(\.id))")
+    print("  Subtaps: \(try aggregate.subtaps.map(\.id))")
+}
+
+private func runTapFirstOutputProbe(
+    physicalDevice: AudioHardwareDevice,
+    tap: AudioHardwareTap
+) throws {
+    let aggregate = try createEmptyAggregate(label: "tap first")
+    defer { _ = AudioHardwareDestroyAggregateDevice(aggregate.id) }
+
+    try aggregate.setSubtaps([tap])
+    try waitUntilAlive(aggregate)
+    var runningTapSource = false
+    var runningActiveSubtaps: [AudioObjectID] = []
+    var runningActiveSubtapError: String?
+    try withRunningSilentIO(on: aggregate) {
+        let selection = try selectRunningTapClockSource(
+            aggregate: aggregate,
+            tap: tap
+        )
+        runningActiveSubtaps = selection.activeSubtapIDs
+        runningActiveSubtapError = selection.activeSubtapError
+        runningTapSource = selection.activeSubtapApplied
+            || selection.originalTapApplied
+    }
+    let sourceAfterStoppingTapOnlyIO = try aggregate.clockSource?.id == tap.id
+    try aggregate.setSubdevices([physicalDevice])
+    try aggregate.setClockSource(tap)
+    let appliedAfterOutput = try waitForClockSource(tap.id, aggregate: aggregate)
+
+    print("")
+    print("Clock source: tap first, then physical output")
+    print("  Aggregate object ID: \(aggregate.id)")
+    print("  Tap source while tap-only IO ran: \(runningTapSource)")
+    print("  Active subtaps while tap-only IO ran: \(runningActiveSubtaps)")
+    if let runningActiveSubtapError {
+        print("  Active sub-tap selection error: \(runningActiveSubtapError)")
+    }
+    print("  Tap source after stopping tap-only IO: \(sourceAfterStoppingTapOnlyIO)")
+    print("  Tap source after output: \(appliedAfterOutput)")
+    print("  Published source: \(describe(try aggregate.clockSource))")
+    print("  Input safety offset: \(try aggregate.inputSafetyOffset) frames")
+    print("  Output safety offset: \(try aggregate.outputSafetyOffset) frames")
+    print("  Input latency: \(try aggregate.inputLatency) frames")
+    print("  Output latency: \(try aggregate.outputLatency) frames")
+    print("  Subdevices: \(try aggregate.subdevices.map(\.id))")
+    print("  Subtaps: \(try aggregate.subtaps.map(\.id))")
+}
+
+private func selectRunningTapClockSource(
+    aggregate: AudioHardwareAggregateDevice,
+    tap: AudioHardwareTap
+) throws -> RunningTapSelection {
+    let activeSubtaps = try aggregate.activeSubtaps
+    var activeSubtapApplied = false
+    var activeSubtapError: String?
+    if let activeSubtap = activeSubtaps.first {
+        do {
+            try aggregate.setClockSource(activeSubtap)
+            activeSubtapApplied = try waitForClockSource(
+                activeSubtap.id,
+                aggregate: aggregate
+            )
+        } catch {
+            activeSubtapError = String(describing: error)
+        }
+    }
+
+    try aggregate.setClockSource(tap)
+    let originalTapApplied = try waitForClockSource(tap.id, aggregate: aggregate)
+    return RunningTapSelection(
+        activeSubtapIDs: activeSubtaps.map(\.id),
+        activeSubtapApplied: activeSubtapApplied,
+        activeSubtapError: activeSubtapError,
+        originalTapApplied: originalTapApplied
+    )
+}
+
+private func withRunningSilentIO(
+    on aggregate: AudioHardwareAggregateDevice,
+    disabledInputStreamCount: Int = 0,
+    _ body: () throws -> Void
+) throws {
+    var ioProcID: AudioDeviceIOProcID?
+    try check(
+        AudioDeviceCreateIOProcIDWithBlock(
+            &ioProcID,
+            aggregate.id,
+            nil
+        ) { _, _, _, outputData, _ in
+            for buffer in UnsafeMutableAudioBufferListPointer(outputData) {
+                guard let data = buffer.mData else {
+                    continue
+                }
+                memset(data, 0, Int(buffer.mDataByteSize))
+            }
+        },
+        operation: "AudioDeviceCreateIOProcIDWithBlock(clock-source probe)"
+    )
+    guard let ioProcID else {
+        throw AggregateClockProbeError.unavailable(
+            "Core Audio created no IOProc for the clock-source probe"
+        )
+    }
+    let inputStreamCount = try aggregate.inputStreamConfiguration.count
+    if inputStreamCount > 0 {
+        let usage = (0..<inputStreamCount).map {
+            UInt32($0 < disabledInputStreamCount ? 0 : 1)
+        }
+        try setInputStreamUsage(
+            usage,
+            aggregateID: aggregate.id,
+            ioProcID: ioProcID
+        )
+    }
+    defer {
+        _ = AudioDeviceStop(aggregate.id, ioProcID)
+        _ = AudioDeviceDestroyIOProcID(aggregate.id, ioProcID)
+    }
+    try check(
+        AudioDeviceStart(aggregate.id, ioProcID),
+        operation: "AudioDeviceStart(clock-source probe)"
+    )
+    Thread.sleep(forTimeInterval: 0.25)
+    try body()
+}
+
+private func setInputStreamUsage(
+    _ usage: [UInt32],
+    aggregateID: AudioObjectID,
+    ioProcID: AudioDeviceIOProcID
+) throws {
+    let valuesOffset = MemoryLayout<AudioHardwareIOProcStreamUsage>.offset(
+        of: \.mStreamIsOn
+    )!
+    let byteCount = valuesOffset + usage.count * MemoryLayout<UInt32>.stride
+    let storage = UnsafeMutableRawPointer.allocate(
+        byteCount: byteCount,
+        alignment: MemoryLayout<AudioHardwareIOProcStreamUsage>.alignment
+    )
+    defer { storage.deallocate() }
+    storage.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+    let header = storage.assumingMemoryBound(to: AudioHardwareIOProcStreamUsage.self)
+    header.pointee.mIOProc = unsafeBitCast(ioProcID, to: UnsafeMutableRawPointer.self)
+    header.pointee.mNumberStreams = UInt32(usage.count)
+    let values = storage
+        .advanced(by: valuesOffset)
+        .assumingMemoryBound(to: UInt32.self)
+    for (index, enabled) in usage.enumerated() {
+        values[index] = enabled
+    }
+
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyIOProcStreamUsage,
+        mScope: kAudioDevicePropertyScopeInput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    try check(
+        AudioObjectSetPropertyData(
+            aggregateID,
+            &address,
+            0,
+            nil,
+            UInt32(byteCount),
+            storage
+        ),
+        operation: "AudioObjectSetPropertyData(clock-probe input stream usage)"
+    )
+}
+
+private func createEmptyAggregate(label: String) throws -> AudioHardwareAggregateDevice {
+    let description: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "GlassEQ Clock Probe \(label)",
+        kAudioAggregateDeviceUIDKey: "com.glasseq.clock-probe.\(UUID().uuidString)",
+        kAudioAggregateDeviceIsPrivateKey: true
+    ]
+    var aggregateID = AudioObjectID(kAudioObjectUnknown)
+    try check(
+        AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateID),
+        operation: "AudioHardwareCreateAggregateDevice(\(label))"
+    )
+    return AudioHardwareAggregateDevice(id: aggregateID)
+}
+
+private func waitUntilAlive(_ aggregate: AudioHardwareAggregateDevice) throws {
+    let deadline = Date().addingTimeInterval(3)
+    repeat {
+        if try aggregate.isAlive {
+            return
+        }
+        Thread.sleep(forTimeInterval: 0.05)
+    } while Date() < deadline
+    throw AggregateClockProbeError.timedOut("aggregate device to become alive")
+}
+
+private func waitForClockSource(
+    _ expectedID: AudioObjectID,
+    aggregate: AudioHardwareAggregateDevice
+) throws -> Bool {
+    let deadline = Date().addingTimeInterval(3)
+    repeat {
+        if try aggregate.clockSource?.id == expectedID {
+            return true
+        }
+        Thread.sleep(forTimeInterval: 0.05)
+    } while Date() < deadline
+    return false
+}
+
+private func describe(_ object: AudioHardwareObject?) -> String {
+    guard let object else {
+        return "none"
+    }
+    let kind: String
+    if object is AudioHardwareTap {
+        kind = "tap"
+    } else if object is AudioHardwareDevice {
+        kind = "device"
+    } else if object is AudioHardwareClock {
+        kind = "clock"
+    } else {
+        kind = "object"
+    }
+    return "\(kind) \(object.id)"
+}
+
+private func stringProperty(
+    objectID: AudioObjectID,
+    selector: AudioObjectPropertySelector
+) throws -> String {
+    var address = AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var value: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    let status = withUnsafeMutablePointer(to: &value) {
+        AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, $0)
+    }
+    try check(status, operation: "AudioObjectGetPropertyData(string)")
+    guard size == UInt32(MemoryLayout<CFString>.size) else {
+        throw AggregateClockProbeError.unavailable(
+            "Core Audio returned an invalid string property size"
+        )
+    }
+    return value as String
+}
+
+private func check(_ status: OSStatus, operation: String) throws {
+    guard status == noErr else {
+        throw AggregateClockProbeError.coreAudio(operation: operation, status: status)
+    }
+}

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -26,6 +26,9 @@ private struct DiagnosticsOptions {
     var health = false
     var expectPermissionDenied = false
     var intentionalCrashAfterStart = false
+    var listOutputs = false
+    var clockSourceProbe = false
+    var outputObjectID: UInt32?
 
     init(arguments: [String]) throws {
         var positionalDuration: TimeInterval?
@@ -41,6 +44,19 @@ private struct DiagnosticsOptions {
                 expectPermissionDenied = true
             case "--intentional-crash-after-start":
                 intentionalCrashAfterStart = true
+            case "--list-outputs":
+                listOutputs = true
+            case "--clock-source-probe":
+                clockSourceProbe = true
+            case "--output-id":
+                index += 1
+                guard index < arguments.count else {
+                    throw DiagnosticsArgumentError.missingValue(argument)
+                }
+                outputObjectID = try Self.parseObjectID(arguments[index], option: argument)
+            case let value where value.hasPrefix("--output-id="):
+                let objectID = String(value.dropFirst("--output-id=".count))
+                outputObjectID = try Self.parseObjectID(objectID, option: "--output-id")
             case "--hold-after-start":
                 index += 1
                 guard index < arguments.count else {
@@ -71,11 +87,19 @@ private struct DiagnosticsOptions {
         }
         return seconds
     }
+
+    private static func parseObjectID(_ value: String, option: String) throws -> UInt32 {
+        guard let objectID = UInt32(value), objectID > 0 else {
+            throw DiagnosticsArgumentError.invalidObjectID(option: option, value: value)
+        }
+        return objectID
+    }
 }
 
 private enum DiagnosticsArgumentError: Error, CustomStringConvertible {
     case missingValue(String)
     case invalidSeconds(option: String, value: String)
+    case invalidObjectID(option: String, value: String)
     case unknownOption(String)
     case unexpectedArgument(String)
 
@@ -85,6 +109,8 @@ private enum DiagnosticsArgumentError: Error, CustomStringConvertible {
             return "\(option) requires a seconds value."
         case .invalidSeconds(let option, let value):
             return "\(option) requires a non-negative seconds value; got \(value)."
+        case .invalidObjectID(let option, let value):
+            return "\(option) requires a positive Core Audio object ID; got \(value)."
         case .unknownOption(let option):
             return "Unknown option \(option)."
         case .unexpectedArgument(let argument):
@@ -97,7 +123,17 @@ private func runDiagnostics(options: DiagnosticsOptions) -> Int32 {
     let engine = SystemTapAudioEngine()
 
     do {
-        let output = try CoreAudioDeviceQuery.defaultOutputDevice()
+        if options.listOutputs {
+            for output in try CoreAudioDeviceQuery.outputDevices() {
+                print("\(output.id)\t\(output.name)\t\(output.uid)")
+            }
+            return 0
+        }
+        let output = if let objectID = options.outputObjectID {
+            try CoreAudioDeviceQuery.outputDevice(id: objectID)
+        } else {
+            try CoreAudioDeviceQuery.defaultOutputDevice()
+        }
         print("GlassEQ diagnostics")
         if options.health {
             print("Mode: health")
@@ -111,6 +147,10 @@ private func runDiagnostics(options: DiagnosticsOptions) -> Int32 {
             print("Transport type: \(transportType)")
         }
 
+        if options.clockSourceProbe {
+            return runAggregateClockSourceProbe(output: output)
+        }
+
         printAudioEngineStatus(.starting)
         try engine.start(output: output, profile: .flatGraphic31)
         printAudioEngineStatus(engine.status)
@@ -118,7 +158,10 @@ private func runDiagnostics(options: DiagnosticsOptions) -> Int32 {
         if case .running(let activeOutput) = engine.state {
             print("Active buffer frames: \(activeOutput.bufferFrameSize)")
         }
-
+        if let latencyMetadata = engine.snapshotLatencyMetadata() {
+            printLatencyMetadata(latencyMetadata.physicalDevice, label: "Physical device")
+            printLatencyMetadata(latencyMetadata.aggregateDevice, label: "Combined aggregate")
+        }
         if options.intentionalCrashAfterStart {
             print("Intentional crash requested after engine start. Pending device setting restoration is persisted and retried on the next launch.")
             fflush(stdout)
@@ -129,7 +172,9 @@ private func runDiagnostics(options: DiagnosticsOptions) -> Int32 {
         Thread.sleep(forTimeInterval: options.holdAfterStart)
         let metrics = engine.snapshotMetrics()
         engine.stop()
-        printMetrics(metrics, fallbackSampleRate: output.nominalSampleRate)
+        let timestampProbeRecords = engine.snapshotTimestampProbeRecords()
+        printMetrics(metrics, sampleRate: output.nominalSampleRate)
+        printTimestampProbeRecords(timestampProbeRecords)
         printAudioEngineStatus(.stopped)
         print("Engine stopped cleanly.")
 
@@ -160,6 +205,39 @@ private func runDiagnostics(options: DiagnosticsOptions) -> Int32 {
         print("Expected permission denial, but observed a different failure.")
         return 1
     }
+}
+
+private func printLatencyMetadata(
+    _ metadata: AudioDeviceLatencyMetadata,
+    label: String
+) {
+    print("\(label) object ID: \(metadata.objectID)")
+    if let device = try? CoreAudioDeviceQuery.outputDevice(id: metadata.objectID) {
+        print("\(label) nominal sample rate: \(device.nominalSampleRate)")
+    } else {
+        print("\(label) nominal sample rate: unavailable")
+    }
+    print("\(label) buffer frames: \(optionalFrames(metadata.bufferFrameSize))")
+    print("\(label) input stream channels: \(optionalChannelCounts(metadata.inputStreamChannelCounts))")
+    print("\(label) output stream channels: \(optionalChannelCounts(metadata.outputStreamChannelCounts))")
+    print("\(label) input latency: \(optionalFrames(metadata.inputLatencyFrames))")
+    print("\(label) input safety offset: \(optionalFrames(metadata.inputSafetyOffsetFrames))")
+    print("\(label) input safety offset settable: \(optionalBoolean(metadata.inputSafetyOffsetSettable))")
+    print("\(label) output latency: \(optionalFrames(metadata.outputLatencyFrames))")
+    print("\(label) output safety offset: \(optionalFrames(metadata.outputSafetyOffsetFrames))")
+    print("\(label) output safety offset settable: \(optionalBoolean(metadata.outputSafetyOffsetSettable))")
+}
+
+private func optionalFrames(_ frames: UInt32?) -> String {
+    frames.map(String.init) ?? "unavailable"
+}
+
+private func optionalBoolean(_ value: Bool?) -> String {
+    value.map(String.init) ?? "unavailable"
+}
+
+private func optionalChannelCounts(_ counts: [Int]?) -> String {
+    counts.map { String(describing: $0) } ?? "unavailable"
 }
 
 private func audioEngineStatus(from state: AudioEngineState) -> AudioEngineStatus {
@@ -242,40 +320,97 @@ private func printAudioEngineFailure(_ failure: AudioEngineFailure) {
     }
 }
 
-private func printMetrics(_ metrics: AudioEngineMetrics, fallbackSampleRate: Double) {
-    let playbackBufferSampleRate = metrics.playbackBufferSampleRate > 0
-        ? metrics.playbackBufferSampleRate
-        : fallbackSampleRate
-    let playbackBufferMillisecondsPerFrame = 1_000 / playbackBufferSampleRate
+private func printMetrics(_ metrics: AudioEngineMetrics, sampleRate: Double) {
     print("Captured frames: \(metrics.capturedFrames)")
     print("Played frames: \(metrics.playedFrames)")
     print("Playback underrun frames: \(metrics.playbackUnderrunFrames)")
     print("Dropped input frames: \(metrics.droppedInputFrames)")
-    print("Dropped buffered frames: \(metrics.droppedBufferedFrames)")
-    print("Ring gate contention failures: \(metrics.ringGateContentionFailures)")
     print("Saturated samples: \(metrics.saturatedSamples)")
-    print("Buffered frames at stop: \(metrics.currentBufferedFrames)")
-    print("Max ring buffered frames: \(metrics.maxBufferedFrames)")
-    print("Max playback buffered frames: \(metrics.maximumPlaybackBufferedFrames)")
+    print("Input timestamp jumps: \(metrics.inputTimestampDiscontinuities)")
+    print("Output timestamp jumps: \(metrics.outputTimestampDiscontinuities)")
+    print("Paired timestamp jumps: \(metrics.pairedTimestampDiscontinuities)")
+    if metrics.pairedTimestampDiscontinuities > 0 {
+        print(String(
+            format: "Last input jump: %+.3f frames, host interval error %+.3f ms",
+            metrics.lastInputTimestampJumpFrames,
+            Double(metrics.lastInputHostIntervalErrorNanoseconds) / 1_000_000
+        ))
+        print(String(
+            format: "Last output jump: %+.3f frames, host interval error %+.3f ms",
+            metrics.lastOutputTimestampJumpFrames,
+            Double(metrics.lastOutputHostIntervalErrorNanoseconds) / 1_000_000
+        ))
+    }
+    if metrics.timestampJumpIntervalObservations > 0 {
+        print(String(
+            format: "Paired jump interval: %.3f ms average, %.3f to %.3f ms",
+            metrics.averageTimestampJumpIntervalNanoseconds / 1_000_000,
+            Double(metrics.minimumTimestampJumpIntervalNanoseconds) / 1_000_000,
+            Double(metrics.maximumTimestampJumpIntervalNanoseconds) / 1_000_000
+        ))
+    } else {
+        print("Paired jump interval: unavailable")
+    }
     print("Max capture callback frames: \(metrics.maximumCaptureCallbackFrames)")
     print("Max playback callback frames: \(metrics.maximumPlaybackCallbackFrames)")
-    print("Output timestamp discontinuities: \(metrics.playbackTimestampDiscontinuities)")
-    print("Playback buffer renegotiations: \(metrics.playbackBufferRenegotiations)")
-    print("Adaptive playback render failures: \(metrics.adaptivePlaybackRenderFailures)")
-    print("Sample-rate conversion active: \(metrics.playbackSampleRateConversionActive)")
-    print(String(format: "Playback rate correction: %+.2f ppm", metrics.playbackRateCorrectionPPM))
-    print("Playback rate correction saturated: \(metrics.playbackRateCorrectionSaturated)")
-    print("Playback occupancy target: \(metrics.playbackOccupancyTargetFrames) frames")
-    print(String(format: "Filtered playback occupancy: %.2f frames", metrics.filteredPlaybackOccupancyFrames))
-    print(String(
-        format: "Max playback buffered latency: %.2f ms",
-        Double(metrics.maximumPlaybackBufferedFrames) * playbackBufferMillisecondsPerFrame
-    ))
-    print("Playback latency observations: \(metrics.playbackBufferObservations)")
-    print(String(format: "GlassEQ added latency: min %.2f ms, avg %.2f ms, max %.2f ms",
-                 Double(metrics.minimumPlaybackBufferedFrames) * playbackBufferMillisecondsPerFrame,
-                 metrics.averagePlaybackBufferedFrames * playbackBufferMillisecondsPerFrame,
-                 Double(metrics.maximumPlaybackBufferedFrames) * playbackBufferMillisecondsPerFrame))
+    if metrics.tapToOutputLatencyObservations > 0 {
+        print(String(
+            format: "Tap-to-output latency: %.3f ms average, %.3f to %.3f ms",
+            metrics.averageTapToOutputLatencyNanoseconds / 1_000_000,
+            Double(metrics.minimumTapToOutputLatencyNanoseconds) / 1_000_000,
+            Double(metrics.maximumTapToOutputLatencyNanoseconds) / 1_000_000
+        ))
+    } else {
+        print("Tap-to-output latency: unavailable")
+    }
+    if metrics.callbackTimingObservations > 0 {
+        print(String(
+            format: "Input age: %.3f ms average, %.3f frames, %.3f to %.3f ms",
+            metrics.averageInputAgeNanoseconds / 1_000_000,
+            metrics.averageInputAgeNanoseconds * sampleRate / 1_000_000_000,
+            Double(metrics.minimumInputAgeNanoseconds) / 1_000_000,
+            Double(metrics.maximumInputAgeNanoseconds) / 1_000_000
+        ))
+        print(String(
+            format: "Output lead: %.3f ms average, %.3f frames, %.3f to %.3f ms",
+            metrics.averageOutputLeadNanoseconds / 1_000_000,
+            metrics.averageOutputLeadNanoseconds * sampleRate / 1_000_000_000,
+            Double(metrics.minimumOutputLeadNanoseconds) / 1_000_000,
+            Double(metrics.maximumOutputLeadNanoseconds) / 1_000_000
+        ))
+    } else {
+        print("Input age: unavailable")
+        print("Output lead: unavailable")
+    }
+}
+
+private func printTimestampProbeRecords(_ records: [AudioTimestampProbeRecord]) {
+    print("Timestamp probe records: \(records.count)")
+    for record in records {
+        print(
+            "Jump #\(record.sequence) callbacks=\(record.inputFrameCount)/\(record.outputFrameCount) "
+                + "inputJump=\(record.inputJumpDetected ? "yes" : "no") "
+                + "outputJump=\(record.outputJumpDetected ? "yes" : "no")"
+        )
+        print(String(
+            format: "  input  mSampleTime=%.6f mHostTime=%llu mRateScalar=%.12f mFlags=0x%08X delta=%+.3f frames hostError=%+.3f ms",
+            record.inputSampleTime,
+            record.inputHostTime,
+            record.inputRateScalar,
+            record.inputFlags,
+            record.inputSampleTimeDeltaFrames,
+            Double(record.inputHostIntervalErrorNanoseconds) / 1_000_000
+        ))
+        print(String(
+            format: "  output mSampleTime=%.6f mHostTime=%llu mRateScalar=%.12f mFlags=0x%08X delta=%+.3f frames hostError=%+.3f ms",
+            record.outputSampleTime,
+            record.outputHostTime,
+            record.outputRateScalar,
+            record.outputFlags,
+            record.outputSampleTimeDeltaFrames,
+            Double(record.outputHostIntervalErrorNanoseconds) / 1_000_000
+        ))
+    }
 }
 
 private struct DSPBenchmarkCase {
@@ -293,26 +428,40 @@ private func runDSPBenchmark() {
             profile: .flatParametric,
             sampleRate: 48_000,
             channelCount: 2,
-            frameCount: 256
+            frameCount: 16
         ),
         DSPBenchmarkCase(
-            name: "31-band graphic",
+            name: "31-band graphic at 48 kHz",
             profile: .flatGraphic31,
             sampleRate: 48_000,
             channelCount: 2,
-            frameCount: 256
+            frameCount: 16
+        ),
+        DSPBenchmarkCase(
+            name: "31-band graphic at 96 kHz",
+            profile: .flatGraphic31,
+            sampleRate: 96_000,
+            channelCount: 2,
+            frameCount: 16
+        ),
+        DSPBenchmarkCase(
+            name: "31-band graphic at 192 kHz",
+            profile: .flatGraphic31,
+            sampleRate: 192_000,
+            channelCount: 2,
+            frameCount: 16
         ),
         DSPBenchmarkCase(
             name: "Complex stereo",
             profile: complexStereoProfile(),
             sampleRate: 48_000,
             channelCount: 2,
-            frameCount: 256
+            frameCount: 16
         )
     ]
 
     print("GlassEQ DSP benchmark")
-    print("Measures CPU processing time only; Core Audio buffering and device latency are not included.")
+    print("Measures the 16-frame DSP workload; Core Audio buffering and device latency are not included.")
     print("Biquad EQ is in-place and has no fixed block/sample delay; recursive filters still have frequency-dependent phase/group delay.")
     print("")
 

--- a/Sources/GlassEQSettings/GlassEQSettingsApp.swift
+++ b/Sources/GlassEQSettings/GlassEQSettingsApp.swift
@@ -401,6 +401,8 @@ final class SettingsPipeClient: NSObject, SettingsPipeClientConnection, @uncheck
             model.commandErrorMessage = failure.message
         case .focusRequested:
             SettingsWindowFocus.request()
+        case .sectionRequested(let section):
+            SettingsWindowFocus.request(section: section)
         case .shutdown:
             NSApplication.shared.terminate(nil)
         }

--- a/Sources/GlassEQSettings/Info.plist
+++ b/Sources/GlassEQSettings/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.0</string>
+    <string>0.9.1</string>
     <key>CFBundleVersion</key>
-    <string>12</string>
+    <string>13</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -39,6 +39,61 @@ public enum SettingsProfileKind: String, Codable, Sendable {
     case parametric
 }
 
+public enum SettingsAggregateBufferMode: String, CaseIterable, Codable, Identifiable, Sendable {
+    case automatic
+    case frames16
+    case frames32
+    case frames64
+
+    public var id: String { rawValue }
+}
+
+public enum SettingsSection: String, Codable, Equatable, Sendable {
+    case editor
+    case importer
+    case output
+}
+
+public struct SettingsAggregateBufferDTO: Codable, Equatable, Sendable {
+    public var mode: SettingsAggregateBufferMode
+    public var automaticFrameSize: UInt32
+    public var isAvailable: Bool
+
+    public init(
+        mode: SettingsAggregateBufferMode = .automatic,
+        automaticFrameSize: UInt32 = 16,
+        isAvailable: Bool = false
+    ) {
+        self.mode = mode
+        self.automaticFrameSize = automaticFrameSize
+        self.isAvailable = isAvailable
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case automaticFrameSize
+        case isAvailable
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            mode: try container.decodeIfPresent(
+                SettingsAggregateBufferMode.self,
+                forKey: .mode
+            ) ?? .automatic,
+            automaticFrameSize: try container.decodeIfPresent(
+                UInt32.self,
+                forKey: .automaticFrameSize
+            ) ?? 16,
+            isAvailable: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .isAvailable
+            ) ?? false
+        )
+    }
+}
+
 public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var capturedFrames: UInt64
     public var playedFrames: UInt64
@@ -53,6 +108,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var minimumPlaybackBufferedFrames: Int
     public var averagePlaybackBufferedFrames: Double
     public var playbackBufferObservations: UInt64
+    public var inputTimestampDiscontinuities: UInt64
+    public var outputTimestampDiscontinuities: UInt64
     public var maximumCaptureCallbackFrames: Int
     public var maximumPlaybackCallbackFrames: Int
     public var playbackTimestampDiscontinuities: UInt64
@@ -64,6 +121,10 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var filteredPlaybackOccupancyFrames: Double
     public var playbackBufferSampleRate: Double
     public var playbackSampleRateConversionActive: Bool
+    public var tapToOutputLatencyObservations: UInt64
+    public var minimumTapToOutputLatencyNanoseconds: UInt64
+    public var maximumTapToOutputLatencyNanoseconds: UInt64
+    public var averageTapToOutputLatencyNanoseconds: Double
 
     private enum CodingKeys: String, CodingKey {
         case capturedFrames
@@ -79,6 +140,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case minimumPlaybackBufferedFrames
         case averagePlaybackBufferedFrames
         case playbackBufferObservations
+        case inputTimestampDiscontinuities
+        case outputTimestampDiscontinuities
         case maximumCaptureCallbackFrames
         case maximumPlaybackCallbackFrames
         case playbackTimestampDiscontinuities
@@ -90,6 +153,10 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case filteredPlaybackOccupancyFrames
         case playbackBufferSampleRate
         case playbackSampleRateConversionActive
+        case tapToOutputLatencyObservations
+        case minimumTapToOutputLatencyNanoseconds
+        case maximumTapToOutputLatencyNanoseconds
+        case averageTapToOutputLatencyNanoseconds
     }
 
     public init(
@@ -106,6 +173,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         minimumPlaybackBufferedFrames: Int = 0,
         averagePlaybackBufferedFrames: Double = 0,
         playbackBufferObservations: UInt64 = 0,
+        inputTimestampDiscontinuities: UInt64 = 0,
+        outputTimestampDiscontinuities: UInt64 = 0,
         maximumCaptureCallbackFrames: Int = 0,
         maximumPlaybackCallbackFrames: Int = 0,
         playbackTimestampDiscontinuities: UInt64 = 0,
@@ -116,7 +185,11 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         playbackOccupancyTargetFrames: Int = 0,
         filteredPlaybackOccupancyFrames: Double = 0,
         playbackBufferSampleRate: Double = 0,
-        playbackSampleRateConversionActive: Bool = false
+        playbackSampleRateConversionActive: Bool = false,
+        tapToOutputLatencyObservations: UInt64 = 0,
+        minimumTapToOutputLatencyNanoseconds: UInt64 = 0,
+        maximumTapToOutputLatencyNanoseconds: UInt64 = 0,
+        averageTapToOutputLatencyNanoseconds: Double = 0
     ) {
         self.capturedFrames = capturedFrames
         self.playedFrames = playedFrames
@@ -131,6 +204,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.minimumPlaybackBufferedFrames = minimumPlaybackBufferedFrames
         self.averagePlaybackBufferedFrames = averagePlaybackBufferedFrames
         self.playbackBufferObservations = playbackBufferObservations
+        self.inputTimestampDiscontinuities = inputTimestampDiscontinuities
+        self.outputTimestampDiscontinuities = outputTimestampDiscontinuities
         self.maximumCaptureCallbackFrames = maximumCaptureCallbackFrames
         self.maximumPlaybackCallbackFrames = maximumPlaybackCallbackFrames
         self.playbackTimestampDiscontinuities = playbackTimestampDiscontinuities
@@ -142,6 +217,10 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.filteredPlaybackOccupancyFrames = filteredPlaybackOccupancyFrames
         self.playbackBufferSampleRate = playbackBufferSampleRate
         self.playbackSampleRateConversionActive = playbackSampleRateConversionActive
+        self.tapToOutputLatencyObservations = tapToOutputLatencyObservations
+        self.minimumTapToOutputLatencyNanoseconds = minimumTapToOutputLatencyNanoseconds
+        self.maximumTapToOutputLatencyNanoseconds = maximumTapToOutputLatencyNanoseconds
+        self.averageTapToOutputLatencyNanoseconds = averageTapToOutputLatencyNanoseconds
     }
 
     public init(from decoder: any Decoder) throws {
@@ -160,6 +239,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             minimumPlaybackBufferedFrames: try container.decodeIfPresent(Int.self, forKey: .minimumPlaybackBufferedFrames) ?? 0,
             averagePlaybackBufferedFrames: try container.decodeIfPresent(Double.self, forKey: .averagePlaybackBufferedFrames) ?? 0,
             playbackBufferObservations: try container.decodeIfPresent(UInt64.self, forKey: .playbackBufferObservations) ?? 0,
+            inputTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .inputTimestampDiscontinuities) ?? 0,
+            outputTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .outputTimestampDiscontinuities) ?? 0,
             maximumCaptureCallbackFrames: try container.decodeIfPresent(Int.self, forKey: .maximumCaptureCallbackFrames) ?? 0,
             maximumPlaybackCallbackFrames: try container.decodeIfPresent(Int.self, forKey: .maximumPlaybackCallbackFrames) ?? 0,
             playbackTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .playbackTimestampDiscontinuities) ?? 0,
@@ -170,7 +251,11 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             playbackOccupancyTargetFrames: try container.decodeIfPresent(Int.self, forKey: .playbackOccupancyTargetFrames) ?? 0,
             filteredPlaybackOccupancyFrames: try container.decodeIfPresent(Double.self, forKey: .filteredPlaybackOccupancyFrames) ?? 0,
             playbackBufferSampleRate: try container.decodeIfPresent(Double.self, forKey: .playbackBufferSampleRate) ?? 0,
-            playbackSampleRateConversionActive: try container.decodeIfPresent(Bool.self, forKey: .playbackSampleRateConversionActive) ?? false
+            playbackSampleRateConversionActive: try container.decodeIfPresent(Bool.self, forKey: .playbackSampleRateConversionActive) ?? false,
+            tapToOutputLatencyObservations: try container.decodeIfPresent(UInt64.self, forKey: .tapToOutputLatencyObservations) ?? 0,
+            minimumTapToOutputLatencyNanoseconds: try container.decodeIfPresent(UInt64.self, forKey: .minimumTapToOutputLatencyNanoseconds) ?? 0,
+            maximumTapToOutputLatencyNanoseconds: try container.decodeIfPresent(UInt64.self, forKey: .maximumTapToOutputLatencyNanoseconds) ?? 0,
+            averageTapToOutputLatencyNanoseconds: try container.decodeIfPresent(Double.self, forKey: .averageTapToOutputLatencyNanoseconds) ?? 0
         )
     }
 }
@@ -227,6 +312,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
     public var fallbackProfileID: UUID?
     public var currentOutput: SettingsOutputDTO?
     public var currentOutputMappedProfileID: SettingsOptionalUUIDPatchDTO?
+    public var aggregateBuffer: SettingsAggregateBufferDTO?
     public var profileStoreProtection: SettingsProfileStoreProtectionDTO?
 
     public init(
@@ -240,6 +326,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
         fallbackProfileID: UUID? = nil,
         currentOutput: SettingsOutputDTO? = nil,
         currentOutputMappedProfileID: SettingsOptionalUUIDPatchDTO? = nil,
+        aggregateBuffer: SettingsAggregateBufferDTO? = nil,
         profileStoreProtection: SettingsProfileStoreProtectionDTO? = nil
     ) {
         self.statusMessage = statusMessage
@@ -252,6 +339,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
         self.fallbackProfileID = fallbackProfileID
         self.currentOutput = currentOutput
         self.currentOutputMappedProfileID = currentOutputMappedProfileID
+        self.aggregateBuffer = aggregateBuffer
         self.profileStoreProtection = profileStoreProtection
     }
 }
@@ -268,6 +356,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
     public var currentOutputChannelCount: Int
     public var currentOutputBufferFrameSize: UInt32
     public var currentOutputMappedProfileID: UUID?
+    public var aggregateBuffer: SettingsAggregateBufferDTO
     public var fallbackProfileID: UUID
     public var statusMessage: String
     public var metrics: SettingsAudioMetricsDTO
@@ -287,6 +376,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         case currentOutputChannelCount
         case currentOutputBufferFrameSize
         case currentOutputMappedProfileID
+        case aggregateBuffer
         case fallbackProfileID
         case statusMessage
         case metrics
@@ -307,6 +397,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         currentOutputChannelCount: Int,
         currentOutputBufferFrameSize: UInt32,
         currentOutputMappedProfileID: UUID?,
+        aggregateBuffer: SettingsAggregateBufferDTO = SettingsAggregateBufferDTO(),
         fallbackProfileID: UUID,
         statusMessage: String,
         metrics: SettingsAudioMetricsDTO,
@@ -325,6 +416,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         self.currentOutputChannelCount = currentOutputChannelCount
         self.currentOutputBufferFrameSize = currentOutputBufferFrameSize
         self.currentOutputMappedProfileID = currentOutputMappedProfileID
+        self.aggregateBuffer = aggregateBuffer
         self.fallbackProfileID = fallbackProfileID
         self.statusMessage = statusMessage
         self.metrics = metrics
@@ -347,6 +439,10 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
             currentOutputChannelCount: try container.decode(Int.self, forKey: .currentOutputChannelCount),
             currentOutputBufferFrameSize: try container.decode(UInt32.self, forKey: .currentOutputBufferFrameSize),
             currentOutputMappedProfileID: try container.decodeIfPresent(UUID.self, forKey: .currentOutputMappedProfileID),
+            aggregateBuffer: try container.decodeIfPresent(
+                SettingsAggregateBufferDTO.self,
+                forKey: .aggregateBuffer
+            ) ?? SettingsAggregateBufferDTO(),
             fallbackProfileID: try container.decode(UUID.self, forKey: .fallbackProfileID),
             statusMessage: try container.decode(String.self, forKey: .statusMessage),
             metrics: try container.decode(SettingsAudioMetricsDTO.self, forKey: .metrics),
@@ -373,6 +469,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
             currentOutputChannelCount: 0,
             currentOutputBufferFrameSize: 0,
             currentOutputMappedProfileID: nil,
+            aggregateBuffer: SettingsAggregateBufferDTO(),
             fallbackProfileID: profile.id,
             statusMessage: "Connecting to GlassEQ...",
             metrics: SettingsAudioMetricsDTO(),
@@ -394,7 +491,8 @@ public enum SettingsCommand: Codable, Equatable, Sendable {
     case preview(EQProfile)
     case stopPreview
     case resetDiagnostics
-    case resetPlaybackBufferCalibration
+    case setAggregateBufferMode(SettingsAggregateBufferMode)
+    case retryAutomaticAggregateBuffer
     case retryAudioEngine
     case openPrivacySettings
     case startMetricsPolling
@@ -428,6 +526,7 @@ public enum SettingsEvent: Codable, Equatable, Sendable {
     case metricsChanged(SettingsAudioMetricsDTO)
     case commandFailed(SettingsCommandFailure)
     case focusRequested
+    case sectionRequested(SettingsSection)
     case shutdown
 }
 

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -178,18 +178,6 @@ private func localizedFrameCount(_ value: UInt32) -> String {
     return value == 1 ? localized("\(number) frame") : localized("\(number) frames")
 }
 
-func canResetPlaybackBufferCalibration(isRunning: Bool, outputUID: String) -> Bool {
-    isRunning && !outputUID.isEmpty
-}
-
-func sampleRateConversionIsActive(isRunning: Bool, metricsActive: Bool) -> Bool {
-    isRunning && metricsActive
-}
-
-func clockCorrectionLimitIsReached(isRunning: Bool, metricsSaturated: Bool) -> Bool {
-    isRunning && metricsSaturated
-}
-
 func settingsCanDeleteSelectedProfile(_ snapshot: SettingsSnapshot) -> Bool {
     !snapshot.profileStoreProtection.isProtected
         && snapshot.profiles.count > 1
@@ -239,8 +227,23 @@ private extension Notification.Name {
 
 @MainActor
 public enum SettingsWindowFocus {
-    public static func request() {
-        NotificationCenter.default.post(name: .glassEQBringSettingsToFront, object: nil)
+    private static var pendingSection: SettingsSection?
+
+    public static func request(section: SettingsSection? = nil) {
+        if let section {
+            pendingSection = section
+        }
+        NotificationCenter.default.post(
+            name: .glassEQBringSettingsToFront,
+            object: section
+        )
+    }
+
+    static func consumePendingSection() -> SettingsSection? {
+        defer {
+            pendingSection = nil
+        }
+        return pendingSection
     }
 }
 
@@ -286,7 +289,8 @@ public struct SettingsView: View {
                 onPreview: previewDraft,
                 onStopPreview: stopPreview,
                 onResetDiagnostics: resetDiagnostics,
-                onResetPlaybackBufferCalibration: resetPlaybackBufferCalibration,
+                onSetAggregateBufferMode: setAggregateBufferMode,
+                onRetryAutomaticAggregateBuffer: retryAutomaticAggregateBuffer,
                 onRetryAudioEngine: retryAudioEngine,
                 onOpenPrivacySettings: openPrivacySettings,
                 onResetUnsupportedProfileStore: resetUnsupportedProfileStore
@@ -317,6 +321,9 @@ public struct SettingsView: View {
             refreshSnapshotFromModel()
         }
         .onAppear {
+            if let requestedSection = SettingsWindowFocus.consumePendingSection() {
+                tab = EditorSection(requestedSection)
+            }
             refreshSnapshotFromModel()
             updateMetricsPolling()
         }
@@ -325,6 +332,14 @@ public struct SettingsView: View {
         }
         .onChange(of: tab) { _, _ in
             updateMetricsPolling()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .glassEQBringSettingsToFront)
+        ) { notification in
+            if let requestedSection = notification.object as? SettingsSection {
+                tab = EditorSection(requestedSection)
+                _ = SettingsWindowFocus.consumePendingSection()
+            }
         }
     }
 
@@ -388,8 +403,12 @@ public struct SettingsView: View {
         perform(.resetDiagnostics)
     }
 
-    private func resetPlaybackBufferCalibration() {
-        perform(.resetPlaybackBufferCalibration)
+    private func setAggregateBufferMode(_ mode: SettingsAggregateBufferMode) {
+        perform(.setAggregateBufferMode(mode))
+    }
+
+    private func retryAutomaticAggregateBuffer() {
+        perform(.retryAutomaticAggregateBuffer)
     }
 
     private func retryAudioEngine() {
@@ -953,7 +972,8 @@ private struct ProfileDetail: View {
     var onPreview: () -> Void
     var onStopPreview: () -> Void
     var onResetDiagnostics: () -> Void
-    var onResetPlaybackBufferCalibration: () -> Void
+    var onSetAggregateBufferMode: (SettingsAggregateBufferMode) -> Void
+    var onRetryAutomaticAggregateBuffer: () -> Void
     var onRetryAudioEngine: () -> Void
     var onOpenPrivacySettings: () -> Void
     var onResetUnsupportedProfileStore: () -> Void
@@ -1003,7 +1023,8 @@ private struct ProfileDetail: View {
                                 onUseForCurrentOutput: onUseForCurrentOutput,
                                 onSetFallback: onSetFallback,
                                 onResetDiagnostics: onResetDiagnostics,
-                                onResetPlaybackBufferCalibration: onResetPlaybackBufferCalibration,
+                                onSetAggregateBufferMode: onSetAggregateBufferMode,
+                                onRetryAutomaticAggregateBuffer: onRetryAutomaticAggregateBuffer,
                                 onRetryAudioEngine: onRetryAudioEngine,
                                 onOpenPrivacySettings: onOpenPrivacySettings
                             )
@@ -1159,6 +1180,17 @@ private enum EditorSection: String, CaseIterable, Identifiable {
     case output
 
     var id: String { rawValue }
+
+    init(_ section: SettingsSection) {
+        switch section {
+        case .editor:
+            self = .editor
+        case .importer:
+            self = .importer
+        case .output:
+            self = .output
+        }
+    }
 
     var title: String {
         switch self {
@@ -2302,7 +2334,8 @@ private struct OutputTab: View {
     var onUseForCurrentOutput: () -> Void
     var onSetFallback: () -> Void
     var onResetDiagnostics: () -> Void
-    var onResetPlaybackBufferCalibration: () -> Void
+    var onSetAggregateBufferMode: (SettingsAggregateBufferMode) -> Void
+    var onRetryAutomaticAggregateBuffer: () -> Void
     var onRetryAudioEngine: () -> Void
     var onOpenPrivacySettings: () -> Void
 
@@ -2319,6 +2352,40 @@ private struct OutputTab: View {
                     LabeledContent(localized("Sample Rate"), value: sampleRateLabel)
                     LabeledContent(localized("Channels"), value: localizedInteger(snapshot.currentOutputChannelCount))
                     LabeledContent(localized("Buffer"), value: localizedFrameCount(snapshot.currentOutputBufferFrameSize))
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .cardPanel(padding: 16)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(localized("Audio Buffer"))
+                        .font(.headline)
+                    Picker(
+                        localized("Audio Buffer"),
+                        selection: Binding(
+                            get: { snapshot.aggregateBuffer.mode },
+                            set: { onSetAggregateBufferMode($0) }
+                        )
+                    ) {
+                        Text(localized("Automatic")).tag(SettingsAggregateBufferMode.automatic)
+                        Text(localized("16 frames")).tag(SettingsAggregateBufferMode.frames16)
+                        Text(localized("32 frames")).tag(SettingsAggregateBufferMode.frames32)
+                        Text(localized("64 frames")).tag(SettingsAggregateBufferMode.frames64)
+                    }
+                    .labelsHidden()
+                    .disabled(!snapshot.aggregateBuffer.isAvailable)
+
+                    Text(aggregateBufferExplanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if snapshot.aggregateBuffer.mode == .automatic,
+                       snapshot.aggregateBuffer.automaticFrameSize > 16 {
+                        Button(localized("Retry 16 frames")) {
+                            onRetryAutomaticAggregateBuffer()
+                        }
+                        .controlSize(.large)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .cardPanel(padding: 16)
@@ -2374,55 +2441,35 @@ private struct OutputTab: View {
                     LabeledContent(localized("Played"), value: localizedInteger(snapshot.metrics.playedFrames))
                     LabeledContent(localized("Underruns"), value: localizedInteger(snapshot.metrics.playbackUnderrunFrames))
                     LabeledContent(localized("Dropped Input"), value: localizedInteger(snapshot.metrics.droppedInputFrames))
-                    LabeledContent(localized("Dropped Buffered"), value: localizedInteger(snapshot.metrics.droppedBufferedFrames))
-                    LabeledContent(localized("Ring Gate Failures"), value: localizedInteger(snapshot.metrics.ringGateContentionFailures))
                     LabeledContent(localized("Saturated Samples"), value: localizedInteger(snapshot.metrics.saturatedSamples))
-                    LabeledContent(localized("Buffered"), value: localizedFrameCount(snapshot.metrics.currentBufferedFrames))
-                    LabeledContent(localized("Peak Buffer"), value: localizedFrameCount(snapshot.metrics.maximumPlaybackBufferedFrames))
-                    LabeledContent(localized("Ring Peak"), value: localizedFrameCount(snapshot.metrics.maxBufferedFrames))
                     LabeledContent(localized("Capture Callback Peak"), value: localizedFrameCount(snapshot.metrics.maximumCaptureCallbackFrames))
                     LabeledContent(localized("Output Callback Peak"), value: localizedFrameCount(snapshot.metrics.maximumPlaybackCallbackFrames))
-                    LabeledContent(localized("Output Timing Gaps"), value: localizedInteger(snapshot.metrics.playbackTimestampDiscontinuities))
-                    LabeledContent(localized("Buffer Renegotiations"), value: localizedInteger(snapshot.metrics.playbackBufferRenegotiations))
-                    LabeledContent(localized("Adaptive Render Failures"), value: localizedInteger(snapshot.metrics.adaptivePlaybackRenderFailures))
-                    LabeledContent(
-                        localized("Sample Rate Conversion"),
-                        value: sampleRateConversionIsActive(
-                            isRunning: snapshot.isRunning,
-                            metricsActive: snapshot.metrics.playbackSampleRateConversionActive
+                    if usesSeparateClockDiagnostics {
+                        LabeledContent(localized("Dropped Buffered"), value: localizedInteger(snapshot.metrics.droppedBufferedFrames))
+                        LabeledContent(localized("Ring Gate Failures"), value: localizedInteger(snapshot.metrics.ringGateContentionFailures))
+                        LabeledContent(localized("Buffered"), value: localizedFrameCount(snapshot.metrics.currentBufferedFrames))
+                        LabeledContent(localized("Peak Buffer"), value: localizedFrameCount(snapshot.metrics.maximumPlaybackBufferedFrames))
+                        LabeledContent(localized("Output Timing Gaps"), value: localizedInteger(snapshot.metrics.playbackTimestampDiscontinuities))
+                        LabeledContent(
+                            localized("Sample Rate Conversion"),
+                            value: snapshot.metrics.playbackSampleRateConversionActive
+                                ? localized("Active")
+                                : localized("Inactive")
                         )
-                            ? localized("Active")
-                            : localized("Inactive")
-                    )
-                    LabeledContent(localized("Clock Correction"), value: playbackRateCorrectionLabel)
-                    LabeledContent(
-                        localized("Clock Correction Limit"),
-                        value: clockCorrectionLimitIsReached(
-                            isRunning: snapshot.isRunning,
-                            metricsSaturated: snapshot.metrics.playbackRateCorrectionSaturated
-                        )
-                            ? localized("Reached")
-                            : localized("Not reached")
-                    )
-                    LabeledContent(localized("Servo Buffer"), value: servoBufferLabel)
-                    LabeledContent(localized("Added Latency"), value: averageAddedLatencyLabel)
-                    LabeledContent(localized("Latency Range"), value: addedLatencyRangeLabel)
-                    HStack {
-                        Button(localized("Reset metrics")) {
-                            onResetDiagnostics()
-                        }
-                        .controlSize(.large)
-
-                        Button(localized("Reset buffer calibration for this device")) {
-                            onResetPlaybackBufferCalibration()
-                        }
-                        .disabled(!canResetPlaybackBufferCalibration(
-                            isRunning: snapshot.isRunning,
-                            outputUID: snapshot.currentOutputUID
-                        ))
-                        .controlSize(.large)
-                        .help(localized("Forget the learned callback size for this output device and calibrate it again"))
+                        LabeledContent(localized("Clock Correction"), value: playbackRateCorrectionLabel)
+                        LabeledContent(localized("Servo Buffer"), value: servoBufferLabel)
+                        LabeledContent(localized("Bridge Latency"), value: bridgeLatencyLabel)
+                        LabeledContent(localized("Bridge Latency Range"), value: bridgeLatencyRangeLabel)
+                    } else {
+                        LabeledContent(localized("Input Timestamp Jumps"), value: localizedInteger(snapshot.metrics.inputTimestampDiscontinuities))
+                        LabeledContent(localized("Output Timestamp Jumps"), value: localizedInteger(snapshot.metrics.outputTimestampDiscontinuities))
+                        LabeledContent(localized("Tap-to-Output Latency"), value: tapToOutputLatencyLabel)
+                        LabeledContent(localized("Tap-to-Output Range"), value: tapToOutputLatencyRangeLabel)
                     }
+                    Button(localized("Reset metrics")) {
+                        onResetDiagnostics()
+                    }
+                    .controlSize(.large)
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .cardPanel(padding: 16)
@@ -2440,6 +2487,20 @@ private struct OutputTab: View {
         return profile.name
     }
 
+    private var aggregateBufferExplanation: String {
+        guard snapshot.aggregateBuffer.isAvailable else {
+            return localized("This route uses GlassEQ's compatibility audio path.")
+        }
+        if snapshot.aggregateBuffer.mode == .automatic {
+            return localized(
+                "Automatic uses the smallest buffer proven reliable for this device stream and sample rate. It is currently \(snapshot.aggregateBuffer.automaticFrameSize) frames."
+            )
+        }
+        return localized(
+            "A fixed buffer disables automatic reliability fallback for this route."
+        )
+    }
+
     private var sampleRateLabel: String {
         guard snapshot.currentOutputSampleRate > 0 else {
             return localized("Unknown")
@@ -2447,26 +2508,59 @@ private struct OutputTab: View {
         return localizedFrequency(snapshot.currentOutputSampleRate)
     }
 
-    private var averageAddedLatencyLabel: String {
-        guard snapshot.metrics.playbackBufferObservations > 0 else {
+    private var tapToOutputLatencyLabel: String {
+        guard snapshot.metrics.tapToOutputLatencyObservations > 0 else {
             return localized("No samples")
         }
-        return formatLatency(milliseconds: framesToMilliseconds(snapshot.metrics.averagePlaybackBufferedFrames))
+        return localizedLatency(
+            milliseconds: snapshot.metrics.averageTapToOutputLatencyNanoseconds / 1_000_000
+        )
     }
 
-    private var addedLatencyRangeLabel: String {
-        guard snapshot.metrics.playbackBufferObservations > 0 else {
+    private var tapToOutputLatencyRangeLabel: String {
+        guard snapshot.metrics.tapToOutputLatencyObservations > 0 else {
             return localized("No samples")
         }
-        let minimum = formatLatency(milliseconds: framesToMilliseconds(Double(snapshot.metrics.minimumPlaybackBufferedFrames)))
-        let maximum = formatLatency(milliseconds: framesToMilliseconds(Double(snapshot.metrics.maximumPlaybackBufferedFrames)))
-        return "\(minimum)-\(maximum)"
+        let minimum = localizedLatency(
+            milliseconds: Double(snapshot.metrics.minimumTapToOutputLatencyNanoseconds) / 1_000_000
+        )
+        let maximum = localizedLatency(
+            milliseconds: Double(snapshot.metrics.maximumTapToOutputLatencyNanoseconds) / 1_000_000
+        )
+        return localized("\(minimum) to \(maximum)")
+    }
+
+    private var usesSeparateClockDiagnostics: Bool {
+        snapshot.metrics.playbackBufferObservations > 0
+    }
+
+    private var bridgeLatencyLabel: String {
+        localizedLatency(
+            milliseconds: playbackFramesToMilliseconds(
+                snapshot.metrics.averagePlaybackBufferedFrames,
+                bufferSampleRate: snapshot.metrics.playbackBufferSampleRate,
+                fallbackSampleRate: snapshot.currentOutputSampleRate
+            )
+        )
+    }
+
+    private var bridgeLatencyRangeLabel: String {
+        let minimum = playbackFramesToMilliseconds(
+            Double(snapshot.metrics.minimumPlaybackBufferedFrames),
+            bufferSampleRate: snapshot.metrics.playbackBufferSampleRate,
+            fallbackSampleRate: snapshot.currentOutputSampleRate
+        )
+        let maximum = playbackFramesToMilliseconds(
+            Double(snapshot.metrics.maximumPlaybackBufferedFrames),
+            bufferSampleRate: snapshot.metrics.playbackBufferSampleRate,
+            fallbackSampleRate: snapshot.currentOutputSampleRate
+        )
+        return localized(
+            "\(localizedLatency(milliseconds: minimum)) to \(localizedLatency(milliseconds: maximum))"
+        )
     }
 
     private var playbackRateCorrectionLabel: String {
-        guard snapshot.isRunning else {
-            return localized("Inactive")
-        }
         let correction = localizedDecimal(
             snapshot.metrics.playbackRateCorrectionPPM,
             minimumFractionDigits: 1,
@@ -2477,9 +2571,6 @@ private struct OutputTab: View {
     }
 
     private var servoBufferLabel: String {
-        guard snapshot.isRunning else {
-            return localized("Inactive")
-        }
         let occupancy = localizedDecimal(
             snapshot.metrics.filteredPlaybackOccupancyFrames,
             minimumFractionDigits: 1,
@@ -2489,17 +2580,6 @@ private struct OutputTab: View {
         return localized("\(occupancy) / \(target) frames")
     }
 
-    private func framesToMilliseconds(_ frames: Double) -> Double {
-        playbackFramesToMilliseconds(
-            frames,
-            bufferSampleRate: snapshot.metrics.playbackBufferSampleRate,
-            fallbackSampleRate: snapshot.currentOutputSampleRate
-        )
-    }
-
-    private func formatLatency(milliseconds: Double) -> String {
-        localizedLatency(milliseconds: milliseconds)
-    }
 }
 
 private extension EQMode {

--- a/Sources/GlassEQSettingsUI/SettingsViewModel.swift
+++ b/Sources/GlassEQSettingsUI/SettingsViewModel.swift
@@ -69,6 +69,9 @@ public final class GlassEQSettingsViewModel {
         if let profileStoreProtection = patch.profileStoreProtection {
             snapshot.profileStoreProtection = profileStoreProtection
         }
+        if let aggregateBuffer = patch.aggregateBuffer {
+            snapshot.aggregateBuffer = aggregateBuffer
+        }
         switch patch.currentOutputMappedProfileID {
         case .set(let profileID):
             snapshot.currentOutputMappedProfileID = profileID

--- a/Tests/GlassEQAppTests/AggregateBufferNotifierTests.swift
+++ b/Tests/GlassEQAppTests/AggregateBufferNotifierTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+import UserNotifications
+@testable import GlassEQApp
+
+@MainActor
+@Suite
+struct AggregateBufferNotifierTests {
+    @Test
+    func notificationSetupIsDisabledOutsideAnAppBundle() {
+        #expect(!AggregateBufferNotifier.canUseUserNotifications(
+            bundleURL: URL(fileURLWithPath: "/tmp/GlassEQ")
+        ))
+        AggregateBufferNotifier.shared.start()
+    }
+
+    @Test
+    func outputSettingsActionDoesNotRelaunchTheMainApp() throws {
+        let category = AggregateBufferNotifier.notificationCategory()
+        let action = try #require(category.actions.first)
+
+        #expect(!action.options.contains(.foreground))
+    }
+}

--- a/Tests/GlassEQAppTests/AggregateBufferPolicyTests.swift
+++ b/Tests/GlassEQAppTests/AggregateBufferPolicyTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import GlassEQAudio
+import GlassEQSettingsIPC
+import Testing
+@testable import GlassEQApp
+
+@MainActor
+@Suite
+struct AggregateBufferPolicyTests {
+    @Test
+    func automaticBufferClimbsTheReliabilityLadderAndPersists() throws {
+        let url = temporaryPolicyURL()
+        let route = fingerprint(uid: "route", stream: 1, sampleRate: 48_000)
+        let store = AggregateBufferPolicyStore(url: url)
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        #expect(store.selection(for: route).frameSize == 16)
+        #expect(try store.recordAutomaticFailure(for: route, at: start) == nil)
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            at: start.addingTimeInterval(1)
+        ) == 32)
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            at: start.addingTimeInterval(2)
+        ) == nil)
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            at: start.addingTimeInterval(3)
+        ) == 64)
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            occurrences: 2,
+            at: start.addingTimeInterval(4)
+        ) == nil)
+
+        let reloaded = AggregateBufferPolicyStore(url: url)
+        #expect(reloaded.selection(for: route).automaticFrameSize == 64)
+        #expect(reloaded.selection(for: route).frameSize == 64)
+    }
+
+    @Test
+    func learningIsIsolatedByDeviceStreamAndSampleRate() throws {
+        let store = AggregateBufferPolicyStore(url: temporaryPolicyURL())
+        let learned = fingerprint(uid: "device", stream: 0, sampleRate: 48_000)
+        let otherStream = fingerprint(uid: "device", stream: 1, sampleRate: 48_000)
+        let otherRate = fingerprint(uid: "device", stream: 0, sampleRate: 96_000)
+
+        #expect(try store.recordAutomaticFailure(for: learned, occurrences: 2) == 32)
+
+        #expect(store.selection(for: learned).frameSize == 32)
+        #expect(store.selection(for: otherStream).frameSize == 16)
+        #expect(store.selection(for: otherRate).frameSize == 16)
+    }
+
+    @Test
+    func fixedModeSuppressesLearningAndRetryRestoresAutomaticSixteen() throws {
+        let store = AggregateBufferPolicyStore(url: temporaryPolicyURL())
+        let route = fingerprint(uid: "fixed", stream: 0, sampleRate: 48_000)
+
+        try store.setMode(.frames16, for: route)
+        #expect(try store.recordAutomaticFailure(for: route) == nil)
+        #expect(store.selection(for: route).mode == .frames16)
+
+        try store.setMode(.automatic, for: route)
+        #expect(try store.recordAutomaticFailure(for: route) == nil)
+        #expect(try store.recordAutomaticFailure(for: route) == 32)
+        try store.retryAutomaticBuffer(for: route)
+
+        #expect(store.selection(for: route).mode == .automatic)
+        #expect(store.selection(for: route).frameSize == 16)
+    }
+
+    @Test
+    func failedPersistenceDoesNotChangeTheInMemorySelection() {
+        let store = AggregateBufferPolicyStore(
+            url: URL(fileURLWithPath: "/dev/null/aggregate-buffer-policy.json")
+        )
+        let route = fingerprint(uid: "unwritable", stream: 0, sampleRate: 48_000)
+
+        #expect(throws: (any Error).self) {
+            try store.recordAutomaticFailure(for: route)
+        }
+        #expect(store.selection(for: route).frameSize == 16)
+    }
+
+    @Test
+    func isolatedFailuresOutsideTheFiveMinuteWindowDoNotIncreaseTheBuffer() throws {
+        let store = AggregateBufferPolicyStore(url: temporaryPolicyURL())
+        let route = fingerprint(uid: "isolated", stream: 0, sampleRate: 48_000)
+        let start = Date(timeIntervalSince1970: 2_000)
+
+        #expect(try store.recordAutomaticFailure(for: route, at: start) == nil)
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            at: start.addingTimeInterval(AggregateBufferPolicyStore.failureWindow + 1)
+        ) == nil)
+        #expect(store.selection(for: route).frameSize == 16)
+    }
+
+    @Test
+    func failureEvidenceSurvivesRelaunchWithinTheWindow() throws {
+        let url = temporaryPolicyURL()
+        let route = fingerprint(uid: "persisted-evidence", stream: 0, sampleRate: 48_000)
+        let start = Date(timeIntervalSince1970: 3_000)
+        let store = AggregateBufferPolicyStore(url: url)
+
+        #expect(try store.recordAutomaticFailure(for: route, at: start) == nil)
+
+        let reloaded = AggregateBufferPolicyStore(url: url)
+        #expect(try reloaded.recordAutomaticFailure(
+            for: route,
+            at: start.addingTimeInterval(10)
+        ) == 32)
+    }
+
+    @Test
+    func threeCleanSessionsRetryOneLowerRungAtATime() throws {
+        let store = AggregateBufferPolicyStore(url: temporaryPolicyURL())
+        let route = fingerprint(uid: "clean", stream: 0, sampleRate: 48_000)
+
+        #expect(try store.recordAutomaticFailure(for: route, occurrences: 2) == 32)
+        #expect(try store.recordAutomaticFailure(for: route, occurrences: 2) == 64)
+
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == 32)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == 16)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+    }
+
+    @Test
+    func aFailureResetsCleanSessionProgress() throws {
+        let store = AggregateBufferPolicyStore(url: temporaryPolicyURL())
+        let route = fingerprint(uid: "reset-clean", stream: 0, sampleRate: 48_000)
+        let start = Date(timeIntervalSince1970: 4_000)
+
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            occurrences: 2,
+            at: start
+        ) == 32)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordAutomaticFailure(
+            for: route,
+            at: start.addingTimeInterval(1)
+        ) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try store.recordCleanAutomaticSession(for: route) == 16)
+    }
+
+    @Test
+    func legacyOneShotLearningIsResetButFixedModeIsPreserved() throws {
+        let url = temporaryPolicyURL()
+        let data = Data(
+            """
+            {
+              "records" : [
+                {
+                  "automaticFrameSize" : 64,
+                  "mode" : "automatic",
+                  "route" : {
+                    "nativeOutputStreamIndex" : 0,
+                    "nominalSampleRate" : 48000,
+                    "outputDeviceUID" : "legacy-automatic"
+                  }
+                },
+                {
+                  "automaticFrameSize" : 64,
+                  "mode" : "frames32",
+                  "route" : {
+                    "nativeOutputStreamIndex" : 0,
+                    "nominalSampleRate" : 48000,
+                    "outputDeviceUID" : "legacy-fixed"
+                  }
+                }
+              ],
+              "schemaVersion" : 1
+            }
+            """.utf8
+        )
+        try data.write(to: url)
+
+        let store = AggregateBufferPolicyStore(url: url)
+        let automatic = fingerprint(
+            uid: "legacy-automatic",
+            stream: 0,
+            sampleRate: 48_000
+        )
+        let fixed = fingerprint(uid: "legacy-fixed", stream: 0, sampleRate: 48_000)
+
+        #expect(store.selection(for: automatic).mode == .automatic)
+        #expect(store.selection(for: automatic).frameSize == 16)
+        #expect(store.selection(for: fixed).mode == .frames32)
+        #expect(store.selection(for: fixed).frameSize == 32)
+    }
+
+    private func fingerprint(
+        uid: String,
+        stream: Int,
+        sampleRate: Double
+    ) -> AggregateAudioRouteFingerprint {
+        AggregateAudioRouteFingerprint(
+            outputDeviceUID: uid,
+            nativeOutputStreamIndex: stream,
+            nominalSampleRate: sampleRate
+        )
+    }
+
+    private func temporaryPolicyURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("AggregateBufferPolicyTests-\(UUID().uuidString).json")
+    }
+}

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -10,6 +10,349 @@ import Testing
 @Suite
 struct GlassEQAppModelLifecycleTests {
     @Test
+    func runtimeEngineFailureStopsTheModelAndSurfacesItsStatus() async {
+        let output = makeOutput(uid: "runtime-output", name: "Runtime Output")
+        let engine = FakeAudioEngine()
+        engine.state = .running(output: output)
+        let model = makeModel(engine: engine)
+
+        model.retryAudioEngine()
+        await waitUntil {
+            model.lifecycleState == .running
+        }
+        engine.emitRuntimeFailure(adaptiveRenderFailure)
+        await waitUntil {
+            model.lifecycleState == .stopped
+        }
+
+        #expect(!model.isRunning)
+        #expect(model.statusMessage == localized(
+            "Audio engine failed: \(adaptiveRenderFailure.userMessage)"
+        ))
+    }
+
+    @Test
+    func runtimeFailureDoesNotCancelNewerPendingRouteStart() async {
+        let firstOutput = makeOutput(uid: "runtime-first", name: "Runtime First", id: 200)
+        let secondOutput = makeOutput(uid: "runtime-second", name: "Runtime Second", id: 300)
+        let engine = FakeAudioEngine()
+        let lookup = FakeDefaultOutputLookup(.success(firstOutput))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero
+        )
+
+        model.start()
+        let observer = observers.observers[0]
+        observer.emit(.success(firstOutput))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        engine.blockStart(for: secondOutput.uid)
+        lookup.result = .success(secondOutput)
+        observer.emit(.success(secondOutput))
+        await waitUntil {
+            engine.startCalls.contains { $0.output == secondOutput }
+        }
+        #expect(engine.waitUntilStartIsBlocked(for: secondOutput.uid, timeout: .now() + 1))
+
+        engine.emitRuntimeFailure(adaptiveRenderFailure)
+        await settleAsyncWork()
+        #expect(model.lifecycleState == .running)
+
+        engine.unblockStart(for: secondOutput.uid)
+        await waitUntil {
+            model.lifecycleState == .running
+                && model.currentOutputUID == secondOutput.uid
+                && engine.state == .running(output: secondOutput)
+        }
+    }
+
+    @Test
+    func staleRuntimeFailureDoesNotStopCompletedNewerRoute() async {
+        let firstOutput = makeOutput(uid: "stale-runtime-first", name: "Stale Runtime First", id: 200)
+        let secondOutput = makeOutput(uid: "stale-runtime-second", name: "Stale Runtime Second", id: 300)
+        let engine = FakeAudioEngine()
+        let lookup = FakeDefaultOutputLookup(.success(firstOutput))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero
+        )
+
+        model.start()
+        let observer = observers.observers[0]
+        observer.emit(.success(firstOutput))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+        lookup.result = .success(secondOutput)
+        observer.emit(.success(secondOutput))
+        await waitUntil {
+            model.lifecycleState == .running
+                && model.currentOutputUID == secondOutput.uid
+                && engine.state == .running(output: secondOutput)
+        }
+
+        engine.emitRuntimeFailure(adaptiveRenderFailure, markEngineFailed: false)
+        await settleAsyncWork()
+
+        #expect(model.lifecycleState == .running)
+        #expect(model.isRunning)
+        #expect(model.currentOutputUID == secondOutput.uid)
+        #expect(engine.state == .running(output: secondOutput))
+    }
+
+    @Test
+    func settledHeadsetRoutePromotesToCombinedAggregate() async {
+        let output = makeOutput(
+            uid: "headset-promotion",
+            name: "AirPods Headset",
+            nominalSampleRate: 24_000,
+            bufferFrameSize: 480
+        )
+        let engine = FakeAudioEngine()
+        engine.headsetPromotionCandidateUIDs = [output.uid]
+        engine.headsetAggregatePromotionResult = .promoted(output)
+        let lookup = FakeDefaultOutputLookup(.success(output))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero,
+            aggregateStabilityDelay: .seconds(1),
+            headsetAggregatePromotionDelay: .zero
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            engine.headsetAggregatePromotionAttemptCount == 1
+                && engine.isUsingPromotedHeadsetAggregate
+        }
+
+        #expect(engine.startCalls.count == 1)
+        #expect(model.statusMessage.contains("low-latency headset path"))
+    }
+
+    @Test
+    func promotedHeadsetRouteFallsBackAfterOneSteadyStateJump() async {
+        let output = makeOutput(
+            uid: "headset-demotion",
+            name: "AirPods Headset",
+            nominalSampleRate: 24_000,
+            bufferFrameSize: 480
+        )
+        let engine = FakeAudioEngine()
+        engine.headsetPromotionCandidateUIDs = [output.uid]
+        engine.headsetAggregatePromotionResult = .promoted(output)
+        let lookup = FakeDefaultOutputLookup(.success(output))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero,
+            headsetAggregatePromotionDelay: .zero
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            engine.headsetAggregatePromotionAttemptCount == 1
+                && engine.isUsingPromotedHeadsetAggregate
+        }
+        try? await Task.sleep(for: .milliseconds(300))
+
+        var metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 1
+        engine.metrics = metrics
+        await waitUntil {
+            engine.startCalls.count == 2
+                && engine.isUsingTransitionalHeadsetBackend
+        }
+
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(engine.headsetAggregatePromotionAttemptCount == 1)
+        #expect(model.statusMessage.contains("compatibility mode"))
+    }
+
+    @Test
+    func automaticAggregateBufferClimbsToSixtyFourAfterQualifyingInterruptions() async {
+        let output = makeOutput(uid: "adaptive-aggregate", name: "Adaptive Aggregate")
+        let engine = FakeAudioEngine()
+        engine.reflectPreferredAggregateBufferFrameSize = true
+        let notifier = FakeAggregateBufferNotifier()
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            observers: observers,
+            outputDelay: .zero,
+            aggregateBufferNotifier: notifier
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running
+                && engine.startCalls.count == 1
+                && engine.startCalls[0].aggregateBufferFrameSize == 16
+        }
+        try? await Task.sleep(for: .milliseconds(30))
+
+        var metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 1
+        engine.metrics = metrics
+        try? await Task.sleep(for: .milliseconds(350))
+        #expect(engine.startCalls.count == 1)
+
+        metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 2
+        engine.metrics = metrics
+        await waitUntil {
+            engine.startCalls.count == 2
+                && engine.startCalls[1].aggregateBufferFrameSize == 32
+                && notifier.calls.count == 1
+        }
+        try? await Task.sleep(for: .milliseconds(30))
+
+        metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 3
+        engine.metrics = metrics
+        try? await Task.sleep(for: .milliseconds(350))
+        #expect(engine.startCalls.count == 2)
+
+        metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 4
+        engine.metrics = metrics
+        await waitUntil {
+            engine.startCalls.count == 3
+                && engine.startCalls[2].aggregateBufferFrameSize == 64
+                && notifier.calls.count == 2
+        }
+
+        metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 6
+        engine.metrics = metrics
+        try? await Task.sleep(for: .milliseconds(350))
+
+        #expect(engine.startCalls.count == 3)
+        #expect(model.settingsSnapshot().aggregateBuffer.automaticFrameSize == 64)
+    }
+
+    @Test
+    func automaticAggregateBufferIgnoresInterruptionsBeforeRouteSettles() async {
+        let output = makeOutput(uid: "settling-aggregate", name: "Settling Aggregate")
+        let engine = FakeAudioEngine()
+        engine.reflectPreferredAggregateBufferFrameSize = true
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            observers: observers,
+            outputDelay: .zero,
+            aggregateStabilityDelay: .seconds(1)
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+        var metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 1
+        engine.metrics = metrics
+        try? await Task.sleep(for: .milliseconds(350))
+
+        #expect(engine.startCalls.count == 1)
+        #expect(model.settingsSnapshot().aggregateBuffer.automaticFrameSize == 16)
+    }
+
+    @Test
+    func automaticAggregateBufferRetriesLowerRungAfterThreeCleanRuns() async throws {
+        let output = makeOutput(uid: "clean-aggregate", name: "Clean Aggregate")
+        let engine = FakeAudioEngine()
+        engine.reflectPreferredAggregateBufferFrameSize = true
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            observers: observers,
+            outputDelay: .zero,
+            aggregateCleanSessionDuration: .milliseconds(100)
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        var metrics = engine.metrics
+        metrics.qualifyingPairedTimestampDiscontinuities = 2
+        engine.metrics = metrics
+        await waitUntil {
+            engine.startCalls.count == 2
+                && engine.startCalls[1].aggregateBufferFrameSize == 32
+        }
+
+        try? await Task.sleep(for: .milliseconds(350))
+        try model.setAggregateBufferMode(.automatic)
+        await waitUntil {
+            engine.startCalls.count == 3
+                && engine.startCalls[2].aggregateBufferFrameSize == 32
+        }
+
+        try? await Task.sleep(for: .milliseconds(350))
+        try model.setAggregateBufferMode(.automatic)
+        await waitUntil {
+            engine.startCalls.count == 4
+                && engine.startCalls[3].aggregateBufferFrameSize == 32
+        }
+        await waitUntil {
+            engine.startCalls.count == 5
+                && engine.startCalls[4].aggregateBufferFrameSize == 16
+        }
+
+        #expect(model.settingsSnapshot().aggregateBuffer.automaticFrameSize == 16)
+    }
+
+    @Test
+    func aggregateBufferControlsAreUnavailableDuringARebuild() async throws {
+        let output = makeOutput(uid: "rebuilding-aggregate", name: "Rebuilding Aggregate")
+        let engine = FakeAudioEngine()
+        engine.reflectPreferredAggregateBufferFrameSize = true
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(engine: engine, observers: observers, outputDelay: .zero)
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+        #expect(model.settingsSnapshot().aggregateBuffer.isAvailable)
+
+        engine.startDelaySeconds = 0.1
+        try model.setAggregateBufferMode(.frames32)
+
+        #expect(!model.settingsSnapshot().aggregateBuffer.isAvailable)
+        #expect(throws: SettingsCommandFailure.self) {
+            try model.setAggregateBufferMode(.frames64)
+        }
+
+        await waitUntil {
+            engine.startCalls.count == 2
+                && model.settingsSnapshot().aggregateBuffer.isAvailable
+        }
+        #expect(model.settingsSnapshot().aggregateBuffer.isAvailable)
+    }
+
+    @Test
     func retryRunningEngineUpdatesActiveProfileWithoutDefaultLookup() async {
         let runningOutput = makeOutput(uid: "running-output", name: "Running Output")
         let defaultOutput = makeOutput(uid: "default-output", name: "Default Output")
@@ -118,85 +461,6 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.currentOutputName == output.name)
         #expect(!model.isRunning)
         #expect(model.lifecycleState == .stopped)
-    }
-
-    @Test
-    func conversionCapacityStartFailureReportsUnsupportedOutputFormat() async {
-        let output = makeOutput(uid: "converted-output", name: "Converted Output")
-        let error = AudioDeviceAvailabilityError.unsupportedPlaybackConversionBuffer(
-            output.id,
-            requiredPrimeFrames: 50_176,
-            maximumPrimeFrames: 40_960
-        )
-        let engine = FakeAudioEngine()
-        engine.startError = error
-        let lookup = FakeDefaultOutputLookup(.success(output))
-        let model = makeModel(engine: engine, lookup: lookup)
-        let expectedStatus = localized("Output format unsupported: \(error.description)")
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .stopped
-                && engine.startCalls.count == 1
-                && model.statusMessage == expectedStatus
-        }
-
-        #expect(model.statusMessage == expectedStatus)
-    }
-
-    @Test
-    func runtimeEngineFailureStopsTheModelAndSurfacesItsStatus() async {
-        let output = makeOutput(uid: "runtime-output", name: "Runtime Output")
-        let engine = FakeAudioEngine()
-        engine.state = .running(output: output)
-        let model = makeModel(engine: engine)
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running
-        }
-        engine.emitRuntimeFailure(adaptiveRenderFailure)
-        await waitUntil {
-            model.lifecycleState == .stopped
-        }
-
-        #expect(!model.isRunning)
-        #expect(model.statusMessage == localized("Audio engine failed: \(adaptiveRenderFailure.userMessage)"))
-    }
-
-    @Test
-    func runtimeFailureDoesNotCancelNewerPendingRouteStart() async {
-        let firstOutput = makeOutput(uid: "runtime-first", name: "Runtime First", id: 200)
-        let secondOutput = makeOutput(uid: "runtime-second", name: "Runtime Second", id: 300)
-        let engine = FakeAudioEngine()
-        let lookup = FakeDefaultOutputLookup(.success(firstOutput))
-        let observers = FakeDefaultOutputObserverFactory()
-        let model = makeModel(engine: engine, lookup: lookup, observers: observers, outputDelay: .zero)
-
-        model.start()
-        let observer = observers.observers[0]
-        observer.emit(.success(firstOutput))
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-
-        engine.blockStart(for: secondOutput.uid)
-        lookup.result = .success(secondOutput)
-        observer.emit(.success(secondOutput))
-        await waitUntil {
-            engine.startCalls.contains { $0.output == secondOutput }
-        }
-        #expect(engine.waitUntilStartIsBlocked(for: secondOutput.uid, timeout: .now() + 1))
-
-        engine.emitRuntimeFailure(adaptiveRenderFailure)
-        await settleAsyncWork()
-        #expect(model.lifecycleState == .running)
-
-        engine.unblockStart(for: secondOutput.uid)
-        await waitUntil {
-            model.lifecycleState == .running
-                && model.currentOutputUID == secondOutput.uid
-                && engine.state == .running(output: secondOutput)
-        }
     }
 
     @Test
@@ -657,38 +921,6 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.profileStore.outputMappings == [originalMapping])
         #expect(!model.profileStore.profiles.contains(where: { $0.id == intermediate.id }))
         #expect(model.profileStore.profile(forOutputUID: secondOutput.uid) == confirmed)
-        #expect(engine.state == .running(output: secondOutput))
-    }
-
-    @Test
-    func staleRuntimeFailureDoesNotStopCompletedNewerRoute() async {
-        let firstOutput = makeOutput(uid: "stale-runtime-first", name: "Stale Runtime First", id: 200)
-        let secondOutput = makeOutput(uid: "stale-runtime-second", name: "Stale Runtime Second", id: 300)
-        let engine = FakeAudioEngine()
-        let lookup = FakeDefaultOutputLookup(.success(firstOutput))
-        let observers = FakeDefaultOutputObserverFactory()
-        let model = makeModel(engine: engine, lookup: lookup, observers: observers, outputDelay: .zero)
-
-        model.start()
-        let observer = observers.observers[0]
-        observer.emit(.success(firstOutput))
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        lookup.result = .success(secondOutput)
-        observer.emit(.success(secondOutput))
-        await waitUntil {
-            model.lifecycleState == .running
-                && model.currentOutputUID == secondOutput.uid
-                && engine.state == .running(output: secondOutput)
-        }
-
-        engine.emitRuntimeFailure(adaptiveRenderFailure, markEngineFailed: false)
-        await settleAsyncWork()
-
-        #expect(model.lifecycleState == .running)
-        #expect(model.isRunning)
-        #expect(model.currentOutputUID == secondOutput.uid)
         #expect(engine.state == .running(output: secondOutput))
     }
 
@@ -2148,8 +2380,7 @@ struct GlassEQAppModelLifecycleTests {
         engine.metrics = AudioEngineMetrics(
             capturedFrames: 123,
             playedFrames: 100,
-            ringGateContentionFailures: 2,
-            playbackBufferSampleRate: 48_000
+            droppedInputFrames: 2
         )
         let model = makeModel(engine: engine)
 
@@ -2158,383 +2389,9 @@ struct GlassEQAppModelLifecycleTests {
         #expect(response.snapshot == nil)
         #expect(model.engineMetrics.capturedFrames == 123)
         #expect(model.engineMetrics.playedFrames == 100)
-        #expect(model.engineMetrics.ringGateContentionFailures == 2)
-        #expect(model.settingsSnapshot().metrics.playbackBufferSampleRate == 48_000)
+        #expect(model.engineMetrics.droppedInputFrames == 2)
+        #expect(model.settingsSnapshot().metrics.droppedInputFrames == 2)
         model.stopMetricsPolling()
-    }
-
-    @Test
-    func resettingPlaybackBufferCalibrationTargetsCurrentDeviceAndRebuildsIt() async throws {
-        let output = makeOutput(uid: "scarlett", name: "Scarlett Solo USB", bufferFrameSize: 1_024)
-        let engine = FakeAudioEngine()
-        let lookup = FakeDefaultOutputLookup(.success(output))
-        let model = makeModel(engine: engine, lookup: lookup)
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-
-        let response = try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-
-        #expect(engine.resetPlaybackBufferCalibrationUIDs == [output.uid])
-        #expect(response.snapshot?.statusMessage == localized("Processing Scarlett Solo USB with Fallback"))
-        #expect(model.isRunning)
-        #expect(model.lifecycleState == .running)
-    }
-
-    @Test
-    func profileAppliedDuringPlaybackBufferCalibrationResetIsRepublished() async throws {
-        let output = makeOutput(uid: "apply-during-reset", name: "Apply During Reset")
-        let initialProfile = makeProfile(name: "Initial")
-        let appliedProfile = makeProfile(name: "Applied During Reset")
-        let store = ProfileStore(
-            profiles: [initialProfile, appliedProfile],
-            fallbackProfileID: initialProfile.id
-        )
-        let engine = FakeAudioEngine()
-        let model = makeModel(
-            store: store,
-            engine: engine,
-            lookup: FakeDefaultOutputLookup(.success(output))
-        )
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        engine.blockPlaybackBufferCalibrationReset()
-
-        let resetTask = Task {
-            try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-        await waitUntil {
-            engine.resetPlaybackBufferCalibrationUIDs == [output.uid]
-        }
-        #expect(engine.waitUntilPlaybackBufferCalibrationResetIsBlocked(timeout: .now() + 1))
-
-        try model.apply(profile: appliedProfile)
-        #expect(engine.updateDSPCalls.isEmpty)
-
-        engine.unblockPlaybackBufferCalibrationReset()
-        _ = try await resetTask.value
-        await waitUntil {
-            engine.updateCalls.last == appliedProfile
-        }
-
-        #expect(model.activeProfile == appliedProfile)
-        #expect(model.lifecycleState == .running)
-    }
-
-    @Test
-    func stoppingPreviewDuringPlaybackBufferCalibrationResetRepublishesReturnProfile() async throws {
-        let output = makeOutput(uid: "stop-preview-reset", name: "Stop Preview Reset")
-        let initialProfile = makeProfile(name: "Initial")
-        let previewProfile = makeProfile(name: "Preview")
-        let store = ProfileStore(
-            profiles: [initialProfile, previewProfile],
-            fallbackProfileID: initialProfile.id
-        )
-        let engine = FakeAudioEngine()
-        let model = makeModel(
-            store: store,
-            engine: engine,
-            lookup: FakeDefaultOutputLookup(.success(output))
-        )
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        model.preview(profile: previewProfile)
-        #expect(engine.updateDSPCalls == [previewProfile])
-        engine.blockPlaybackBufferCalibrationReset()
-
-        let resetTask = Task {
-            try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-        await waitUntil {
-            engine.resetPlaybackBufferCalibrationUIDs == [output.uid]
-        }
-        #expect(engine.waitUntilPlaybackBufferCalibrationResetIsBlocked(timeout: .now() + 1))
-
-        model.stopPreview()
-        #expect(engine.updateDSPCalls == [previewProfile])
-
-        engine.unblockPlaybackBufferCalibrationReset()
-        _ = try await resetTask.value
-        await waitUntil {
-            engine.updateCalls.last == initialProfile
-        }
-
-        #expect(model.activeProfile == initialProfile)
-        #expect(model.previewReturnProfile == nil)
-        #expect(model.lifecycleState == .running)
-    }
-
-    @Test
-    func stoppingDuringPlaybackBufferCalibrationResetKeepsModelStopped() async throws {
-        let output = makeOutput(uid: "stop-during-reset", name: "Stop During Reset")
-        let engine = FakeAudioEngine()
-        let model = makeModel(engine: engine, lookup: FakeDefaultOutputLookup(.success(output)))
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        engine.blockPlaybackBufferCalibrationReset()
-
-        let resetTask = Task {
-            try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-        await waitUntil {
-            engine.resetPlaybackBufferCalibrationUIDs == [output.uid]
-        }
-        #expect(engine.waitUntilPlaybackBufferCalibrationResetIsBlocked(timeout: .now() + 1))
-
-        model.stop()
-        engine.unblockPlaybackBufferCalibrationReset()
-        _ = try await resetTask.value
-        await waitUntil {
-            engine.stopCallCount == 1
-        }
-
-        #expect(!model.isRunning)
-        #expect(model.lifecycleState == .stopped)
-        #expect(model.statusMessage == localized("Stopped"))
-    }
-
-    @Test
-    func sleepingDuringPlaybackBufferCalibrationResetKeepsModelSleeping() async throws {
-        let output = makeOutput(uid: "sleep-during-reset", name: "Sleep During Reset")
-        let engine = FakeAudioEngine()
-        let model = makeModel(engine: engine, lookup: FakeDefaultOutputLookup(.success(output)))
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        engine.blockPlaybackBufferCalibrationReset()
-
-        let resetTask = Task {
-            try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-        await waitUntil {
-            engine.resetPlaybackBufferCalibrationUIDs == [output.uid]
-        }
-        #expect(engine.waitUntilPlaybackBufferCalibrationResetIsBlocked(timeout: .now() + 1))
-
-        model.handleWillSleep()
-        engine.unblockPlaybackBufferCalibrationReset()
-        _ = try await resetTask.value
-        await waitUntil {
-            engine.stopCallCount == 1
-        }
-
-        #expect(!model.isRunning)
-        #expect(model.lifecycleState == .sleeping)
-        #expect(model.statusMessage == localized("Paused for system sleep"))
-    }
-
-    @Test
-    func playbackBufferCalibrationResetIsRejectedWhileSleepingOrWaking() async {
-        let output = makeOutput(uid: "sleep-reset", name: "Sleep Reset")
-        let engine = FakeAudioEngine()
-        let observers = FakeDefaultOutputObserverFactory()
-        let model = makeModel(
-            engine: engine,
-            lookup: FakeDefaultOutputLookup(.success(output)),
-            observers: observers,
-            wakeDelay: .zero
-        )
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running
-        }
-        model.handleWillSleep()
-
-        await #expect(throws: SettingsCommandFailure.self) {
-            _ = try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-        #expect(model.lifecycleState == .sleeping)
-        #expect(engine.resetPlaybackBufferCalibrationUIDs.isEmpty)
-
-        model.handleDidWake()
-        await waitUntil {
-            model.lifecycleState == .waking && observers.observers.count == 1
-        }
-        await #expect(throws: SettingsCommandFailure.self) {
-            _ = try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-        #expect(model.lifecycleState == .waking)
-        #expect(engine.resetPlaybackBufferCalibrationUIDs.isEmpty)
-    }
-
-    @Test
-    func playbackBufferCalibrationFailureReconcilesFailedEngineState() async {
-        let output = makeOutput(uid: "failed-reset", name: "Failed Reset")
-        let engine = FakeAudioEngine()
-        let model = makeModel(engine: engine, lookup: FakeDefaultOutputLookup(.success(output)))
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        engine.playbackBufferCalibrationResetError = TestAudioError.calibrationResetFailed
-        engine.playbackBufferCalibrationResetFailureState = .failed("Calibration rebuild failed")
-
-        await #expect(throws: TestAudioError.calibrationResetFailed) {
-            _ = try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-
-        #expect(!model.isRunning)
-        #expect(model.lifecycleState == .stopped)
-        #expect(model.statusMessage == "Calibration rebuild failed")
-    }
-
-    @Test
-    func playbackBufferCalibrationFailurePublishesReconciledHelperSnapshot() async throws {
-        let output = makeOutput(uid: "failed-helper-reset", name: "Failed Helper Reset")
-        let engine = FakeAudioEngine()
-        let model = makeModel(engine: engine, lookup: FakeDefaultOutputLookup(.success(output)))
-        let launcher = ControllableSettingsHelperLauncher()
-        let coordinator = SettingsCoordinator(
-            model: model,
-            helperLauncher: launcher,
-            helperValidator: PermissiveSettingsHelperLaunchValidator(),
-            settingsHelperURLProvider: { URL(fileURLWithPath: "/tmp/GlassEQSettings.app") }
-        )
-        model.settingsCoordinator = coordinator
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        engine.playbackBufferCalibrationResetError = TestAudioError.calibrationResetFailed
-        engine.playbackBufferCalibrationResetFailureState = .failed("Calibration rebuild failed")
-
-        #expect(coordinator.openSettings() == .helper)
-        await waitUntil {
-            launcher.receivedAppMessages.contains { message in
-                if case .bootstrap = message {
-                    return true
-                }
-                return false
-            }
-        }
-        let bootstrap = try #require(launcher.receivedAppMessages.first { message in
-            if case .bootstrap = message {
-                return true
-            }
-            return false
-        })
-        guard case .bootstrap(let token) = bootstrap else {
-            Issue.record("Expected Settings bootstrap message")
-            return
-        }
-
-        try launcher.writeHelperMessage(.request(
-            sessionToken: token,
-            id: "connect",
-            kind: .connect,
-            command: nil
-        ))
-        await waitUntil {
-            launcher.receivedAppMessages.contains { message in
-                if case .response(_, "connect", _, _) = message {
-                    return true
-                }
-                return false
-            }
-        }
-        try launcher.writeHelperMessage(.request(
-            sessionToken: token,
-            id: "ready",
-            kind: .ready,
-            command: nil
-        ))
-        await waitUntil {
-            coordinator.isHelperReadyForTesting
-        }
-        let commandMessageStart = launcher.receivedAppMessages.count
-
-        try launcher.writeHelperMessage(.request(
-            sessionToken: token,
-            id: "reset",
-            kind: .command,
-            command: .resetPlaybackBufferCalibration
-        ))
-        await waitUntil {
-            launcher.receivedAppMessages.contains { message in
-                if case .response(_, "reset", _, _) = message {
-                    return true
-                }
-                return false
-            }
-        }
-
-        let commandMessages = Array(launcher.receivedAppMessages.dropFirst(commandMessageStart))
-        let patchIndex = try #require(commandMessages.firstIndex { message in
-            guard case .event(_, .snapshotPatched(let patch)) = message else {
-                return false
-            }
-            return patch.isRunning == false && patch.statusMessage == "Calibration rebuild failed"
-        })
-        let errorIndex = try #require(commandMessages.firstIndex { message in
-            guard case .response(_, "reset", nil, let error) = message else {
-                return false
-            }
-            return error != nil
-        })
-        #expect(patchIndex < errorIndex)
-    }
-
-    @Test
-    func playbackBufferCalibrationFailurePreservesRunningEngineState() async {
-        let output = makeOutput(uid: "running-reset", name: "Running Reset")
-        let engine = FakeAudioEngine()
-        let model = makeModel(engine: engine, lookup: FakeDefaultOutputLookup(.success(output)))
-
-        model.retryAudioEngine()
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-        engine.playbackBufferCalibrationResetError = TestAudioError.calibrationResetFailed
-
-        await #expect(throws: TestAudioError.calibrationResetFailed) {
-            _ = try await model.performSettingsCommand(.resetPlaybackBufferCalibration)
-        }
-
-        #expect(model.isRunning)
-        #expect(model.lifecycleState == .running)
-        #expect(model.statusMessage.contains("Buffer calibration reset failed"))
-    }
-
-    @Test
-    func bufferRenegotiationUpdatesOutputAndSendsNotification() async {
-        let engine = FakeAudioEngine()
-        let notifier = FakePlaybackBufferRenegotiationNotifier()
-        let output = makeOutput(bufferFrameSize: 64)
-        let renegotiation = PlaybackBufferRenegotiation(
-            outputName: output.name,
-            outputUID: output.uid,
-            sampleRate: output.nominalSampleRate,
-            previousFrameSize: 64,
-            frameSize: 128,
-            playbackTargetFrames: 192,
-            reason: .outputTimestampDiscontinuity
-        )
-        let model = makeModel(engine: engine, playbackBufferNotifier: notifier)
-        #expect(notifier.prepareCallCount == 1)
-        model.currentOutputUID = output.uid
-        model.currentOutputBufferFrameSize = 64
-
-        engine.emitBufferRenegotiation(renegotiation)
-        await Task.yield()
-
-        #expect(model.currentOutputBufferFrameSize == 128)
-        #expect(notifier.renegotiations == [renegotiation])
     }
 
     @Test
@@ -2967,6 +2824,17 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func aggregateBufferNotificationOpensSettingsInTheMainProcess() {
+        let model = makeModel()
+
+        model.openAggregateBufferSettings()
+
+        #expect(model.inProcessSettingsPresentationIsPending)
+        #expect(model.inProcessSettingsPresentationGeneration == 1)
+        #expect(!model.settingsCoordinator.hasActiveSessionResourcesForTesting)
+    }
+
+    @Test
     func inProcessSettingsFallbackPerformsCommandsAndTracksModelChanges() async throws {
         let model = makeModel()
         let settingsModel = model.inProcessSettingsViewModel()
@@ -3138,20 +3006,6 @@ struct GlassEQAppModelLifecycleTests {
 }
 
 @MainActor
-private final class FakePlaybackBufferRenegotiationNotifier: PlaybackBufferRenegotiationNotifying {
-    private(set) var prepareCallCount = 0
-    private(set) var renegotiations: [PlaybackBufferRenegotiation] = []
-
-    func prepare() {
-        prepareCallCount += 1
-    }
-
-    func notify(_ renegotiation: PlaybackBufferRenegotiation) {
-        renegotiations.append(renegotiation)
-    }
-}
-
-@MainActor
 private func makeModel(
     store: ProfileStore? = nil,
     storeURL: URL = FileManager.default.temporaryDirectory
@@ -3160,11 +3014,14 @@ private func makeModel(
     lookup: FakeDefaultOutputLookup = FakeDefaultOutputLookup(.success(makeOutput())),
     observers: any DefaultOutputObservingMaking = FakeDefaultOutputObserverFactory(),
     workspaceOpener: any WorkspaceOpening = FakeWorkspaceOpener(results: []),
-    playbackBufferNotifier: any PlaybackBufferRenegotiationNotifying = FakePlaybackBufferRenegotiationNotifier(),
     profileImportOperation: (@Sendable (ImportFormat, String, String) async -> Result<EQProfile, any Error>)? = nil,
     saveDelay: Duration = .zero,
     outputDelay: Duration? = nil,
-    wakeDelay: Duration? = nil
+    wakeDelay: Duration? = nil,
+    aggregateStabilityDelay: Duration = .zero,
+    aggregateCleanSessionDuration: Duration = .seconds(5 * 60),
+    headsetAggregatePromotionDelay: Duration = .seconds(6),
+    aggregateBufferNotifier: (any AggregateBufferChangeNotifying)? = nil
 ) -> GlassEQAppModel {
     let store = normalizedStore(store ?? ProfileStore(profiles: [makeProfile(name: "Fallback")]))
     return GlassEQAppModel(
@@ -3177,11 +3034,16 @@ private func makeModel(
         installLifecycleObservers: false,
         registerAppDelegate: false,
         workspaceOpener: workspaceOpener,
-        playbackBufferRenegotiationNotifier: playbackBufferNotifier,
         profileImportOperation: profileImportOperation,
         saveDebounceDelay: saveDelay,
         outputChangeSettlingDelayOverride: outputDelay,
-        wakeReconnectDelayOverride: wakeDelay
+        wakeReconnectDelayOverride: wakeDelay,
+        aggregateBufferPolicyURL: storeURL.deletingPathExtension()
+            .appendingPathExtension("aggregate-buffer-policy.json"),
+        aggregateStabilitySettlingDelay: aggregateStabilityDelay,
+        aggregateCleanSessionDuration: aggregateCleanSessionDuration,
+        headsetAggregatePromotionDelay: headsetAggregatePromotionDelay,
+        aggregateBufferNotifier: aggregateBufferNotifier
     )
 }
 
@@ -3312,7 +3174,6 @@ private enum TestAudioError: Error, Equatable {
     case startFailed
     case updateFailed
     case defaultOutputUnavailable
-    case calibrationResetFailed
 }
 
 private let adaptiveRenderFailure = AudioEngineFailure(
@@ -3661,6 +3522,7 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     struct StartCall: Equatable {
         var output: AudioOutputDevice
         var profile: EQProfile
+        var aggregateBufferFrameSize: UInt32
     }
 
     private let lock = NSLock()
@@ -3681,18 +3543,29 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private var _stopCallCount = 0
     private var _muteOutputCallCount = 0
     private var _setBypassedCalls: [Bool] = []
-    private var _resetPlaybackBufferCalibrationUIDs: [String] = []
-    private var _playbackBufferCalibrationResetBlocker: FakeStartBlocker?
-    private var _playbackBufferCalibrationResetError: Error?
-    private var _playbackBufferCalibrationResetFailureState: AudioEngineState?
     private var _metrics = AudioEngineMetrics()
-    private var _bufferRenegotiationHandler: (@Sendable (PlaybackBufferRenegotiation) -> Void)?
     private var _events: [String] = []
+    private var _preferredAggregateBufferFrameSize: UInt32 = 16
+    private var _nativeOutputStreamIndex = 0
+    private var _reflectPreferredAggregateBufferFrameSize = false
+    private var _headsetPromotionCandidateUIDs: Set<String> = []
+    private var _headsetAggregatePromotionResult = HeadsetAggregatePromotionResult.notApplicable
+    private var _headsetAggregatePromotionAttemptCount = 0
+    private var _isUsingTransitionalHeadsetBackend = false
+    private var _isUsingPromotedHeadsetAggregate = false
     private var _runtimeFailureHandler: (@Sendable (AudioEngineFailure) -> Void)?
 
     var state: AudioEngineState {
         get { withLock { _state } }
         set { withLock { _state = newValue } }
+    }
+
+    var isUsingTransitionalHeadsetBackend: Bool {
+        withLock { _isUsingTransitionalHeadsetBackend }
+    }
+
+    var isUsingPromotedHeadsetAggregate: Bool {
+        withLock { _isUsingPromotedHeadsetAggregate }
     }
 
     var startError: Error? {
@@ -3765,24 +3638,28 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         set { withLock { _setBypassedCalls = newValue } }
     }
 
-    private(set) var resetPlaybackBufferCalibrationUIDs: [String] {
-        get { withLock { _resetPlaybackBufferCalibrationUIDs } }
-        set { withLock { _resetPlaybackBufferCalibrationUIDs = newValue } }
-    }
-
-    var playbackBufferCalibrationResetError: Error? {
-        get { withLock { _playbackBufferCalibrationResetError } }
-        set { withLock { _playbackBufferCalibrationResetError = newValue } }
-    }
-
-    var playbackBufferCalibrationResetFailureState: AudioEngineState? {
-        get { withLock { _playbackBufferCalibrationResetFailureState } }
-        set { withLock { _playbackBufferCalibrationResetFailureState = newValue } }
-    }
-
     var metrics: AudioEngineMetrics {
         get { withLock { _metrics } }
         set { withLock { _metrics = newValue } }
+    }
+
+    var reflectPreferredAggregateBufferFrameSize: Bool {
+        get { withLock { _reflectPreferredAggregateBufferFrameSize } }
+        set { withLock { _reflectPreferredAggregateBufferFrameSize = newValue } }
+    }
+
+    var headsetPromotionCandidateUIDs: Set<String> {
+        get { withLock { _headsetPromotionCandidateUIDs } }
+        set { withLock { _headsetPromotionCandidateUIDs = newValue } }
+    }
+
+    var headsetAggregatePromotionResult: HeadsetAggregatePromotionResult {
+        get { withLock { _headsetAggregatePromotionResult } }
+        set { withLock { _headsetAggregatePromotionResult = newValue } }
+    }
+
+    var headsetAggregatePromotionAttemptCount: Int {
+        withLock { _headsetAggregatePromotionAttemptCount }
     }
 
     var events: [String] {
@@ -3827,41 +3704,14 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         blocker?.unblock()
     }
 
-    func blockPlaybackBufferCalibrationReset() {
-        withLock {
-            _playbackBufferCalibrationResetBlocker = FakeStartBlocker()
-        }
-    }
-
-    func waitUntilPlaybackBufferCalibrationResetIsBlocked(timeout: DispatchTime) -> Bool {
-        withLock {
-            _playbackBufferCalibrationResetBlocker
-        }?.waitUntilEntered(timeout: timeout) ?? false
-    }
-
-    func unblockPlaybackBufferCalibrationReset() {
-        let blocker = withLock {
-            let blocker = _playbackBufferCalibrationResetBlocker
-            _playbackBufferCalibrationResetBlocker = nil
-            return blocker
-        }
-        blocker?.unblock()
-    }
-
-    func emitRuntimeFailure(_ failure: AudioEngineFailure, markEngineFailed: Bool = true) {
-        let handler = withLock {
-            if markEngineFailed {
-                _state = .failed(failure.description)
-            }
-            return _runtimeFailureHandler
-        }
-        handler?(failure)
-    }
-
     func start(output: AudioOutputDevice, profile: EQProfile) throws {
         let startControl = withLock {
             _events.append("start:\(output.uid)")
-            _startCalls.append(StartCall(output: output, profile: profile))
+            _startCalls.append(StartCall(
+                output: output,
+                profile: profile,
+                aggregateBufferFrameSize: _preferredAggregateBufferFrameSize
+            ))
             return (
                 delay: _startDelaySecondsByUID[output.uid] ?? _startDelaySeconds,
                 blocker: _startBlockersByUID[output.uid],
@@ -3884,7 +3734,53 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
             throw startError
         }
         withLock {
-            _state = .running(output: output)
+            var activeOutput = output
+            if _reflectPreferredAggregateBufferFrameSize {
+                activeOutput.bufferFrameSize = _preferredAggregateBufferFrameSize
+            }
+            _state = .running(output: activeOutput)
+            _isUsingTransitionalHeadsetBackend = _headsetPromotionCandidateUIDs.contains(output.uid)
+            _isUsingPromotedHeadsetAggregate = false
+        }
+    }
+
+    func attemptHeadsetAggregatePromotion() throws -> HeadsetAggregatePromotionResult {
+        withLock {
+            _headsetAggregatePromotionAttemptCount += 1
+            let result = _headsetAggregatePromotionResult
+            if case .promoted(let output) = result {
+                _state = .running(output: output)
+                _isUsingTransitionalHeadsetBackend = false
+                _isUsingPromotedHeadsetAggregate = true
+            }
+            return result
+        }
+    }
+
+    func rejectHeadsetAggregatePromotion() {
+        withLock {
+            _isUsingPromotedHeadsetAggregate = false
+        }
+    }
+
+    func aggregateRouteFingerprint(
+        for output: AudioOutputDevice
+    ) throws -> AggregateAudioRouteFingerprint? {
+        withLock {
+            if _isUsingTransitionalHeadsetBackend {
+                return nil
+            }
+            return AggregateAudioRouteFingerprint(
+                outputDeviceUID: output.uid,
+                nativeOutputStreamIndex: _nativeOutputStreamIndex,
+                nominalSampleRate: output.nominalSampleRate
+            )
+        }
+    }
+
+    func setPreferredAggregateBufferFrameSize(_ frameSize: UInt32) {
+        withLock {
+            _preferredAggregateBufferFrameSize = frameSize
         }
     }
 
@@ -3944,11 +3840,23 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         }
     }
 
+    func emitRuntimeFailure(_ failure: AudioEngineFailure, markEngineFailed: Bool = true) {
+        let handler = withLock {
+            if markEngineFailed {
+                _state = .failed(failure.description)
+            }
+            return _runtimeFailureHandler
+        }
+        handler?(failure)
+    }
+
     func stop() {
         withLock {
             _events.append("stop")
             _stopCallCount += 1
             _state = .stopped
+            _isUsingTransitionalHeadsetBackend = false
+            _isUsingPromotedHeadsetAggregate = false
         }
     }
 
@@ -3964,41 +3872,33 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         }
     }
 
-    func resetPlaybackBufferCalibration(forOutputUID outputUID: String) throws {
-        let reset = withLock {
-            _resetPlaybackBufferCalibrationUIDs.append(outputUID)
-            return (
-                blocker: _playbackBufferCalibrationResetBlocker,
-                error: _playbackBufferCalibrationResetError,
-                failureState: _playbackBufferCalibrationResetFailureState
-            )
-        }
-        reset.blocker?.waitUntilUnblocked()
-        if let error = reset.error {
-            if let failureState = reset.failureState {
-                state = failureState
-            }
-            throw error
-        }
-    }
-
-    func setPlaybackBufferRenegotiationHandler(
-        _ handler: (@Sendable (PlaybackBufferRenegotiation) -> Void)?
-    ) {
-        withLock {
-            _bufferRenegotiationHandler = handler
-        }
-    }
-
-    func emitBufferRenegotiation(_ renegotiation: PlaybackBufferRenegotiation) {
-        let handler = withLock { _bufferRenegotiationHandler }
-        handler?(renegotiation)
-    }
-
     private func withLock<T>(_ body: () -> T) -> T {
         lock.lock()
         defer { lock.unlock() }
         return body()
+    }
+}
+
+@MainActor
+private final class FakeAggregateBufferNotifier: AggregateBufferChangeNotifying {
+    struct Call: Equatable {
+        var outputName: String
+        var previousFrameSize: UInt32
+        var newFrameSize: UInt32
+    }
+
+    private(set) var calls: [Call] = []
+
+    func notifyBufferIncrease(
+        outputName: String,
+        previousFrameSize: UInt32,
+        newFrameSize: UInt32
+    ) {
+        calls.append(Call(
+            outputName: outputName,
+            previousFrameSize: previousFrameSize,
+            newFrameSize: newFrameSize
+        ))
     }
 }
 

--- a/Tests/GlassEQAudioTests/AdaptivePlaybackRateTests.swift
+++ b/Tests/GlassEQAudioTests/AdaptivePlaybackRateTests.swift
@@ -291,6 +291,59 @@ struct AdaptivePlaybackRateTests {
     }
 
     @Test
+    func schemaTwoCalibrationIsDiscardedBeforeRecordingFreshEvidence() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlassEQPlaybackBufferCalibration-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("LearnedPlaybackBuffers.json")
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let contaminatedJSON = """
+        {
+          "schemaVersion": 2,
+          "calibrations": [
+            {
+              "outputUID": "scarlett",
+              "sampleRate": 48000,
+              "stableFrameSize": 512,
+              "operatingPoints": [
+                {
+                  "frameSize": 512,
+                  "stableTargetFrames": 704
+                }
+              ],
+              "events": []
+            }
+          ]
+        }
+        """
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try #require(contaminatedJSON.data(using: .utf8)).write(to: url)
+
+        #expect(PersistedPlaybackBufferCalibrationStore.calibration(
+            outputUID: "scarlett",
+            sampleRate: 48_000,
+            from: url
+        ) == nil)
+
+        try PersistedPlaybackBufferCalibrationStore.recordStable(
+            outputUID: "scarlett",
+            sampleRate: 48_000,
+            frameSize: 64,
+            targetFrames: 128,
+            at: url
+        )
+        let calibration = try #require(PersistedPlaybackBufferCalibrationStore.calibration(
+            outputUID: "scarlett",
+            sampleRate: 48_000,
+            from: url
+        ))
+        #expect(calibration.stableFrameSize == 64)
+        #expect(calibration.operatingPoint(for: 64)?.stableTargetFrames == 128)
+        #expect(calibration.operatingPoint(for: 512) == nil)
+    }
+
+    @Test
     func resettingPlaybackBufferCalibrationRemovesOnlyTheSelectedDevice() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("GlassEQPlaybackBufferCalibration-\(UUID().uuidString)", isDirectory: true)
@@ -395,7 +448,7 @@ struct AdaptivePlaybackRateTests {
             resultingFrameSize: 128,
             previousTargetFrames: 128,
             resultingTargetFrames: 256,
-            reason: .outputTimestampDiscontinuity,
+            reason: .underrun,
             timestamp: Date(timeIntervalSince1970: 2),
             at: url
         )
@@ -406,10 +459,11 @@ struct AdaptivePlaybackRateTests {
         ))
         #expect(calibration.stableFrameSize == nil)
         #expect(calibration.probingFrameSize == 128)
-        #expect(calibration.operatingPoint(for: 64)?.stableTargetFrames == 128)
+        #expect(calibration.operatingPoint(for: 64)?.stableTargetFrames == nil)
+        #expect(calibration.operatingPoint(for: 64)?.unstableThroughTargetFrames == 128)
         #expect(calibration.operatingPoint(for: 128)?.probingTargetFrames == 256)
         #expect(calibration.events.last?.kind == .instability)
-        #expect(calibration.events.last?.reason == .outputTimestampDiscontinuity)
+        #expect(calibration.events.last?.reason == .underrun)
         #expect(calibration.events.last?.previousFrameSize == 64)
         #expect(calibration.events.last?.resultingFrameSize == 128)
         #expect(calibration.events.last?.previousTargetFrames == 128)
@@ -527,7 +581,7 @@ struct AdaptivePlaybackRateTests {
     }
 
     @Test
-    func excessiveBacklogDoesNotInvalidateStableBufferCalibration() throws {
+    func adaptiveRenderFailureDoesNotInvalidateStableBufferCalibration() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("GlassEQPlaybackBufferCalibration-\(UUID().uuidString)", isDirectory: true)
         let url = directory.appendingPathComponent("LearnedPlaybackBuffers.json")
@@ -552,7 +606,7 @@ struct AdaptivePlaybackRateTests {
             resultingFrameSize: 64,
             previousTargetFrames: 128,
             resultingTargetFrames: 128,
-            reason: .excessiveBacklog,
+            reason: .adaptiveRenderFailure,
             timestamp: Date(timeIntervalSince1970: 2),
             at: url
         )
@@ -581,6 +635,112 @@ struct AdaptivePlaybackRateTests {
 
         #expect(!probe.hasCompletedProbation(at: start.advanced(by: .seconds(59))))
         #expect(probe.hasCompletedProbation(at: start.advanced(by: .seconds(60))))
+    }
+
+    @Test
+    func underrunEvidenceRequiresThreeEpisodesWithinTwoSeconds() {
+        let start = ContinuousClock().now
+        var evidence = PlaybackBufferUnderrunEvidence()
+
+        let first = evidence.record(eventCount: 1, at: start)
+        let second = evidence.record(eventCount: 1, at: start.advanced(by: .seconds(1)))
+        let third = evidence.record(eventCount: 1, at: start.advanced(by: .seconds(2)))
+        let afterReset = evidence.record(eventCount: 1, at: start.advanced(by: .seconds(2)))
+        #expect(!first)
+        #expect(!second)
+        #expect(third)
+        #expect(!afterReset)
+    }
+
+    @Test
+    func underrunEvidenceExpiresAndAcceptsControllerGenerationDeltas() {
+        let start = ContinuousClock().now
+        var evidence = PlaybackBufferUnderrunEvidence()
+
+        let first = evidence.record(eventCount: 1, at: start)
+        let afterExpiry = evidence.record(
+            eventCount: 1,
+            at: start.advanced(by: .seconds(2) + .milliseconds(1))
+        )
+        evidence.reset()
+        let batched = evidence.record(eventCount: 3, at: start.advanced(by: .seconds(3)))
+        #expect(!first)
+        #expect(!afterExpiry)
+        #expect(batched)
+    }
+
+    @Test
+    func adaptationEvidenceRequiresThreeUnderrunEpisodesBeforeEscalating() {
+        let start = ContinuousClock().now
+        var evidence = PlaybackBufferAdaptationEvidence()
+        evidence.reset(instabilityGeneration: 0, timestampDiscontinuities: 0)
+
+        let first = evidence.observe(
+            instabilityGeneration: 1,
+            reason: .underrun,
+            timestampDiscontinuities: 0,
+            at: start
+        )
+        let second = evidence.observe(
+            instabilityGeneration: 2,
+            reason: .underrun,
+            timestampDiscontinuities: 0,
+            at: start.advanced(by: .seconds(1))
+        )
+        let third = evidence.observe(
+            instabilityGeneration: 3,
+            reason: .underrun,
+            timestampDiscontinuities: 0,
+            at: start.advanced(by: .seconds(2))
+        )
+
+        #expect(first.observedDisturbance)
+        #expect(first.escalationReason == nil)
+        #expect(second.observedDisturbance)
+        #expect(second.escalationReason == nil)
+        #expect(third.escalationReason == .underrun)
+    }
+
+    @Test
+    func adaptationEvidenceTreatsTimestampChangesAsDisturbancesWithoutEscalating() {
+        let start = ContinuousClock().now
+        var evidence = PlaybackBufferAdaptationEvidence()
+        evidence.reset(instabilityGeneration: 4, timestampDiscontinuities: 2)
+
+        let discontinuity = evidence.observe(
+            instabilityGeneration: 4,
+            reason: .underrun,
+            timestampDiscontinuities: 3,
+            at: start
+        )
+        let diagnosticsReset = evidence.observe(
+            instabilityGeneration: 4,
+            reason: .underrun,
+            timestampDiscontinuities: 0,
+            at: start.advanced(by: .seconds(1))
+        )
+
+        #expect(discontinuity.observedDisturbance)
+        #expect(discontinuity.escalationReason == nil)
+        #expect(!diagnosticsReset.observedDisturbance)
+        #expect(diagnosticsReset.escalationReason == nil)
+    }
+
+    @Test
+    func adaptationEvidenceEscalatesActiveRenderFailuresImmediately() {
+        let start = ContinuousClock().now
+        var evidence = PlaybackBufferAdaptationEvidence()
+        evidence.reset(instabilityGeneration: 8, timestampDiscontinuities: 0)
+
+        let observation = evidence.observe(
+            instabilityGeneration: 9,
+            reason: .adaptiveRenderFailure,
+            timestampDiscontinuities: 0,
+            at: start
+        )
+
+        #expect(observation.observedDisturbance)
+        #expect(observation.escalationReason == .adaptiveRenderFailure)
     }
 
     @Test
@@ -624,42 +784,24 @@ struct AdaptivePlaybackRateTests {
     }
 
     @Test
-    func onlyUnderrunsGrowTheReservoirBeforeTheCallbackSizeChanges() {
+    func underrunsGrowTheReservoirBeforeTheCallbackSizeChanges() {
         #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .underrun,
             callbackFrames: 64,
             after: 128
         ) == 192)
         #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .excessiveBacklog,
-            callbackFrames: 64,
-            after: 192
-        ) == nil)
-        #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .underrun,
             callbackFrames: 64,
             after: 256
         ) == nil)
         #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .outputTimestampDiscontinuity,
-            callbackFrames: 64,
-            after: 128
-        ) == nil)
-        #expect(AdaptivePlaybackBufferPolicy.shouldIncreaseCallback(for: .underrun))
-        #expect(AdaptivePlaybackBufferPolicy.shouldIncreaseCallback(for: .outputTimestampDiscontinuity))
-        #expect(!AdaptivePlaybackBufferPolicy.shouldIncreaseCallback(for: .excessiveBacklog))
-        #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .underrun,
             callbackFrames: 128,
             after: 192
         ) == 256)
         #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .underrun,
             callbackFrames: 128,
             after: 320
         ) == nil)
         #expect(AdaptivePlaybackBufferPolicy.nextTargetFrames(
-            for: .underrun,
             callbackFrames: 3_072,
             after: 4_096,
             maximumReservoirFrames: 2_048
@@ -675,29 +817,29 @@ struct AdaptivePlaybackRateTests {
             targetFrames: 704,
             reason: .underrun
         )
-        var timestampGap = underrun
-        timestampGap.reason = .outputTimestampDiscontinuity
+        var largerTarget = underrun
+        largerTarget.targetFrames = 768
         var gate = PlaybackBufferInstabilityPersistenceGate()
 
         let firstUnderrun = gate.shouldPersist(underrun)
         let repeatedUnderrun = gate.shouldPersist(underrun)
-        let firstTimestampGap = gate.shouldPersist(timestampGap)
-        let repeatedTimestampGap = gate.shouldPersist(timestampGap)
+        let firstLargerTarget = gate.shouldPersist(largerTarget)
+        let repeatedLargerTarget = gate.shouldPersist(largerTarget)
         #expect(firstUnderrun)
         #expect(!repeatedUnderrun)
-        #expect(firstTimestampGap)
-        #expect(!repeatedTimestampGap)
+        #expect(firstLargerTarget)
+        #expect(!repeatedLargerTarget)
 
         gate.reset(outputUID: "other-output")
-        let afterUnrelatedReset = gate.shouldPersist(timestampGap)
+        let afterUnrelatedReset = gate.shouldPersist(largerTarget)
         #expect(!afterUnrelatedReset)
 
         gate.reset(outputUID: "scarlett")
-        let afterMatchingReset = gate.shouldPersist(timestampGap)
+        let afterMatchingReset = gate.shouldPersist(largerTarget)
         #expect(afterMatchingReset)
 
-        gate.persistenceFailed(for: timestampGap)
-        let afterPersistenceFailure = gate.shouldPersist(timestampGap)
+        gate.persistenceFailed(for: largerTarget)
+        let afterPersistenceFailure = gate.shouldPersist(largerTarget)
         #expect(afterPersistenceFailure)
     }
 
@@ -710,13 +852,13 @@ struct AdaptivePlaybackRateTests {
     @Test
     func activeAdaptiveRenderFailureTakesPriorityOverLaterInstability() {
         #expect(AdaptivePlaybackRenderRecoveryPolicy.effectiveInstabilityReason(
-            latest: .outputTimestampDiscontinuity,
+            latest: .underrun,
             renderFailureActive: true
         ) == .adaptiveRenderFailure)
         #expect(AdaptivePlaybackRenderRecoveryPolicy.effectiveInstabilityReason(
-            latest: .outputTimestampDiscontinuity,
+            latest: .underrun,
             renderFailureActive: false
-        ) == .outputTimestampDiscontinuity)
+        ) == .underrun)
     }
 
     @Test
@@ -839,7 +981,7 @@ struct AdaptivePlaybackRateTests {
         #expect(operatingPoint.stableTargetFrames == 256)
         #expect(operatingPoint.probingTargetFrames == 256)
         #expect(operatingPoint.unstableThroughTargetFrames == 192)
-        #expect(AdaptivePlaybackBufferPolicy.nextSessionTargetProbe(
+        #expect(AdaptivePlaybackBufferPolicy.nextDecayTargetFrames(
             callbackFrames: 128,
             stableTargetFrames: 256,
             unstableThroughTargetFrames: operatingPoint.unstableThroughTargetFrames
@@ -847,26 +989,32 @@ struct AdaptivePlaybackRateTests {
     }
 
     @Test
-    func nextSessionReservoirProbeIsConservativeAndRemembersFailures() {
-        #expect(AdaptivePlaybackBufferPolicy.nextSessionTargetProbe(
+    func targetDecayIsConservativeAndRemembersFailures() {
+        #expect(AdaptivePlaybackBufferPolicy.nextDecayTargetFrames(
             callbackFrames: 128,
             stableTargetFrames: 256,
             unstableThroughTargetFrames: nil
         ) == 192)
-        #expect(AdaptivePlaybackBufferPolicy.nextSessionTargetProbe(
+        #expect(AdaptivePlaybackBufferPolicy.nextDecayTargetFrames(
             callbackFrames: 128,
             stableTargetFrames: 256,
             unstableThroughTargetFrames: 192
         ) == nil)
-        #expect(AdaptivePlaybackBufferPolicy.nextSessionTargetProbe(
+        #expect(AdaptivePlaybackBufferPolicy.nextDecayTargetFrames(
             callbackFrames: 64,
             stableTargetFrames: 128,
             unstableThroughTargetFrames: nil
         ) == nil)
+        #expect(AdaptivePlaybackBufferPolicy.nextDecayTargetFrames(
+            callbackFrames: 128,
+            stableTargetFrames: 256,
+            unstableThroughTargetFrames: nil,
+            baselineTargetFrames: 256
+        ) == nil)
     }
 
     @Test
-    func startupTargetSelectsStableOrOneStepDown() {
+    func startupTargetUsesBaselineOrCurrentCalibrationWithoutProbingDown() {
         let stable = PersistedPlaybackBufferOperatingPoint(
             frameSize: 128,
             stableTargetFrames: 256,
@@ -874,27 +1022,17 @@ struct AdaptivePlaybackRateTests {
             unstableThroughTargetFrames: nil
         )
         #expect(AdaptivePlaybackBufferPolicy.startupTargetFrames(
-            callbackFrames: 128,
             baselineTargetFrames: 192,
-            operatingPoint: nil,
-            allowsDownwardProbe: false
+            operatingPoint: nil
         ) == 192)
         #expect(AdaptivePlaybackBufferPolicy.startupTargetFrames(
-            callbackFrames: 128,
             baselineTargetFrames: 192,
-            operatingPoint: stable,
-            allowsDownwardProbe: false
+            operatingPoint: stable
         ) == 256)
-        #expect(AdaptivePlaybackBufferPolicy.startupTargetFrames(
-            callbackFrames: 128,
-            baselineTargetFrames: 192,
-            operatingPoint: stable,
-            allowsDownwardProbe: true
-        ) == 192)
     }
 
     @Test
-    func startupFrameSizeProbesOneRungBelowStableCalibration() {
+    func startupFrameSizeUsesCurrentCalibrationWithoutProbingDown() {
         let calibration = PersistedPlaybackBufferCalibration(
             outputUID: "output-a",
             sampleRate: 48_000,
@@ -908,14 +1046,7 @@ struct AdaptivePlaybackRateTests {
         #expect(AdaptivePlaybackBufferPolicy.startupFrameSize(
             preferredFrameSize: 64,
             calibration: calibration,
-            supportedRange: range,
-            allowsDownwardProbe: true
-        ) == 128)
-        #expect(AdaptivePlaybackBufferPolicy.startupFrameSize(
-            preferredFrameSize: 64,
-            calibration: calibration,
-            supportedRange: range,
-            allowsDownwardProbe: false
+            supportedRange: range
         ) == 256)
 
         var probing = calibration
@@ -923,8 +1054,7 @@ struct AdaptivePlaybackRateTests {
         #expect(AdaptivePlaybackBufferPolicy.startupFrameSize(
             preferredFrameSize: 64,
             calibration: probing,
-            supportedRange: range,
-            allowsDownwardProbe: true
+            supportedRange: range
         ) == 512)
     }
 
@@ -1038,6 +1168,35 @@ struct AdaptivePlaybackRateTests {
         #expect(servo.targetFrames == 192)
         #expect(servo.filteredOccupancyFrames == 192)
         #expect(servo.correctionPartsPerMillion == learnedCorrection)
+    }
+
+    @Test
+    func reprimeAndRetargetDoNotPromoteProportionalCorrectionIntoLearnedBias() {
+        var servo = PlaybackRateServo(sampleRate: 48_000, targetFrames: 128)
+        servo.didPrime(occupancyFrames: 128)
+        for _ in 0..<Int(48_000 / 64) {
+            _ = servo.update(occupancyFrames: 64, outputFrames: 64)
+        }
+        let learnedCorrection = servo.learnedCorrectionPartsPerMillion
+        let activeCorrection = servo.correctionPartsPerMillion
+        #expect(abs(activeCorrection - learnedCorrection) > 10)
+
+        var reprimeServo = servo
+        reprimeServo.beginPriming()
+        #expect(reprimeServo.learnedCorrectionPartsPerMillion == learnedCorrection)
+        #expect(reprimeServo.correctionPartsPerMillion == activeCorrection)
+        reprimeServo.didPrime(occupancyFrames: 128)
+        for _ in 0..<Int(48_000 / 64) {
+            _ = reprimeServo.update(occupancyFrames: 128, outputFrames: 64)
+        }
+        #expect(abs(
+            reprimeServo.correctionPartsPerMillion
+                - reprimeServo.learnedCorrectionPartsPerMillion
+        ) < 0.5)
+
+        servo.retarget(192)
+        #expect(servo.learnedCorrectionPartsPerMillion == learnedCorrection)
+        #expect(servo.correctionPartsPerMillion == activeCorrection)
     }
 
     @Test

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -7,12 +7,166 @@ import Testing
 @Suite
 struct CoreAudioDeviceTests {
     @Test
+    func realtimeOutputFadeStartsMutedAndReachesUnity() {
+        var fade = RealtimeOutputFade(
+            sampleRate: 4,
+            durationSeconds: 1
+        )
+        var samples = Array(repeating: Float(1), count: 8)
+
+        fade.setMuted(false)
+        samples.withUnsafeMutableBufferPointer {
+            fade.apply(to: $0, frameCount: 4, channelCount: 2)
+        }
+
+        #expect(samples == [0, 0, 0.15625, 0.15625, 0.5, 0.5, 0.84375, 0.84375])
+        #expect(fade.gain == 1)
+        #expect(!fade.isMuted)
+
+        samples = [1, 1]
+        samples.withUnsafeMutableBufferPointer {
+            fade.apply(to: $0, frameCount: 1, channelCount: 2)
+        }
+        #expect(samples == [1, 1])
+    }
+
+    @Test
+    func realtimeOutputFadeEndsAtSilence() {
+        var fade = RealtimeOutputFade(
+            sampleRate: 4,
+            initiallyMuted: false,
+            durationSeconds: 1
+        )
+        var samples = Array(repeating: Float(1), count: 4)
+
+        fade.setMuted(true)
+        samples.withUnsafeMutableBufferPointer {
+            fade.apply(to: $0, frameCount: 4, channelCount: 1)
+        }
+
+        #expect(samples == [1, 0.84375, 0.5, 0.15625])
+        #expect(fade.gain == 0)
+        #expect(fade.isMuted)
+
+        samples = [1]
+        samples.withUnsafeMutableBufferPointer {
+            fade.apply(to: $0, frameCount: 1, channelCount: 1)
+        }
+        #expect(samples == [0])
+    }
+
+    @Test
+    func realtimeOutputFadeReversesWithoutGainJump() {
+        var fade = RealtimeOutputFade(
+            sampleRate: 4,
+            durationSeconds: 1
+        )
+        var fadeInSamples = Array(repeating: Float(1), count: 2)
+
+        fade.setMuted(false)
+        fadeInSamples.withUnsafeMutableBufferPointer {
+            fade.apply(to: $0, frameCount: 2, channelCount: 1)
+        }
+        #expect(fadeInSamples == [0, 0.15625])
+        #expect(fade.gain == 0.5)
+
+        var fadeOutSamples = Array(repeating: Float(1), count: 4)
+        fade.setMuted(true)
+        fadeOutSamples.withUnsafeMutableBufferPointer {
+            fade.apply(to: $0, frameCount: 4, channelCount: 1)
+        }
+
+        #expect(fadeOutSamples == [0.5, 0.421875, 0.25, 0.078125])
+        #expect(fade.isMuted)
+    }
+
+    @Test
     func defaultOutputQueryDoesNotCrash() throws {
         let device = try CoreAudioDeviceQuery.defaultOutputDevice()
 
         #expect(!device.name.isEmpty)
         #expect(!device.uid.isEmpty)
         #expect(device.nominalSampleRate > 0)
+    }
+
+    @Test
+    func systemTapExcludesGlassEQAndSystemSoundsByBundleID() {
+        let description = SystemTapAudioEngine.makeSystemTapDescription(
+            excluding: [42],
+            outputUID: "test-output",
+            streamIndex: 1
+        )
+
+        #expect(description.processes == [42])
+        #expect(description.bundleIDs == ["systemsoundserverd"])
+        #expect(description.isExclusive)
+        #expect(description.isProcessRestoreEnabled)
+    }
+
+    @Test
+    func systemSoundTapIncludesDormantDaemonByBundleID() {
+        let description = SystemTapAudioEngine.makeSystemSoundTapDescription(
+            outputUID: "test-output",
+            streamIndex: 1
+        )
+
+        #expect(description.processes.isEmpty)
+        #expect(description.bundleIDs == ["systemsoundserverd"])
+        #expect(!description.isExclusive)
+        #expect(description.muteBehavior == .muted)
+        #expect(!description.isMixdown)
+        #expect(description.isProcessRestoreEnabled)
+    }
+
+    @Test
+    func aggregateTapValidationReturnsHALStreamOrder() {
+        let systemSounds = aggregateTapEntry(uid: "system-sounds")
+        let main = aggregateTapEntry(uid: "main")
+
+        let order = SystemTapAudioEngine.validatedAggregateTapUIDOrder(
+            [systemSounds, main],
+            expectedTapDriftCompensation: ["main": true, "system-sounds": true]
+        )
+
+        #expect(order == ["system-sounds", "main"])
+    }
+
+    @Test
+    func aggregateTapValidationRejectsUnknownOrUncompensatedTap() {
+        let main = aggregateTapEntry(uid: "main")
+        let unknown = aggregateTapEntry(uid: "unknown")
+        let uncompensated = aggregateTapEntry(uid: "system-sounds", drift: false)
+
+        #expect(SystemTapAudioEngine.validatedAggregateTapUIDOrder(
+            [main, unknown],
+            expectedTapDriftCompensation: ["main": true, "system-sounds": true]
+        ) == nil)
+        #expect(SystemTapAudioEngine.validatedAggregateTapUIDOrder(
+            [main, uncompensated],
+            expectedTapDriftCompensation: ["main": true, "system-sounds": true]
+        ) == nil)
+    }
+
+    @Test
+    func systemSoundPreampUsesPerChannelProfileGains() {
+        let profile = EQProfile(
+            name: "Stereo",
+            mode: .parametric,
+            channelMode: .stereo,
+            filters: [],
+            leftPreampDB: -6,
+            rightPreampDB: -12
+        )
+        let configuration = EQRenderConfiguration(
+            profile: profile,
+            sampleRate: 48_000,
+            channelCount: 2
+        )
+
+        let gains = SystemTapAudioEngine.systemSoundPreampGains(for: configuration)
+
+        #expect(abs(gains.left - Float(pow(10, -6.0 / 20))) < 0.000_001)
+        #expect(abs(gains.right - Float(pow(10, -12.0 / 20))) < 0.000_001)
     }
 
     @Test
@@ -92,53 +246,73 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
-    func playbackConversionCapacityRejectsPrimesWithoutRingHeadroom() throws {
-        try SystemTapAudioEngine.validatePlaybackConversionCapacity(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 8_192),
-            tapSampleRate: 48_000
-        )
-        try SystemTapAudioEngine.validatePlaybackConversionCapacity(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 1_024),
-            tapSampleRate: 192_000
-        )
+    func tapToOutputLatencyUsesValidHostTimestamps() throws {
+        var inputTime = AudioTimeStamp()
+        inputTime.mHostTime = AudioConvertNanosToHostTime(1_000_000_000)
+        inputTime.mFlags = .hostTimeValid
 
-        do {
-            try SystemTapAudioEngine.validatePlaybackConversionCapacity(
-                for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 8_192),
-                tapSampleRate: 96_000
-            )
-            Issue.record("Expected oversized converted playback prime to be rejected")
-        } catch let error as AudioDeviceAvailabilityError {
-            #expect(error == .unsupportedPlaybackConversionBuffer(
-                42,
-                requiredPrimeFrames: 50_176,
-                maximumPrimeFrames: 40_960
-            ))
-        } catch {
-            Issue.record("Expected unsupported converted playback buffer error, got \(error)")
-        }
+        let latencyHostTime = AudioConvertNanosToHostTime(2_500_000)
+        var outputTime = AudioTimeStamp()
+        outputTime.mHostTime = inputTime.mHostTime + latencyHostTime
+        outputTime.mFlags = .hostTimeValid
+
+        #expect(SystemTapAudioEngine.tapToOutputLatencyNanoseconds(
+            inputTime: inputTime,
+            outputTime: outputTime
+        ) == AudioConvertHostTimeToNanos(latencyHostTime))
+
+        var invalidInputTime = inputTime
+        invalidInputTime.mFlags = []
+        #expect(SystemTapAudioEngine.tapToOutputLatencyNanoseconds(
+            inputTime: invalidInputTime,
+            outputTime: outputTime
+        ) == nil)
+
+        outputTime.mHostTime = inputTime.mHostTime - 1
+        #expect(SystemTapAudioEngine.tapToOutputLatencyNanoseconds(
+            inputTime: inputTime,
+            outputTime: outputTime
+        ) == nil)
     }
 
     @Test
-    func unsupportedRuntimeChannelCountSkipsDevicePreparation() {
-        var didPrepareDevice = false
-        let channelCount = CoreAudioDeviceQuery.maxChannelCount + 1
+    func callbackTimingSplitsInputAgeFromOutputLead() throws {
+        var inputTime = AudioTimeStamp()
+        inputTime.mHostTime = AudioConvertNanosToHostTime(1_000_000_000)
+        inputTime.mFlags = .hostTimeValid
 
-        do {
-            _ = try SystemTapAudioEngine.performAfterRuntimeChannelValidation(
-                for: output(channelCount: channelCount, sampleRate: 44_100)
-            ) {
-                didPrepareDevice = true
-                return output(channelCount: channelCount, sampleRate: 48_000)
-            }
-            Issue.record("Expected out-of-range output to be rejected")
-        } catch let error as AudioDeviceAvailabilityError {
-            #expect(error == .unsupportedOutputChannelCount(42, channelCount))
-        } catch {
-            Issue.record("Expected unsupported channel count error, got \(error)")
-        }
+        let inputAgeHostTime = AudioConvertNanosToHostTime(1_875_000)
+        let outputLeadHostTime = AudioConvertNanosToHostTime(625_000)
+        let callbackHostTime = inputTime.mHostTime + inputAgeHostTime
+        var outputTime = AudioTimeStamp()
+        outputTime.mHostTime = callbackHostTime + outputLeadHostTime
+        outputTime.mFlags = .hostTimeValid
 
-        #expect(!didPrepareDevice)
+        let timing = try #require(SystemTapAudioEngine.callbackTimingNanoseconds(
+            inputTime: inputTime,
+            callbackHostTime: callbackHostTime,
+            outputTime: outputTime
+        ))
+        #expect(timing.inputAge == AudioConvertHostTimeToNanos(inputAgeHostTime))
+        #expect(timing.outputLead == AudioConvertHostTimeToNanos(outputLeadHostTime))
+
+        var invalidInputTime = inputTime
+        invalidInputTime.mFlags = []
+        #expect(SystemTapAudioEngine.callbackTimingNanoseconds(
+            inputTime: invalidInputTime,
+            callbackHostTime: callbackHostTime,
+            outputTime: outputTime
+        ) == nil)
+        #expect(SystemTapAudioEngine.callbackTimingNanoseconds(
+            inputTime: inputTime,
+            callbackHostTime: inputTime.mHostTime - 1,
+            outputTime: outputTime
+        ) == nil)
+        #expect(SystemTapAudioEngine.callbackTimingNanoseconds(
+            inputTime: inputTime,
+            callbackHostTime: outputTime.mHostTime + 1,
+            outputTime: outputTime
+        ) == nil)
     }
 
     @Test
@@ -149,55 +323,6 @@ struct CoreAudioDeviceTests {
         #expect(resolvedOutput.uid == defaultOutput.uid)
         #expect(resolvedOutput.outputChannelCount > 0)
         #expect(try CoreAudioDeviceQuery.outputDevice(uid: "") == nil)
-    }
-
-    @Test
-    func sampleRateMutationRecordsRestorationBeforeDeviceWrite() throws {
-        let output = output(uid: "record-before-set", channelCount: 2, sampleRate: 44_100)
-        var events: [String] = []
-
-        try SystemTapAudioEngine.setSampleRateAfterRecordingRestoration(
-            48_000,
-            on: output,
-            needsRestoration: true,
-            recordRestoration: { restoration in
-                #expect(restoration.uid == output.uid)
-                #expect(restoration.originalSampleRate == 44_100)
-                events.append("record")
-            },
-            installRestoration: { restoration in
-                #expect(restoration.uid == output.uid)
-                events.append("install")
-            },
-            setSampleRate: { sampleRate, objectID in
-                #expect(sampleRate == 48_000)
-                #expect(objectID == output.id)
-                events.append("set")
-            }
-        )
-
-        #expect(events == ["record", "install", "set"])
-    }
-
-    @Test
-    func sampleRateMutationSkipsDeviceWriteWhenRestorationRecordFails() {
-        let output = output(uid: "record-fails", channelCount: 2, sampleRate: 44_100)
-        var didInstall = false
-        var didSet = false
-
-        #expect(throws: TestDeviceMutationError.recordFailed) {
-            try SystemTapAudioEngine.setSampleRateAfterRecordingRestoration(
-                48_000,
-                on: output,
-                needsRestoration: true,
-                recordRestoration: { _ in throw TestDeviceMutationError.recordFailed },
-                installRestoration: { _ in didInstall = true },
-                setSampleRate: { _, _ in didSet = true }
-            )
-        }
-
-        #expect(!didInstall)
-        #expect(!didSet)
     }
 
     @Test
@@ -230,59 +355,6 @@ struct CoreAudioDeviceTests {
         #expect(setCalls.count == 1)
         #expect(setCalls.first?.sampleRate == 48_000)
         #expect(setCalls.first?.objectID == 9_001)
-    }
-
-    @Test
-    func sameOutputRebuildReinstallsRestorationFromFreshDeviceRate() throws {
-        let uid = "same-output"
-        let objectID = AudioObjectID(9_003)
-        var currentSampleRate = 48_000.0
-        let originalRestoration = SystemTapAudioEngine.SampleRateRestoration(
-            uid: uid,
-            originalSampleRate: 44_100
-        )
-        let outputForUID: (String) throws -> AudioOutputDevice? = { requestedUID in
-            #expect(requestedUID == uid)
-            return output(
-                id: objectID,
-                uid: uid,
-                channelCount: 2,
-                sampleRate: currentSampleRate
-            )
-        }
-        let setSampleRate: (Double, AudioObjectID) throws -> Void = { sampleRate, requestedID in
-            #expect(requestedID == objectID)
-            currentSampleRate = sampleRate
-        }
-
-        #expect(SystemTapAudioEngine.restoreSampleRateRestoration(
-            originalRestoration,
-            outputForUID: outputForUID,
-            setSampleRate: setSampleRate
-        ))
-        let refreshedOutput = try #require(try outputForUID(uid))
-        #expect(refreshedOutput.nominalSampleRate == 44_100)
-        #expect(SystemTapAudioEngine.shouldRecordSampleRateRestoration(
-            tapSampleRate: 48_000,
-            output: refreshedOutput
-        ))
-
-        var replacementRestoration: SystemTapAudioEngine.SampleRateRestoration?
-        try SystemTapAudioEngine.setSampleRateAfterRecordingRestoration(
-            48_000,
-            on: refreshedOutput,
-            needsRestoration: true,
-            recordRestoration: { replacementRestoration = $0 },
-            installRestoration: { _ in },
-            setSampleRate: setSampleRate
-        )
-        #expect(currentSampleRate == 48_000)
-        #expect(SystemTapAudioEngine.restoreSampleRateRestoration(
-            try #require(replacementRestoration),
-            outputForUID: outputForUID,
-            setSampleRate: setSampleRate
-        ))
-        #expect(currentSampleRate == 44_100)
     }
 
     @Test
@@ -364,6 +436,56 @@ struct CoreAudioDeviceTests {
 
         #expect(restored)
         #expect(!didSet)
+    }
+
+    @Test
+    func adaptiveBufferDecayWritesAndVerifiesThePreviousStep() throws {
+        let current = output(channelCount: 2, bufferFrameSize: 256)
+        var requestedFrameSize: UInt32?
+
+        let updated = try SeparateClockAudioBackend.decayedPlaybackOutput(
+            current,
+            supportedRange: AudioBufferFrameSizeRange(minimum: 64, maximum: 512),
+            setBufferFrameSize: { frameSize, objectID in
+                #expect(objectID == current.id)
+                requestedFrameSize = frameSize
+            },
+            queryOutput: { objectID in
+                #expect(objectID == current.id)
+                return output(id: objectID, channelCount: 2, bufferFrameSize: 128)
+            }
+        )
+
+        #expect(requestedFrameSize == 128)
+        #expect(updated?.bufferFrameSize == 128)
+    }
+
+    @Test
+    func adaptiveBufferDecayWaitsForTheDevicePropertyToSettle() throws {
+        let current = output(channelCount: 2, bufferFrameSize: 256)
+        var queryCount = 0
+        var waitCount = 0
+
+        let updated = try SeparateClockAudioBackend.decayedPlaybackOutput(
+            current,
+            supportedRange: AudioBufferFrameSizeRange(minimum: 64, maximum: 512),
+            setBufferFrameSize: { _, _ in },
+            queryOutput: { objectID in
+                queryCount += 1
+                return output(
+                    id: objectID,
+                    channelCount: 2,
+                    bufferFrameSize: queryCount < 3 ? 256 : 128
+                )
+            },
+            waitForPropertySettlement: {
+                waitCount += 1
+            }
+        )
+
+        #expect(queryCount == 3)
+        #expect(waitCount == 2)
+        #expect(updated?.bufferFrameSize == 128)
     }
 
     @Test
@@ -504,174 +626,104 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
-    func preferredBufferFrameSizeShrinksStandardSpeakerRoutesForLowLatency() {
-        #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 128)) == 64)
-        #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 512)) == 64)
-        #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 2_048)) == 64)
+    func preferredBufferFrameSizeUses16FramesForStandardSpeakerRoutes() {
+        #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 128)) == 16)
+        #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 512)) == 16)
+        #expect(SystemTapAudioEngine.preferredBufferFrameSize(for: output(channelCount: 2, bufferFrameSize: 2_048)) == 16)
     }
 
     @Test
-    func bluetoothAndLowSampleRateRoutesKeepRouteSpecificBufferPreferences() {
+    func aggregateTimestampSlopeQualificationRequiresStableNominalTiming() {
+        #expect(SystemTapAudioEngine.timestampSlopeAgrees(
+            frameCount: 16,
+            sampleRate: 48_000,
+            sampleTimeDeltaFrames: 0,
+            hostIntervalErrorNanoseconds: 40_000,
+            rateScalar: 1.000005752,
+            rateScalarIsValid: true
+        ))
+        #expect(!SystemTapAudioEngine.timestampSlopeAgrees(
+            frameCount: 16,
+            sampleRate: 48_000,
+            sampleTimeDeltaFrames: 1,
+            hostIntervalErrorNanoseconds: 40_000,
+            rateScalar: 1,
+            rateScalarIsValid: true
+        ))
+        #expect(!SystemTapAudioEngine.timestampSlopeAgrees(
+            frameCount: 16,
+            sampleRate: 48_000,
+            sampleTimeDeltaFrames: 0,
+            hostIntervalErrorNanoseconds: 100_000,
+            rateScalar: 1,
+            rateScalarIsValid: true
+        ))
+        #expect(!SystemTapAudioEngine.timestampSlopeAgrees(
+            frameCount: 16,
+            sampleRate: 48_000,
+            sampleTimeDeltaFrames: 0,
+            hostIntervalErrorNanoseconds: 0,
+            rateScalar: 1.02,
+            rateScalarIsValid: true
+        ))
+    }
+
+    @Test
+    func headsetPromotionRequiresDeviceClockToMatchTheNominalRate() {
+        #expect(SystemTapAudioEngine.deviceClockSlopeAgrees(
+            sampleTimeDeltaFrames: 2_400,
+            hostTimeDeltaNanoseconds: 100_000_000,
+            nominalSampleRate: 24_000,
+            rateScalar: 1,
+            rateScalarIsValid: true
+        ))
+        #expect(!SystemTapAudioEngine.deviceClockSlopeAgrees(
+            sampleTimeDeltaFrames: 4_800,
+            hostTimeDeltaNanoseconds: 100_000_000,
+            nominalSampleRate: 24_000,
+            rateScalar: 1,
+            rateScalarIsValid: true
+        ))
+        #expect(!SystemTapAudioEngine.deviceClockSlopeAgrees(
+            sampleTimeDeltaFrames: 2_400,
+            hostTimeDeltaNanoseconds: 100_000_000,
+            nominalSampleRate: 24_000,
+            rateScalar: 1.03,
+            rateScalarIsValid: true
+        ))
+    }
+
+    @Test
+    func aggregateBufferPreferenceIs16FramesForBluetoothAndLowSampleRateRoutes() {
         #expect(SystemTapAudioEngine.preferredBufferFrameSize(
             for: output(channelCount: 2, bufferFrameSize: 256, transportType: kAudioDeviceTransportTypeBluetooth)
-        ) == 64)
+        ) == 16)
         #expect(SystemTapAudioEngine.preferredBufferFrameSize(
             for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 256)
-        ) == 1_024)
+        ) == 16)
     }
 
     @Test
-    func playbackPrimeTracksTheTunedRouteCallbackSize() {
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, bufferFrameSize: 64)
-        ) == 128)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, bufferFrameSize: 128)
-        ) == 192)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
+    func headsetModeUsesSeparateClockBackend() {
+        #expect(SystemTapAudioEngine.shouldUseSeparateClockBackend(
             for: output(
                 channelCount: 2,
-                bufferFrameSize: 64,
+                sampleRate: 24_000,
+                bufferFrameSize: 480,
                 transportType: kAudioDeviceTransportTypeBluetooth
             )
-        ) == 128)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
+        ))
+        #expect(!SystemTapAudioEngine.shouldUseSeparateClockBackend(
             for: output(
                 channelCount: 2,
-                bufferFrameSize: 1_024,
-                transportType: kAudioDeviceTransportTypeBluetooth
-            )
-        ) == 1_088)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 1_024)
-        ) == 2_048)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, sampleRate: 24_000, bufferFrameSize: 1_024),
-            tapSampleRate: 48_000
-        ) == 3_072)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 1_024),
-            tapSampleRate: 48_000
-        ) == 4_096)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 1_024),
-            tapSampleRate: 48_000,
-            captureCallbackFrames: 8_192
-        ) == 11_264)
-        #expect(SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, sampleRate: 48_000, bufferFrameSize: 64),
-            tapSampleRate: 24_000
-        ) == 1_056)
-    }
-
-    @Test
-    func startupCaptureCallbackUsesReportedSizeOrAdmittedMaximum() {
-        #expect(SystemTapAudioEngine.startupCaptureCallbackFrames(reportedFrames: 64) == 64)
-        #expect(SystemTapAudioEngine.startupCaptureCallbackFrames(reportedFrames: 8_192) == 8_192)
-        #expect(SystemTapAudioEngine.startupCaptureCallbackFrames(reportedFrames: nil) == 8_192)
-        #expect(SystemTapAudioEngine.startupCaptureCallbackFrames(reportedFrames: 8_193) == 8_192)
-    }
-
-    @Test
-    func headsetSampleRateConversionHandlesBothTransitionDirections() {
-        let headsetOutput = output(
-            channelCount: 2,
-            sampleRate: 24_000,
-            bufferFrameSize: 1_024,
-            transportType: kAudioDeviceTransportTypeBluetooth
-        )
-        let normalOutput = output(
-            channelCount: 2,
-            sampleRate: 48_000,
-            bufferFrameSize: 128,
-            transportType: kAudioDeviceTransportTypeBluetooth
-        )
-
-        #expect(SystemTapAudioEngine.shouldUseSampleRateConversion(
-            tapSampleRate: 48_000,
-            output: headsetOutput
-        ))
-        #expect(!SystemTapAudioEngine.shouldUseSampleRateConversion(
-            tapSampleRate: 48_000,
-            output: normalOutput
-        ))
-        #expect(SystemTapAudioEngine.shouldUseSampleRateConversion(
-            tapSampleRate: 24_000,
-            output: normalOutput
-        ))
-        #expect(!SystemTapAudioEngine.shouldUseSampleRateConversion(
-            tapSampleRate: 24_000,
-            output: headsetOutput
-        ))
-        #expect(SystemTapAudioEngine.shouldRefreshCaptureForOutput(
-            tapSampleRate: 24_000,
-            output: normalOutput
-        ))
-        #expect(SystemTapAudioEngine.shouldRefreshCaptureForOutput(
-            tapSampleRate: 16_000,
-            output: headsetOutput
-        ))
-        #expect(!SystemTapAudioEngine.shouldRefreshCaptureForOutput(
-            tapSampleRate: 24_000,
-            output: output(
-                channelCount: 2,
-                sampleRate: 16_000,
-                bufferFrameSize: 1_024,
+                sampleRate: 48_000,
+                bufferFrameSize: 512,
                 transportType: kAudioDeviceTransportTypeBluetooth
             )
         ))
-        #expect(!SystemTapAudioEngine.shouldRefreshCaptureForOutput(
-            tapSampleRate: 48_000,
-            output: headsetOutput
+        #expect(!SystemTapAudioEngine.shouldUseSeparateClockBackend(
+            for: output(channelCount: 2, sampleRate: 24_000, bufferFrameSize: 480)
         ))
-        #expect(SystemTapAudioEngine.maximumPlaybackReservoirFrames(
-            for: normalOutput,
-            tapSampleRate: 24_000,
-            maximumKnownCaptureCallbackFrames: 768
-        ) == 1_024)
-        #expect(SystemTapAudioEngine.maximumPlaybackReservoirFrames(
-            for: normalOutput,
-            tapSampleRate: 48_000,
-            maximumKnownCaptureCallbackFrames: 768
-        ) == AdaptivePlaybackBufferPolicy.maximumReservoirFrames)
-    }
-
-    @Test
-    func outputRebuildUsesAProfileHotSwappedAfterPreparation() {
-        let prepared = EQProfile(name: "Prepared", mode: .parametric, filters: [])
-        let hotSwapped = EQProfile(name: "Hot Swapped", mode: .parametric, filters: [])
-
-        #expect(SystemTapAudioEngine.effectiveOutputRebuildProfile(
-            preparedProfile: prepared,
-            preparedProfileRevision: 1,
-            activeProfile: prepared,
-            activeProfileRevision: 1
-        ) == prepared)
-        #expect(SystemTapAudioEngine.effectiveOutputRebuildProfile(
-            preparedProfile: prepared,
-            preparedProfileRevision: 1,
-            activeProfile: hotSwapped,
-            activeProfileRevision: 2
-        ) == hotSwapped)
-    }
-
-    @Test
-    func staleOutputRebuildRequestUsesTheCurrentProfile() {
-        let requested = EQProfile(name: "Requested", mode: .parametric, filters: [])
-        let current = EQProfile(name: "Current", mode: .parametric, filters: [])
-
-        #expect(SystemTapAudioEngine.requestedOutputRebuildProfile(
-            requestedProfile: requested,
-            expectedProfileRevision: 1,
-            activeProfile: requested,
-            activeProfileRevision: 1
-        ) == requested)
-        #expect(SystemTapAudioEngine.requestedOutputRebuildProfile(
-            requestedProfile: requested,
-            expectedProfileRevision: 1,
-            activeProfile: current,
-            activeProfileRevision: 2
-        ) == current)
     }
 
     @Test
@@ -682,160 +734,6 @@ struct CoreAudioDeviceTests {
 
         let activeOutput = output(uid: "profile-update-output", channelCount: 2)
         #expect(try SystemTapAudioEngine.profileUpdateOutput(activeOutput) == activeOutput)
-    }
-
-    @Test
-    func adaptivePlaybackBufferAppliesToEveryValidOutputRate() {
-        #expect(SystemTapAudioEngine.shouldAdaptPlaybackBuffer(
-            for: output(channelCount: 2, bufferFrameSize: 64)
-        ))
-        #expect(SystemTapAudioEngine.shouldAdaptPlaybackBuffer(
-            for: output(
-                channelCount: 2,
-                bufferFrameSize: 64,
-                transportType: kAudioDeviceTransportTypeBluetooth
-            )
-        ))
-        #expect(SystemTapAudioEngine.shouldAdaptPlaybackBuffer(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 1_024)
-        ))
-        #expect(SystemTapAudioEngine.playbackInputCallbackFrames(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 1_024),
-            tapSampleRate: 48_000
-        ) == 3_072)
-    }
-
-    @Test
-    func runtimeRingAlwaysLeavesHeadroomAboveTheLargestPrime() {
-        let largestPrime = SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, bufferFrameSize: 8_192)
-        )
-
-        #expect(largestPrime == 8_256)
-        #expect(SystemTapAudioEngine.runtimeRingCapacityFrames >= largestPrime * 2)
-
-        let largestConvertedPrime = SystemTapAudioEngine.preferredPlaybackPrimeFrames(
-            for: output(channelCount: 2, sampleRate: 16_000, bufferFrameSize: 8_192),
-            tapSampleRate: 48_000
-        )
-        #expect(SystemTapAudioEngine.runtimeRingCapacityFrames >= largestConvertedPrime * 2)
-    }
-
-    @Test
-    func adaptiveBufferLadderStopsAtStableLegacySize() {
-        let range = AudioBufferFrameSizeRange(minimum: 15, maximum: 960)
-
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 64, supportedRange: range) == 128)
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 128, supportedRange: range) == 256)
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 256, supportedRange: range) == 512)
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 512, supportedRange: range) == nil)
-        #expect(AdaptivePlaybackBufferPolicy.previousFrameSize(before: 512, supportedRange: range) == 256)
-        #expect(AdaptivePlaybackBufferPolicy.previousFrameSize(before: 128, supportedRange: range) == 64)
-        #expect(AdaptivePlaybackBufferPolicy.previousFrameSize(before: 64, supportedRange: range) == 15)
-    }
-
-    @Test
-    func adaptiveBufferLadderHonorsPartialDeviceRange() {
-        let range = AudioBufferFrameSizeRange(minimum: 96, maximum: 300)
-
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 96, supportedRange: range) == 128)
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 128, supportedRange: range) == 256)
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 256, supportedRange: range) == 300)
-        #expect(AdaptivePlaybackBufferPolicy.nextFrameSize(after: 300, supportedRange: range) == nil)
-    }
-
-    @Test
-    func adaptiveBufferRenegotiationWritesAndVerifiesTheNextStep() throws {
-        let current = output(
-            channelCount: 2,
-            bufferFrameSize: 64,
-            transportType: kAudioDeviceTransportTypeBluetooth
-        )
-        var requestedFrameSize: UInt32?
-
-        let updated = try SystemTapAudioEngine.renegotiatedPlaybackOutput(
-            current,
-            supportedRange: AudioBufferFrameSizeRange(minimum: 15, maximum: 960),
-            setBufferFrameSize: { frameSize, objectID in
-                #expect(objectID == current.id)
-                requestedFrameSize = frameSize
-            },
-            queryOutput: { objectID in
-                #expect(objectID == current.id)
-                return output(
-                    id: objectID,
-                    channelCount: 2,
-                    bufferFrameSize: 128,
-                    transportType: kAudioDeviceTransportTypeBluetooth
-                )
-            }
-        )
-
-        #expect(requestedFrameSize == 128)
-        #expect(updated?.bufferFrameSize == 128)
-    }
-
-    @Test
-    func adaptiveBufferRenegotiationWaitsForTheDevicePropertyToSettle() throws {
-        let current = output(channelCount: 2, bufferFrameSize: 64)
-        var queryCount = 0
-        var waitCount = 0
-
-        let updated = try SystemTapAudioEngine.renegotiatedPlaybackOutput(
-            current,
-            supportedRange: AudioBufferFrameSizeRange(minimum: 64, maximum: 512),
-            setBufferFrameSize: { _, _ in },
-            queryOutput: { objectID in
-                queryCount += 1
-                return output(
-                    id: objectID,
-                    channelCount: 2,
-                    bufferFrameSize: queryCount < 3 ? 64 : 128
-                )
-            },
-            waitForPropertySettlement: {
-                waitCount += 1
-            }
-        )
-
-        #expect(queryCount == 3)
-        #expect(waitCount == 2)
-        #expect(updated?.bufferFrameSize == 128)
-    }
-
-    @Test
-    func topologyRebuildAcquiresMuteGuardBeforeRebuildAndReleasesAfter() throws {
-        var events: [String] = []
-        let result = try SystemTapAudioEngine.performTopologyRebuild(
-            acquireMuteGuard: {
-                events.append("acquire")
-                return FakeTopologyRebuildMuteGuard(events: { events.append($0) })
-            },
-            rebuild: {
-                events.append("rebuild")
-                return 7
-            }
-        )
-
-        #expect(result == 7)
-        #expect(events == ["acquire", "rebuild", "release"])
-    }
-
-    @Test
-    func topologyRebuildSkipsTeardownWhenMuteGuardCannotBeAcquired() {
-        var rebuildWasCalled = false
-
-        #expect(throws: TopologyRebuildMuteGuardUnavailable.self) {
-            _ = try SystemTapAudioEngine.performTopologyRebuild(
-                acquireMuteGuard: {
-                    throw CoreAudioError(operation: "test mute guard", status: kAudioHardwareUnspecifiedError)
-                },
-                rebuild: {
-                    rebuildWasCalled = true
-                }
-            )
-        }
-        #expect(!rebuildWasCalled)
     }
 
     @Test
@@ -1018,6 +916,13 @@ struct CoreAudioDeviceTests {
             try CoreAudioDeviceQuery.validateStreamConfigurationSize(4, objectID: 42)
         }
         expectInvalidMetadata {
+            try CoreAudioDeviceQuery.validateAudioBufferListStorage(
+                bufferCount: 1,
+                byteCount: 8,
+                objectID: 42
+            )
+        }
+        expectInvalidMetadata {
             try CoreAudioDeviceQuery.validateStreamConfigurationSize(
                 CoreAudioDeviceQuery.maxStreamConfigurationBytes + 1,
                 objectID: 42
@@ -1038,6 +943,16 @@ struct CoreAudioDeviceTests {
         #expect(range == AudioBufferFrameSizeRange(minimum: 128, maximum: 256))
     }
 
+    @Test
+    func zeroBufferStreamConfigurationIsValidForOutputOnlyDevice() throws {
+        try CoreAudioDeviceQuery.validateStreamConfigurationSize(8, objectID: 42)
+        try CoreAudioDeviceQuery.validateAudioBufferListStorage(
+            bufferCount: 0,
+            byteCount: 8,
+            objectID: 42
+        )
+    }
+
     private func expectInvalidMetadata(_ operation: () throws -> Void) {
         do {
             try operation()
@@ -1050,6 +965,18 @@ struct CoreAudioDeviceTests {
         } catch {
             Issue.record("Expected invalid metadata error, got \(error)")
         }
+    }
+
+    private func aggregateTapEntry(
+        uid: String,
+        drift: Bool = true
+    ) -> NSDictionary {
+        [
+            kAudioSubTapUIDKey: uid,
+            kAudioSubTapDriftCompensationKey: NSNumber(value: drift),
+            kAudioSubTapDriftCompensationQualityKey:
+                NSNumber(value: kAudioAggregateDriftCompensationHighQuality)
+        ] as NSDictionary
     }
 
     private func output(
@@ -1072,10 +999,6 @@ struct CoreAudioDeviceTests {
     }
 }
 
-private enum TestDeviceMutationError: Error {
-    case recordFailed
-}
-
 private final class LockedCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0
@@ -1092,17 +1015,5 @@ private final class LockedCounter: @unchecked Sendable {
             lock.unlock()
         }
         return count
-    }
-}
-
-private final class FakeTopologyRebuildMuteGuard: TopologyRebuildMuteGuarding {
-    private let record: (String) -> Void
-
-    init(events record: @escaping (String) -> Void) {
-        self.record = record
-    }
-
-    func release() {
-        record("release")
     }
 }

--- a/Tests/GlassEQAudioTests/MultiChannelOutputMappingTests.swift
+++ b/Tests/GlassEQAudioTests/MultiChannelOutputMappingTests.swift
@@ -19,6 +19,42 @@ struct MultiChannelOutputMappingTests {
     }
 
     @Test
+    func deviceTapUsesStreamContainingBothPlaybackChannels() {
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [2],
+            playbackChannels: (0, 1)
+        ) == 0)
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [2, 2, 2],
+            playbackChannels: (2, 3)
+        ) == 1)
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [2, 2, 1],
+            playbackChannels: (4, 4)
+        ) == 2)
+    }
+
+    @Test
+    func deviceTapRejectsPlaybackChannelsThatCannotShareAStream() {
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [2, 2, 2],
+            playbackChannels: (1, 2)
+        ) == nil)
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [2, 0, 2],
+            playbackChannels: (0, 1)
+        ) == nil)
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [],
+            playbackChannels: (0, 1)
+        ) == nil)
+        #expect(SystemTapAudioEngine.tapOutputStreamIndex(
+            streamChannelCounts: [6],
+            playbackChannels: (2, 3)
+        ) == nil)
+    }
+
+    @Test
     func playbackChannelPairEncodingRoundTripsAndClamps() {
         #expect(SystemTapAudioEngine.decodedPlaybackChannelPair(
             SystemTapAudioEngine.encodedPlaybackChannelPair(left: 0, right: 1)
@@ -199,6 +235,175 @@ struct MultiChannelOutputMappingTests {
         #expect(written == [[1, 2, 3, 4]])
     }
 
+    @Test
+    func tapInputOffsetAccountsForDuplexPhysicalOutput() {
+        #expect(SystemTapAudioEngine.tapInputChannelOffset(
+            physicalInputChannelCount: 0,
+            aggregateInputChannelCount: 2,
+            tapChannelCount: 2
+        ) == 0)
+        #expect(SystemTapAudioEngine.tapInputChannelOffset(
+            physicalInputChannelCount: 2,
+            aggregateInputChannelCount: 4,
+            tapChannelCount: 2
+        ) == 2)
+        #expect(SystemTapAudioEngine.tapInputChannelOffset(
+            physicalInputChannelCount: 2,
+            aggregateInputChannelCount: 2,
+            tapChannelCount: 2
+        ) == nil)
+    }
+
+    @Test
+    func tapInputOffsetsAccountForBothProcessTaps() throws {
+        let duplexOffsets = try #require(SystemTapAudioEngine.tapInputChannelOffsets(
+            physicalInputChannelCount: 2,
+            aggregateInputChannelCount: 6,
+            mainTapChannelCount: 2,
+            systemSoundTapChannelCount: 2
+        ))
+        let outputOnlyOffsets = try #require(SystemTapAudioEngine.tapInputChannelOffsets(
+            physicalInputChannelCount: 0,
+            aggregateInputChannelCount: 4,
+            mainTapChannelCount: 2,
+            systemSoundTapChannelCount: 2
+        ))
+        let reorderedOffsets = try #require(SystemTapAudioEngine.tapInputChannelOffsets(
+            physicalInputChannelCount: 2,
+            aggregateInputChannelCount: 6,
+            mainTapChannelCount: 2,
+            systemSoundTapChannelCount: 2,
+            mainTapIndex: 1,
+            systemSoundTapIndex: 0
+        ))
+
+        #expect(duplexOffsets.main == 2)
+        #expect(duplexOffsets.systemSounds == 4)
+        #expect(outputOnlyOffsets.main == 0)
+        #expect(outputOnlyOffsets.systemSounds == 2)
+        #expect(reorderedOffsets.main == 4)
+        #expect(reorderedOffsets.systemSounds == 2)
+        #expect(SystemTapAudioEngine.tapInputChannelOffsets(
+            physicalInputChannelCount: 2,
+            aggregateInputChannelCount: 5,
+            mainTapChannelCount: 2,
+            systemSoundTapChannelCount: 1
+        ) == nil)
+        #expect(SystemTapAudioEngine.tapInputChannelOffsets(
+            physicalInputChannelCount: 2,
+            aggregateInputChannelCount: 6,
+            mainTapChannelCount: 2,
+            systemSoundTapChannelCount: 2,
+            mainTapIndex: 0,
+            systemSoundTapIndex: 0
+        ) == nil)
+    }
+
+    @Test
+    func inputStreamUsageEnablesOnlyTapStreams() {
+        #expect(SystemTapAudioEngine.inputStreamUsage(
+            streamChannelCounts: [2, 2],
+            tapChannelOffset: 2,
+            tapChannelCount: 2
+        ) == [0, 1])
+        #expect(SystemTapAudioEngine.inputStreamUsage(
+            streamChannelCounts: [2],
+            tapChannelOffset: 0,
+            tapChannelCount: 2
+        ) == [1])
+        #expect(SystemTapAudioEngine.inputStreamUsage(
+            streamChannelCounts: [2, 2, 2],
+            tapChannelOffset: 2,
+            tapChannelCount: 4
+        ) == [0, 1, 1])
+    }
+
+    @Test
+    func inputStreamUsageRejectsLayoutsThatCannotIsolateTheTap() {
+        #expect(SystemTapAudioEngine.inputStreamUsage(
+            streamChannelCounts: [4],
+            tapChannelOffset: 2,
+            tapChannelCount: 2
+        ) == nil)
+        #expect(SystemTapAudioEngine.inputStreamUsage(
+            streamChannelCounts: [2, 2],
+            tapChannelOffset: 2,
+            tapChannelCount: 1
+        ) == nil)
+        #expect(SystemTapAudioEngine.inputStreamUsage(
+            streamChannelCounts: [2, 0, 2],
+            tapChannelOffset: 2,
+            tapChannelCount: 2
+        ) == nil)
+    }
+
+    @Test
+    func aggregateInputCopySkipsPhysicalInputChannels() {
+        let interleaved = copiedInput(
+            input: [
+                10, 11, 1, 2,
+                12, 13, 3, 4
+            ],
+            inputChannelLayout: [4],
+            frameCount: 2,
+            channelCount: 2,
+            sourceChannelOffset: 2
+        )
+        let split = copiedInput(
+            input: [
+                10, 11, 12, 13,
+                1, 2, 3, 4
+            ],
+            inputChannelLayout: [2, 2],
+            frameCount: 2,
+            channelCount: 2,
+            sourceChannelOffset: 2
+        )
+
+        #expect(interleaved == [1, 2, 3, 4])
+        #expect(split == [1, 2, 3, 4])
+    }
+
+    @Test
+    func systemSoundInputIsMixedWithPerChannelPreamp() {
+        let result = mixedInput(
+            input: [
+                10, 11, 12, 13,
+                20, 21, 22, 23,
+                0.4, -0.4, 0.2, -0.2
+            ],
+            inputChannelLayout: [2, 2, 2],
+            samples: [0.1, -0.2, 0.3, -0.4],
+            frameCount: 2,
+            channelCount: 2,
+            sourceChannelOffset: 4,
+            preampGains: (left: 0.5, right: 0.25)
+        )
+
+        #expect(abs(result.samples[0] - 0.3) < 0.000_001)
+        #expect(abs(result.samples[1] + 0.3) < 0.000_001)
+        #expect(abs(result.samples[2] - 0.4) < 0.000_001)
+        #expect(abs(result.samples[3] + 0.45) < 0.000_001)
+        #expect(result.saturated == 0)
+    }
+
+    @Test
+    func systemSoundMixSmoothlyLimitsOverload() {
+        let result = mixedInput(
+            input: [1, -1],
+            inputChannelLayout: [2],
+            samples: [0.5, -0.5],
+            frameCount: 1,
+            channelCount: 2,
+            sourceChannelOffset: 0,
+            preampGains: (left: 1, right: 1)
+        )
+
+        #expect(result.samples[0] > 0.98 && result.samples[0] <= 1)
+        #expect(result.samples[1] < -0.98 && result.samples[1] >= -1)
+        #expect(result.saturated == 2)
+    }
+
     // MARK: - Helpers
 
     /// Builds an AudioBufferList with one garbage-prefilled buffer per channelLayout entry,
@@ -260,5 +465,75 @@ struct MultiChannelOutputMappingTests {
                 )
             }
         }
+    }
+
+    private func copiedInput(
+        input: [Float],
+        inputChannelLayout: [Int],
+        frameCount: Int,
+        channelCount: Int,
+        sourceChannelOffset: Int
+    ) -> [Float] {
+        var inputOffset = 0
+        var samples = Array(repeating: Float.zero, count: frameCount * channelCount)
+        _ = withMappedBuffers(channelLayout: inputChannelLayout, frames: frameCount) { buffers in
+            for bufferIndex in buffers.indices {
+                let sampleCount = inputChannelLayout[bufferIndex] * frameCount
+                input.withUnsafeBufferPointer { source in
+                    buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self).update(
+                        from: source.baseAddress!.advanced(by: inputOffset),
+                        count: sampleCount
+                    )
+                }
+                inputOffset += sampleCount
+            }
+            samples.withUnsafeMutableBufferPointer { destination in
+                SystemTapAudioEngine.copyInputSamples(
+                    from: buffers,
+                    into: destination,
+                    frameCount: frameCount,
+                    channelCount: channelCount,
+                    sourceChannelOffset: sourceChannelOffset
+                )
+            }
+        }
+        return samples
+    }
+
+    private func mixedInput(
+        input: [Float],
+        inputChannelLayout: [Int],
+        samples: [Float],
+        frameCount: Int,
+        channelCount: Int,
+        sourceChannelOffset: Int,
+        preampGains: (left: Float, right: Float)
+    ) -> (samples: [Float], saturated: UInt64) {
+        var inputOffset = 0
+        var samples = samples
+        var saturated: UInt64 = 0
+        _ = withMappedBuffers(channelLayout: inputChannelLayout, frames: frameCount) { buffers in
+            for bufferIndex in buffers.indices {
+                let sampleCount = inputChannelLayout[bufferIndex] * frameCount
+                input.withUnsafeBufferPointer { source in
+                    buffers[bufferIndex].mData?.assumingMemoryBound(to: Float.self).update(
+                        from: source.baseAddress!.advanced(by: inputOffset),
+                        count: sampleCount
+                    )
+                }
+                inputOffset += sampleCount
+            }
+            samples.withUnsafeMutableBufferPointer { destination in
+                saturated = SystemTapAudioEngine.mixInputSamples(
+                    from: buffers,
+                    into: destination,
+                    frameCount: frameCount,
+                    channelCount: channelCount,
+                    sourceChannelOffset: sourceChannelOffset,
+                    preampGains: preampGains
+                )
+            }
+        }
+        return (samples, saturated)
     }
 }

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -31,27 +31,6 @@ struct SettingsIPCTests {
     }
 
     @Test
-    func playbackBufferCalibrationResetRequiresRunningOutput() {
-        #expect(canResetPlaybackBufferCalibration(isRunning: true, outputUID: "speakers"))
-        #expect(!canResetPlaybackBufferCalibration(isRunning: false, outputUID: "speakers"))
-        #expect(!canResetPlaybackBufferCalibration(isRunning: true, outputUID: ""))
-    }
-
-    @Test
-    func sampleRateConversionRequiresARunningEngineAndActiveMetrics() {
-        #expect(sampleRateConversionIsActive(isRunning: true, metricsActive: true))
-        #expect(!sampleRateConversionIsActive(isRunning: false, metricsActive: true))
-        #expect(!sampleRateConversionIsActive(isRunning: true, metricsActive: false))
-    }
-
-    @Test
-    func clockCorrectionLimitRequiresARunningEngineAndSaturatedMetrics() {
-        #expect(clockCorrectionLimitIsReached(isRunning: true, metricsSaturated: true))
-        #expect(!clockCorrectionLimitIsReached(isRunning: false, metricsSaturated: true))
-        #expect(!clockCorrectionLimitIsReached(isRunning: true, metricsSaturated: false))
-    }
-
-    @Test
     func profileDeletionIsDisabledWhilePreviewProtectsTheReturnProfile() {
         let returnProfile = EQProfile(name: "Return", mode: .parametric, filters: [])
         let previewProfile = EQProfile(name: "Preview", mode: .parametric, filters: [])
@@ -277,19 +256,41 @@ struct SettingsIPCTests {
     }
 
     @Test
-    func resetPlaybackBufferCalibrationCommandRoundTrips() throws {
-        let message = SettingsPipeMessage.request(
-            sessionToken: "token",
-            id: "request-reset-buffer",
-            kind: .command,
-            command: .resetPlaybackBufferCalibration
+    func aggregateBufferCommandsAndOutputDeepLinkRoundTrip() throws {
+        let messages = [
+            SettingsPipeMessage.request(
+                sessionToken: "token",
+                id: "buffer-mode",
+                kind: .command,
+                command: .setAggregateBufferMode(.frames64)
+            ),
+            SettingsPipeMessage.request(
+                sessionToken: "token",
+                id: "buffer-retry",
+                kind: .command,
+                command: .retryAutomaticAggregateBuffer
+            ),
+            SettingsPipeMessage.event(
+                sessionToken: "token",
+                event: .sectionRequested(.output)
+            )
+        ]
+
+        for message in messages {
+            let encoded = try SettingsPipeCodec.encodeLine(message)
+            let decoded = try SettingsPipeCodec.decodeLine(Data(encoded.dropLast()))
+            #expect(decoded == message)
+        }
+    }
+
+    @Test
+    func aggregateBufferSnapshotDefaultsLegacyPayloadToAutomaticSixteen() throws {
+        let decoded = try JSONDecoder().decode(
+            SettingsAggregateBufferDTO.self,
+            from: Data("{}".utf8)
         )
 
-        let decoded = try SettingsPipeCodec.decodeLine(
-            Data(try SettingsPipeCodec.encodeLine(message).dropLast())
-        )
-
-        #expect(decoded == message)
+        #expect(decoded == SettingsAggregateBufferDTO())
     }
 
     @Test
@@ -311,40 +312,28 @@ struct SettingsIPCTests {
         #expect(metrics.playedFrames == 24)
         #expect(metrics.playbackUnderrunFrames == 1)
         #expect(metrics.saturatedSamples == 2)
-        #expect(metrics.currentBufferedFrames == 512)
-        #expect(metrics.maxBufferedFrames == 1024)
-        #expect(metrics.maximumPlaybackBufferedFrames == 0)
-        #expect(metrics.minimumPlaybackBufferedFrames == 0)
-        #expect(metrics.averagePlaybackBufferedFrames == 0)
-        #expect(metrics.ringGateContentionFailures == 0)
-        #expect(metrics.playbackBufferObservations == 0)
         #expect(metrics.maximumCaptureCallbackFrames == 0)
         #expect(metrics.maximumPlaybackCallbackFrames == 0)
-        #expect(metrics.playbackTimestampDiscontinuities == 0)
-        #expect(metrics.playbackBufferRenegotiations == 0)
-        #expect(metrics.adaptivePlaybackRenderFailures == 0)
         #expect(metrics.droppedInputFrames == 0)
-        #expect(metrics.droppedBufferedFrames == 0)
-        #expect(metrics.playbackRateCorrectionPPM == 0)
-        #expect(!metrics.playbackRateCorrectionSaturated)
-        #expect(metrics.playbackOccupancyTargetFrames == 0)
-        #expect(metrics.filteredPlaybackOccupancyFrames == 0)
-        #expect(metrics.playbackBufferSampleRate == 0)
-        #expect(!metrics.playbackSampleRateConversionActive)
+        #expect(metrics.tapToOutputLatencyObservations == 0)
+        #expect(metrics.minimumTapToOutputLatencyNanoseconds == 0)
+        #expect(metrics.maximumTapToOutputLatencyNanoseconds == 0)
+        #expect(metrics.averageTapToOutputLatencyNanoseconds == 0)
     }
 
     @Test
-    func playbackLatencyUsesTheBufferFrameRate() {
-        #expect(playbackFramesToMilliseconds(
-            480,
-            bufferSampleRate: 48_000,
-            fallbackSampleRate: 16_000
-        ) == 10)
-        #expect(playbackFramesToMilliseconds(
-            480,
-            bufferSampleRate: 0,
-            fallbackSampleRate: 16_000
-        ) == 30)
+    func audioMetricsRoundTripTapToOutputLatency() throws {
+        let metrics = SettingsAudioMetricsDTO(
+            tapToOutputLatencyObservations: 500,
+            minimumTapToOutputLatencyNanoseconds: 1_250_000,
+            maximumTapToOutputLatencyNanoseconds: 2_750_000,
+            averageTapToOutputLatencyNanoseconds: 1_500_000
+        )
+
+        let data = try JSONEncoder().encode(metrics)
+        let decoded = try JSONDecoder().decode(SettingsAudioMetricsDTO.self, from: data)
+
+        #expect(decoded == metrics)
     }
 
     @Test


### PR DESCRIPTION
- Normal-rate routes currently bridge capture and playback clocks independently, which adds buffering and makes route behavior harder to reason about. A private aggregate driven by the physical output clock gives those routes one timebase while retaining the separate-clock fallback for unsettled low-rate hardware.
- This records the aggregate safety-offset investigation and the qualification rules that keep unsupported drivers on the compatibility path.
- This is the first pull request in the alpha-0.9.2 stack.