### PR TITLE
feat(audio): add resilient render transitions and watchdog recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -15,11 +15,15 @@ The normal-rate runtime flow is:
 7. Process tap buffers and write the result to the physical output in one aggregate-device callback.
 8. Rebuild the tap and aggregate when macOS changes the selected output device or stream.
 
+On an explicit stop or profile bypass, GlassEQ changes the tap to mute its source only while the tap is being read, then stops the IOProc and destroys the graph. Direct system playback can resume when the read ends instead of waiting for each active client to recover after an always-muted tap disappears. Route handoffs keep the tap continuously muted until the replacement path is active.
+
 Bluetooth routes at 24 kHz or below initially use a separate-clock compatibility backend. The tap runs in a tap-only aggregate, the physical output has its own HAL callback, and a bounded ring buffer, occupancy servo, and realtime sample-rate converter bridge the two clocks. After the route settles and its physical clock advances at the advertised rate, GlassEQ attempts to replace the bridge with the normal combined aggregate. A failed promotion or later paired timestamp discontinuity returns the route to compatibility mode for the remainder of that output transition.
 
 ## Real-Time Rules
 
-The audio render path must not allocate, lock, touch disk, log, parse text, mutate SwiftUI state, or use Combine. UI and import work produce immutable profile/config values that are swapped into the renderer outside the callback.
+The audio render path must not allocate, lock, touch disk, log, parse text, mutate SwiftUI state, or use Combine. UI and import work build a complete candidate processor bank outside the callback. The callback warms that bank for 20 ms, then blends from the active bank with a sample-accurate 10 ms smoothstep ramp. This permits filter-count, mode, and channel-mode changes without rebuilding the Core Audio graph. Only the newest queued edit is retained, and retired banks are released outside the callback.
+
+A watchdog observes render progress outside the callback. One three-second steady-state stall stops the engine before rebuilding it once. Another stall within 60 seconds leaves GlassEQ stopped, restoring direct system audio until the user explicitly retries.
 
 ## Current Implementation Status
 

--- a/Sources/GlassEQApp/AudioRenderWatchdog.swift
+++ b/Sources/GlassEQApp/AudioRenderWatchdog.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+enum AudioRenderWatchdogAction: Equatable, Sendable {
+    case restart
+    case stop
+}
+
+struct AudioRenderWatchdogRoute: Equatable, Sendable {
+    var outputDeviceUID: String
+    var nativeOutputStreamIndex: Int?
+    var nominalSampleRate: Int64
+
+    init(
+        outputDeviceUID: String,
+        nativeOutputStreamIndex: Int? = nil,
+        nominalSampleRate: Double
+    ) {
+        self.outputDeviceUID = outputDeviceUID
+        self.nativeOutputStreamIndex = nativeOutputStreamIndex
+        self.nominalSampleRate = Int64(nominalSampleRate.rounded())
+    }
+}
+
+struct AudioRenderWatchdog: Sendable {
+    static let defaultStallThreshold: Duration = .seconds(3)
+    static let defaultRepeatedFailureWindow: Duration = .seconds(60)
+
+    private let stallThreshold: Duration
+    private let repeatedFailureWindow: Duration
+    private var observedGeneration: Int?
+    private var lastPlayedFrames: UInt64?
+    private var lastProgressAt: ContinuousClock.Instant?
+    private var actionIssuedForGeneration: Int?
+    private var lastAutomaticRecoveryAt: ContinuousClock.Instant?
+    private var lastAutomaticRecoveryRoute: AudioRenderWatchdogRoute?
+
+    init(
+        stallThreshold: Duration = Self.defaultStallThreshold,
+        repeatedFailureWindow: Duration = Self.defaultRepeatedFailureWindow
+    ) {
+        self.stallThreshold = stallThreshold
+        self.repeatedFailureWindow = repeatedFailureWindow
+    }
+
+    mutating func observe(
+        generation: Int,
+        route: AudioRenderWatchdogRoute,
+        isRunning: Bool,
+        playedFrames: UInt64,
+        at now: ContinuousClock.Instant = .now
+    ) -> AudioRenderWatchdogAction? {
+        guard isRunning else {
+            pause()
+            return nil
+        }
+
+        guard observedGeneration == generation else {
+            observedGeneration = generation
+            lastPlayedFrames = playedFrames
+            lastProgressAt = now
+            actionIssuedForGeneration = nil
+            return nil
+        }
+
+        guard lastPlayedFrames == playedFrames else {
+            lastPlayedFrames = playedFrames
+            lastProgressAt = now
+            return nil
+        }
+        guard actionIssuedForGeneration != generation,
+              let lastProgressAt,
+              lastProgressAt.duration(to: now) >= stallThreshold else {
+            return nil
+        }
+
+        actionIssuedForGeneration = generation
+        if lastAutomaticRecoveryRoute == route,
+           let lastAutomaticRecoveryAt,
+           lastAutomaticRecoveryAt.duration(to: now) < repeatedFailureWindow {
+            return .stop
+        }
+        lastAutomaticRecoveryAt = now
+        lastAutomaticRecoveryRoute = route
+        return .restart
+    }
+
+    mutating func pause() {
+        observedGeneration = nil
+        lastPlayedFrames = nil
+        lastProgressAt = nil
+        actionIssuedForGeneration = nil
+    }
+
+    mutating func reset() {
+        pause()
+        lastAutomaticRecoveryAt = nil
+        lastAutomaticRecoveryRoute = nil
+    }
+}

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -256,18 +256,24 @@ protocol AudioEngineControlling: AnyObject, Sendable {
     func setPreferredAggregateBufferFrameSize(_ frameSize: UInt32)
     func update(profile: EQProfile) throws
     @discardableResult func updateDSP(profile: EQProfile) -> Bool
-    func setBypassed(_ isBypassed: Bool)
     func muteOutputForTransition()
     func stop()
     func snapshotMetrics() -> AudioEngineMetrics
     func resetDiagnostics()
     func setRuntimeFailureHandler(_ handler: (@Sendable (AudioEngineFailure) -> Void)?)
+    #if DEBUG
+    func simulateRenderStallForTesting()
+    #endif
 }
 
 extension AudioEngineControlling {
     func setRuntimeFailureHandler(
         _: (@Sendable (AudioEngineFailure) -> Void)?
     ) {}
+
+    #if DEBUG
+    func simulateRenderStallForTesting() {}
+    #endif
 }
 
 extension SystemTapAudioEngine: AudioEngineControlling {}
@@ -436,6 +442,9 @@ final class GlassEQAppModel {
     private let saveDebounceDelay: Duration
     private var observer: (any DefaultOutputObserving)?
     private var metricsTask: Task<Void, Never>?
+    private var renderWatchdogTask: Task<Void, Never>?
+    private var renderWatchdog: AudioRenderWatchdog
+    private let renderWatchdogPollInterval: Duration
     private var aggregateStabilityTask: Task<Void, Never>?
     private var headsetAggregatePromotionTask: Task<Void, Never>?
     private var outputChangeTask: Task<Void, Never>?
@@ -648,10 +657,17 @@ final class GlassEQAppModel {
             aggregateBufferFrameSize: UInt32
         )
         case restart(profile: EQProfile, rollback: ProfileRollback?)
+        case recoverRenderStall(
+            output: AudioOutputDevice,
+            profile: EQProfile,
+            aggregateBufferFrameSize: UInt32
+        )
 
         var profile: EQProfile {
             switch self {
-            case .start(_, let profile, _, _), .restart(let profile, _):
+            case .start(_, let profile, _, _),
+                 .restart(let profile, _),
+                 .recoverRenderStall(_, let profile, _):
                 return profile
             }
         }
@@ -660,6 +676,8 @@ final class GlassEQAppModel {
             switch self {
             case .start(_, _, let rollback, _), .restart(_, let rollback):
                 return rollback
+            case .recoverRenderStall:
+                return nil
             }
         }
     }
@@ -702,6 +720,9 @@ final class GlassEQAppModel {
         aggregateStabilitySettlingDelay: Duration = .seconds(2),
         aggregateCleanSessionDuration: Duration = .seconds(5 * 60),
         headsetAggregatePromotionDelay: Duration = .seconds(6),
+        renderWatchdogStallThreshold: Duration = AudioRenderWatchdog.defaultStallThreshold,
+        renderWatchdogRepeatedFailureWindow: Duration = AudioRenderWatchdog.defaultRepeatedFailureWindow,
+        renderWatchdogPollInterval: Duration = .milliseconds(500),
         aggregateBufferNotifier: (any AggregateBufferChangeNotifying)? = nil
     ) {
         let loadResult: ProfileStoreLoadResult?
@@ -751,6 +772,11 @@ final class GlassEQAppModel {
         self.aggregateStabilitySettlingDelay = aggregateStabilitySettlingDelay
         self.aggregateCleanSessionDuration = aggregateCleanSessionDuration
         self.headsetAggregatePromotionDelay = headsetAggregatePromotionDelay
+        self.renderWatchdog = AudioRenderWatchdog(
+            stallThreshold: renderWatchdogStallThreshold,
+            repeatedFailureWindow: renderWatchdogRepeatedFailureWindow
+        )
+        self.renderWatchdogPollInterval = renderWatchdogPollInterval
         self.aggregateBufferNotifier = aggregateBufferNotifier
             ?? (registerAppDelegate
                 ? AggregateBufferNotifier.shared
@@ -966,6 +992,9 @@ final class GlassEQAppModel {
         invalidatePendingEngineStart()
         metricsTask?.cancel()
         metricsTask = nil
+        renderWatchdogTask?.cancel()
+        renderWatchdogTask = nil
+        renderWatchdog.reset()
         scheduleEngineStop(updateMetrics: true)
         previewReturnProfile = nil
         lifecycleState = .stopped
@@ -1243,6 +1272,19 @@ final class GlassEQAppModel {
         notifyModelDidChange()
     }
 
+    #if DEBUG
+    func simulateRenderStallForTesting() {
+        guard lifecycleState == .running,
+              isRunning,
+              engineStartTask == nil else {
+            return
+        }
+        engine.simulateRenderStallForTesting()
+        statusMessage = localized("Debug: render heartbeat frozen for watchdog test")
+        notifyModelDidChange()
+    }
+    #endif
+
     @discardableResult
     private func addProfile(_ profile: EQProfile, name: String, status: String? = nil) throws -> EQProfile {
         try ensureProfileStoreWritable()
@@ -1502,6 +1544,9 @@ final class GlassEQAppModel {
 
         engineStartGeneration += 1
         let generation = engineStartGeneration
+        renderWatchdogTask?.cancel()
+        renderWatchdogTask = nil
+        renderWatchdog.pause()
         aggregateStabilityTask?.cancel()
         aggregateStabilityTask = nil
         headsetAggregatePromotionTask?.cancel()
@@ -1512,6 +1557,8 @@ final class GlassEQAppModel {
             pendingEngineStartOutput = output
         case .restart:
             pendingEngineStartOutput = nil
+        case .recoverRenderStall(let output, _, _):
+            pendingEngineStartOutput = output
         }
 
         let engine = engine
@@ -1606,6 +1653,7 @@ final class GlassEQAppModel {
         let shouldStopEngine = isRunning || engineStartTask != nil || engineStateNeedsStop
         invalidatePendingOutputChange()
         invalidatePendingEngineStart()
+        renderWatchdog.reset()
         if shouldStopEngine {
             scheduleEngineStop(updateMetrics: updateMetrics)
         }
@@ -1750,6 +1798,25 @@ final class GlassEQAppModel {
                         output = defaultOutput
                     }
                 }
+            case .recoverRenderStall(
+                let requestedOutput,
+                let profile,
+                let aggregateBufferFrameSize
+            ):
+                attemptedOutput = requestedOutput
+                engine.stop()
+                confirmedState.clear()
+                guard !Task.isCancelled else {
+                    confirmedState.recordCancelledAttempt(failedAttempt)
+                    return .cancelled
+                }
+                engine.setPreferredAggregateBufferFrameSize(aggregateBufferFrameSize)
+                try engine.start(output: requestedOutput, profile: profile)
+                if case .running(let activeOutput) = engine.state {
+                    output = activeOutput
+                } else {
+                    output = requestedOutput
+                }
             }
             confirmedState.confirm(confirmation)
             return .success(output)
@@ -1848,6 +1915,11 @@ final class GlassEQAppModel {
             statusMessage = audioEngineStatusMessage(error)
         case .cancelled:
             return
+        }
+        if lifecycleState == .running {
+            startRenderWatchdog()
+        } else {
+            renderWatchdog.pause()
         }
         notifyModelDidChange()
     }
@@ -2396,6 +2468,7 @@ final class GlassEQAppModel {
             requestWakeReconnectAttempt()
             return
         }
+        renderWatchdog.reset()
         restartEngineWithActiveProfile()
     }
 
@@ -2507,6 +2580,89 @@ final class GlassEQAppModel {
         metricsTask = nil
     }
 
+    private func startRenderWatchdog() {
+        renderWatchdogTask?.cancel()
+        renderWatchdog.pause()
+        guard case .running(let output) = engine.state else {
+            return
+        }
+        let generation = engineStartGeneration
+        let route = AudioRenderWatchdogRoute(
+            outputDeviceUID: output.uid,
+            nativeOutputStreamIndex: activeAggregateRoute?.nativeOutputStreamIndex,
+            nominalSampleRate: output.nominalSampleRate
+        )
+        let initialMetrics = engine.snapshotMetrics()
+        _ = renderWatchdog.observe(
+            generation: generation,
+            route: route,
+            isRunning: true,
+            playedFrames: initialMetrics.playedFrames
+        )
+        renderWatchdogTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: self?.renderWatchdogPollInterval ?? .milliseconds(500))
+                guard let self,
+                      !Task.isCancelled,
+                      self.lifecycleState == .running,
+                      self.isRunning,
+                      self.engineStartTask == nil,
+                      self.engineStartGeneration == generation else {
+                    return
+                }
+                let metrics = self.engine.snapshotMetrics()
+                guard let action = self.renderWatchdog.observe(
+                    generation: generation,
+                    route: route,
+                    isRunning: true,
+                    playedFrames: metrics.playedFrames
+                ) else {
+                    continue
+                }
+                self.handleRenderWatchdogAction(action, generation: generation)
+                return
+            }
+        }
+    }
+
+    private func handleRenderWatchdogAction(
+        _ action: AudioRenderWatchdogAction,
+        generation: Int
+    ) {
+        guard lifecycleState == .running,
+              isRunning,
+              engineStartTask == nil,
+              engineStartGeneration == generation,
+              case .running(let output) = engine.state else {
+            return
+        }
+
+        switch action {
+        case .restart:
+            let frameSize = activeAggregateRoute.map {
+                aggregateBufferPolicyStore.selection(for: $0).frameSize
+            } ?? 16
+            statusMessage = localized(
+                "Audio rendering stalled; rebuilding \(output.name)..."
+            )
+            notifyModelDidChange()
+            scheduleEngineWork(.recoverRenderStall(
+                output: output,
+                profile: activeProfile,
+                aggregateBufferFrameSize: frameSize
+            ))
+        case .stop:
+            invalidatePendingEngineStart()
+            scheduleEngineStop(updateMetrics: true)
+            lifecycleState = .stopped
+            isRunning = false
+            statusMessage = localized(
+                "Audio rendering stalled again, so GlassEQ stopped processing. Retry the audio engine when ready."
+            )
+            notifyModelDidChange()
+        }
+    }
+
     func notifyModelDidChange() {
         NotificationCenter.default.post(name: .glassEQModelDidChange, object: self)
         settingsCoordinator.modelDidChange()
@@ -2536,6 +2692,9 @@ final class GlassEQAppModel {
 
     private func invalidatePendingEngineStart() {
         engineStartGeneration += 1
+        renderWatchdogTask?.cancel()
+        renderWatchdogTask = nil
+        renderWatchdog.pause()
         aggregateStabilityTask?.cancel()
         aggregateStabilityTask = nil
         headsetAggregatePromotionTask?.cancel()
@@ -2859,6 +3018,14 @@ private struct MenuBarView: View {
                 .buttonStyle(.glass)
                 .tint(popoverControlsAreActive ? .macOSSystemRed : nil)
             }
+
+            #if DEBUG
+            Button(localized("Test render watchdog")) {
+                model.simulateRenderStallForTesting()
+            }
+            .disabled(!model.isRunning || model.activeProfile.isBypassed)
+            .accessibilityHint(Text(localized("Freezes render progress metrics without stopping audio")))
+            #endif
 
             Text(model.statusMessage)
                 .font(.caption.weight(.medium))

--- a/Sources/GlassEQAudio/AudioDevice.swift
+++ b/Sources/GlassEQAudio/AudioDevice.swift
@@ -414,6 +414,57 @@ public enum CoreAudioDeviceQuery {
         return value as String
     }
 
+    static func setProcessTapMuteBehavior(
+        _ muteBehavior: CATapMuteBehavior,
+        tapID: AudioObjectID
+    ) throws {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyDescription,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var description: Unmanaged<CATapDescription>?
+        var size = UInt32(MemoryLayout<Unmanaged<CATapDescription>?>.size)
+        try checkOSStatus(
+            AudioObjectGetPropertyData(
+                tapID,
+                &address,
+                0,
+                nil,
+                &size,
+                &description
+            ),
+            operation: "AudioObjectGetPropertyData(tap description)"
+        )
+        try validatePropertySize(
+            actual: size,
+            expected: UInt32(MemoryLayout<Unmanaged<CATapDescription>?>.size),
+            operation: "AudioObjectGetPropertyData(tap description)",
+            objectID: tapID
+        )
+        guard let description else {
+            throw CoreAudioError(
+                operation: "AudioObjectGetPropertyData(tap description) nil",
+                status: kAudioHardwareBadObjectError
+            )
+        }
+
+        let tapDescription = description.takeUnretainedValue()
+        tapDescription.muteBehavior = muteBehavior
+        var updatedDescription = Unmanaged.passUnretained(tapDescription)
+        try checkOSStatus(
+            AudioObjectSetPropertyData(
+                tapID,
+                &address,
+                0,
+                nil,
+                UInt32(MemoryLayout<Unmanaged<CATapDescription>>.size),
+                &updatedDescription
+            ),
+            operation: "AudioObjectSetPropertyData(tap description)"
+        )
+    }
+
     /// The device's preferred stereo pair as raw 1-based channel numbers; callers sanitize
     /// (the HAL reports zeros when the pair was never configured).
     static func preferredStereoChannels(objectID: AudioObjectID) throws -> (left: UInt32, right: UInt32) {

--- a/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
+++ b/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
@@ -209,12 +209,12 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
     }
 
     private final class PreparedDSPConfigBox: @unchecked Sendable {
-        let config: EQRenderConfiguration
-        var retiredStorage: EQProcessorRetiredRenderStorage?
+        var processor: EQProcessor?
+        var retiredProcessor: EQProcessor?
         var nextRetiredPointer: UInt = 0
 
         init(config: EQRenderConfiguration) {
-            self.config = config
+            self.processor = EQProcessor(renderConfiguration: config)
         }
     }
 
@@ -231,7 +231,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         private let configuredCaptureCallbackFrames: Int
         private let playbackPrimeFrames: Atomic<Int>
         private let maxCallbackFrames: Int
-        private var processor: EQProcessor
+        private var dspTransition: RealtimeEQTransition
         private var captureScratchSamples: [Float]
         private var adaptiveInputSamples: [Float]
         private var sampleRateConverterInputSamples: UnsafeMutableBufferPointer<Float>
@@ -246,6 +246,9 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
         private let capturedFrames = Atomic<UInt64>(0)
         private let playedFrames = Atomic<UInt64>(0)
+        #if DEBUG
+        private let freezePlayedFramesForTesting = Atomic<Bool>(false)
+        #endif
         private let playbackUnderrunFrames = Atomic<UInt64>(0)
         private let droppedInputFrames = Atomic<UInt64>(0)
         private let droppedBufferedFrames = Atomic<UInt64>(0)
@@ -271,13 +274,13 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         private let playbackRateCorrectionSaturated = Atomic<Bool>(false)
         private let filteredPlaybackOccupancyMilliFrames = Atomic<Int64>(0)
         private let sampleRateConversionActive = Atomic<Bool>(false)
-        private let bypassEnabled: Atomic<Bool>
         private let playbackPriming = Atomic<Bool>(true)
         private let outputMutedForTransition = Atomic<Bool>(false)
         private let pendingPlaybackReset = Atomic<Bool>(false)
         private let pendingOutputTimestampReset = Atomic<Bool>(true)
         private let pendingDSPConfigPointer = Atomic<UInt>(0)
         private let retiredDSPConfigHeadPointer = Atomic<UInt>(0)
+        private var activeDSPConfigPointer: UInt = 0
         private let stopping = Atomic<Bool>(false)
         private let captureInCallback = Atomic<Bool>(false)
         private let playbackInCallback = Atomic<Bool>(false)
@@ -322,18 +325,23 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
                 inputSampleRate: sampleRate,
                 outputSampleRate: sampleRate
             )
-            self.processor = EQProcessor(
-                renderConfiguration: EQRenderConfiguration(
-                    profile: SeparateClockAudioBackend.dspProfile(from: profile),
-                    sampleRate: sampleRate,
-                    channelCount: self.channelCount
-                )
+            self.dspTransition = RealtimeEQTransition(
+                activeProcessor: EQProcessor(
+                    renderConfiguration: EQRenderConfiguration(
+                        profile: profile,
+                        sampleRate: sampleRate,
+                        channelCount: self.channelCount
+                    )
+                ),
+                maximumFrameCount: scratchFrames,
+                channelCount: self.channelCount,
+                sampleRate: sampleRate
             )
-            self.bypassEnabled = Atomic(profile.isBypassed)
         }
 
         deinit {
             drainDSPConfigBoxes()
+            releaseDSPConfigBox(activeDSPConfigPointer)
             sampleRateConverterInputSamples.deinitialize()
             sampleRateConverterInputSamples.deallocate()
             adaptiveOutputSamples.deinitialize()
@@ -344,10 +352,6 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             stopping.store(true, ordering: .releasing)
             outputMutedForTransition.store(true, ordering: .releasing)
             playbackPriming.store(true, ordering: .releasing)
-        }
-
-        func setBypassed(_ isBypassed: Bool) {
-            bypassEnabled.store(isBypassed, ordering: .relaxed)
         }
 
         func muteOutputForTransition() {
@@ -563,12 +567,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
                 return
             }
 
-            applyPendingDSPConfig()
-
-            if bypassEnabled.load(ordering: .relaxed) {
-                captureBypassed(inputBuffers: inputBuffers, frameCount: frameCount)
-                return
-            }
+            beginPendingDSPTransitionIfPossible()
 
             var saturatedSampleCount: UInt64 = 0
             captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
@@ -587,11 +586,13 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
                         frameCount: chunkFrames,
                         channelCount: channelCount
                     )
-                    saturatedSampleCount += processor.processInterleavedWithDiagnostics(
+                    let transitionResult = dspTransition.processInterleavedWithDiagnostics(
                         chunkSamples,
                         frameCount: chunkFrames,
                         channelCount: channelCount
                     )
+                    finishDSPTransition(transitionResult)
+                    saturatedSampleCount += transitionResult.saturatedSamples
                     recordWriteResult(
                         ringBuffer.writeInterleaved(
                             UnsafeBufferPointer(chunkSamples),
@@ -757,8 +758,20 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
                 beginPlaybackReprime()
             }
             updateMaxBufferedFrames(ringBuffer.occupancyFrames())
+            #if DEBUG
+            if !freezePlayedFramesForTesting.load(ordering: .relaxed) {
+                playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+            }
+            #else
             playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+            #endif
         }
+
+        #if DEBUG
+        func simulateRenderStallForTesting() {
+            freezePlayedFramesForTesting.store(true, ordering: .releasing)
+        }
+        #endif
 
         private func beginPlaybackReprime() {
             playbackRateServo.beginPriming()
@@ -1034,55 +1047,6 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             }
         }
 
-        private func captureBypassed(
-            inputBuffers: UnsafeMutableAudioBufferListPointer,
-            frameCount: Int
-        ) {
-            if let inputSamples = contiguousInterleavedInputBuffer(
-                inputBuffers,
-                frameCount: frameCount,
-                channelCount: channelCount
-            ) {
-                recordWriteResult(
-                    ringBuffer.writeInterleaved(
-                        inputSamples,
-                        frameCount: frameCount,
-                        sourceChannelCount: channelCount
-                    )
-                )
-            } else {
-                captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
-                    let scratchFrames = max(scratch.count / channelCount, 1)
-                    var frameOffset = 0
-                    while frameOffset < frameCount {
-                        let chunkFrames = min(frameCount - frameOffset, scratchFrames)
-                        let chunkSamples = UnsafeMutableBufferPointer(
-                            start: scratch.baseAddress,
-                            count: chunkFrames * channelCount
-                        )
-                        copyInput(
-                            from: inputBuffers,
-                            sourceFrameOffset: frameOffset,
-                            into: chunkSamples,
-                            frameCount: chunkFrames,
-                            channelCount: channelCount
-                        )
-                        recordWriteResult(
-                            ringBuffer.writeInterleaved(
-                                UnsafeBufferPointer(chunkSamples),
-                                frameCount: chunkFrames,
-                                sourceChannelCount: channelCount
-                            )
-                        )
-                        frameOffset += chunkFrames
-                    }
-                }
-            }
-
-            updateMaxBufferedFrames(ringBuffer.occupancyFrames())
-            capturedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
-        }
-
         private func recordWriteResult(_ result: RingBufferWriteResult) {
             if result.droppedInputFrames > 0 {
                 droppedInputFrames.wrappingAdd(UInt64(result.droppedInputFrames), ordering: .relaxed)
@@ -1092,7 +1056,11 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             }
         }
 
-        private func applyPendingDSPConfig() {
+        private func beginPendingDSPTransitionIfPossible() {
+            guard activeDSPConfigPointer == 0,
+                  !dspTransition.isTransitioning else {
+                return
+            }
             let rawPointer = pendingDSPConfigPointer.exchange(0, ordering: .acquiringAndReleasing)
             guard rawPointer != 0 else {
                 return
@@ -1100,7 +1068,25 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
             let pointer = UnsafeRawPointer(bitPattern: rawPointer)!
             let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
-            box.retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(box.config)
+            guard let processor = box.processor,
+                  dspTransition.beginTransition(to: processor) else {
+                pushRetiredDSPConfigBox(rawPointer)
+                return
+            }
+            box.processor = nil
+            activeDSPConfigPointer = rawPointer
+        }
+
+        private func finishDSPTransition(_ result: EQTransitionRenderResult) {
+            guard result.completedTransition,
+                  activeDSPConfigPointer != 0,
+                  let pointer = UnsafeRawPointer(bitPattern: activeDSPConfigPointer) else {
+                return
+            }
+            let rawPointer = activeDSPConfigPointer
+            activeDSPConfigPointer = 0
+            let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
+            box.retiredProcessor = result.retiredProcessor
             pushRetiredDSPConfigBox(rawPointer)
         }
 
@@ -1516,7 +1502,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
     func completeCombinedHandoff() {
         control.withLock { state in
-            stopLocked(&state)
+            stopLocked(&state, restoringDirectPlayback: false)
         }
         updatePlaybackBufferAdaptationTimer()
     }
@@ -1689,14 +1675,13 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         }
 
         let preparedConfig = EQRenderConfiguration(
-            profile: Self.dspProfile(from: profile),
+            profile: profile,
             sampleRate: runtime.sampleRate,
             channelCount: runtime.channelCount,
             maximumUsableFrequency: maximumUsableFrequency
         )
         runtime.drainDSPConfigBoxes()
         runtime.publishPendingDSPConfig(preparedConfig)
-        runtime.setBypassed(profile.isBypassed)
         state.activeProfile = profile
         if incrementsProfileRevision {
             state.profileRevision &+= 1
@@ -1705,38 +1690,18 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
     }
 
     static func canHotSwapDSP(
-        from activeProfile: EQProfile,
+        from _: EQProfile,
         to nextProfile: EQProfile,
         sampleRate: Double,
         channelCount: Int,
         maximumUsableFrequency: Double? = nil
     ) -> Bool {
-        guard activeProfile.mode == nextProfile.mode,
-              activeProfile.channelMode == nextProfile.channelMode else {
-            return false
-        }
-
-        return EQRenderConfiguration(
-            profile: Self.dspProfile(from: nextProfile),
+        EQRenderConfiguration(
+            profile: nextProfile,
             sampleRate: sampleRate,
             channelCount: channelCount,
             maximumUsableFrequency: maximumUsableFrequency
-        ).hasRealtimeCompatibleTopology(
-            with: EQRenderConfiguration(
-                profile: Self.dspProfile(from: activeProfile),
-                sampleRate: sampleRate,
-                channelCount: channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
-            )
-        )
-    }
-
-    public func setBypassed(_ isBypassed: Bool) {
-        control.withLock { state in
-            state.runtime?.setBypassed(isBypassed)
-            state.activeProfile?.isBypassed = isBypassed
-            state.profileRevision &+= 1
-        }
+        ).isNumericallySafe
     }
 
     public func muteOutputForTransition() {
@@ -1830,10 +1795,22 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         }
     }
 
-    private func stopLocked(_ state: inout ControlState) {
+    #if DEBUG
+    func simulateRenderStallForTesting() {
+        control.withLock { $0.runtime }?.simulateRenderStallForTesting()
+    }
+    #endif
+
+    private func stopLocked(
+        _ state: inout ControlState,
+        restoringDirectPlayback: Bool = true
+    ) {
         state.runtime?.markStopping()
         stopOutputHalfLocked(&state)
-        stopCaptureHalfLocked(&state)
+        stopCaptureHalfLocked(
+            &state,
+            restoringDirectPlayback: restoringDirectPlayback
+        )
         state.activeProfile = nil
         state.profileRevision &+= 1
         state.playbackBufferAdaptationEvidence = PlaybackBufferAdaptationEvidence()
@@ -1930,8 +1907,20 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         state.captureRunning = true
     }
 
-    private func stopCaptureHalfLocked(_ state: inout ControlState) {
+    private func stopCaptureHalfLocked(
+        _ state: inout ControlState,
+        restoringDirectPlayback: Bool = false
+    ) {
         state.runtime?.markStopping()
+
+        // Hand direct playback back to HAL as soon as capture stops. Destroying an
+        // always-muted tap first can leave an active client silent until it rebuilds.
+        if restoringDirectPlayback, state.tapID != kAudioObjectUnknown {
+            try? CoreAudioDeviceQuery.setProcessTapMuteBehavior(
+                .mutedWhenTapped,
+                tapID: state.tapID
+            )
+        }
 
         if state.aggregateDeviceID != kAudioObjectUnknown, let captureIOProcID = state.captureIOProcID {
             _ = AudioDeviceStop(state.aggregateDeviceID, captureIOProcID)
@@ -2055,7 +2044,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             )
             runtime.drainDSPConfigBoxes()
             runtime.publishPendingDSPConfig(EQRenderConfiguration(
-                profile: Self.dspProfile(from: effectiveProfile),
+                profile: effectiveProfile,
                 sampleRate: runtime.sampleRate,
                 channelCount: runtime.channelCount,
                 maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
@@ -2330,12 +2319,6 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         }
 
         try? PersistedAudioDeviceRestorationStore.save(records, to: url)
-    }
-
-    private static func dspProfile(from profile: EQProfile) -> EQProfile {
-        var profile = profile
-        profile.isBypassed = false
-        return profile
     }
 
     private func audioEngineFailure(from error: Error) -> AudioEngineFailure {

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -478,13 +478,13 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
     }
 
     private final class PreparedDSPConfigBox: @unchecked Sendable {
-        let config: EQRenderConfiguration
+        var processor: EQProcessor?
         let systemSoundPreampGains: (left: Float, right: Float)
-        var retiredStorage: EQProcessorRetiredRenderStorage?
+        var retiredProcessor: EQProcessor?
         var nextRetiredPointer: UInt = 0
 
         init(config: EQRenderConfiguration) {
-            self.config = config
+            self.processor = EQProcessor(renderConfiguration: config)
             self.systemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
                 for: config
             )
@@ -511,11 +511,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let inputChannelOffset: Int
         private let systemSoundInputChannelOffset: Int
         private let maxCallbackFrames: Int
-        private var processor: EQProcessor
+        private var dspTransition: RealtimeEQTransition
         private var activeSystemSoundPreampGains: (left: Float, right: Float)
         private var outputFade: RealtimeOutputFade
-        private var dspTransitionInProgress = false
-        private var activeBypassEnabled: Bool
         private var scratchSamples: [Float]
         private var inputTimestampState = TimestampContinuityState()
         private var outputTimestampState = TimestampContinuityState()
@@ -529,6 +527,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private var timestampProbeSequence: UInt64 = 0
         private let capturedFrames = Atomic<UInt64>(0)
         private let playedFrames = Atomic<UInt64>(0)
+        #if DEBUG
+        private let freezePlayedFramesForTesting = Atomic<Bool>(false)
+        #endif
         private let playbackUnderrunFrames = Atomic<UInt64>(0)
         private let droppedInputFrames = Atomic<UInt64>(0)
         private let saturatedSamples = Atomic<UInt64>(0)
@@ -558,11 +559,11 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let minOutputLeadNanoseconds = Atomic<UInt64>(.max)
         private let maxOutputLeadNanoseconds = Atomic<UInt64>(0)
         private let totalOutputLeadNanoseconds = Atomic<UInt64>(0)
-        private let requestedBypassEnabled: Atomic<Bool>
         private let outputMutedForTransition = Atomic<Bool>(true)
         private let outputIsMuted = Atomic<Bool>(true)
         private let pendingDSPConfigPointer = Atomic<UInt>(0)
         private let retiredDSPConfigHeadPointer = Atomic<UInt>(0)
+        private var activeDSPConfigPointer: UInt = 0
         private let stopping = Atomic<Bool>(false)
         private let inCallback = Atomic<Bool>(false)
         private let playbackChannelPair = Atomic<UInt64>(
@@ -583,28 +584,32 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             self.systemSoundInputChannelOffset = max(systemSoundInputChannelOffset, 0)
             self.maxCallbackFrames = maxCallbackFrames
             self.outputFade = RealtimeOutputFade(sampleRate: sampleRate)
-            self.activeBypassEnabled = profile.isBypassed
             self.scratchSamples = Array(
                 repeating: 0,
                 count: maxCallbackFrames * self.channelCount
             )
             let renderConfiguration = EQRenderConfiguration(
-                profile: SystemTapAudioEngine.dspProfile(from: profile),
+                profile: profile,
                 sampleRate: sampleRate,
                 channelCount: self.channelCount,
                 maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
                     sampleRate: sampleRate
                 )
             )
-            self.processor = EQProcessor(renderConfiguration: renderConfiguration)
+            self.dspTransition = RealtimeEQTransition(
+                activeProcessor: EQProcessor(renderConfiguration: renderConfiguration),
+                maximumFrameCount: maxCallbackFrames,
+                channelCount: self.channelCount,
+                sampleRate: sampleRate
+            )
             self.activeSystemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
                 for: renderConfiguration
             )
-            self.requestedBypassEnabled = Atomic(profile.isBypassed)
         }
 
         deinit {
             drainDSPConfigBoxes()
+            releaseDSPConfigBox(activeDSPConfigPointer)
         }
 
         func render(
@@ -696,15 +701,16 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     sourceChannelOffset: inputChannelOffset
                 )
 
-                if !activeBypassEnabled {
-                    let saturated = processor.processInterleavedWithDiagnostics(
-                        samples,
-                        frameCount: frameCount,
-                        channelCount: channelCount
+                let transitionResult = dspTransition.processInterleavedWithDiagnostics(
+                    samples,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+                if transitionResult.saturatedSamples > 0 {
+                    saturatedSamples.wrappingAdd(
+                        transitionResult.saturatedSamples,
+                        ordering: .relaxed
                     )
-                    if saturated > 0 {
-                        saturatedSamples.wrappingAdd(saturated, ordering: .relaxed)
-                    }
                 }
 
                 let systemSoundSaturated = SystemTapAudioEngine.mixInputSamples(
@@ -713,10 +719,11 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     frameCount: frameCount,
                     channelCount: channelCount,
                     sourceChannelOffset: systemSoundInputChannelOffset,
-                    preampGains: activeBypassEnabled
-                        ? (left: 1, right: 1)
-                        : activeSystemSoundPreampGains
+                    preampGains: activeSystemSoundPreampGains,
+                    incomingPreampGains: incomingSystemSoundPreampGains(),
+                    transition: transitionResult
                 )
+                finishDSPTransition(transitionResult)
                 if systemSoundSaturated > 0 {
                     saturatedSamples.wrappingAdd(
                         systemSoundSaturated,
@@ -745,8 +752,20 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     to: outputBuffers
                 )
             }
+            #if DEBUG
+            if !freezePlayedFramesForTesting.load(ordering: .relaxed) {
+                playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+            }
+            #else
             playedFrames.wrappingAdd(UInt64(frameCount), ordering: .relaxed)
+            #endif
         }
+
+        #if DEBUG
+        func simulateRenderStallForTesting() {
+            freezePlayedFramesForTesting.store(true, ordering: .releasing)
+        }
+        #endif
 
         func activate() {
             outputMutedForTransition.store(false, ordering: .releasing)
@@ -780,10 +799,6 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                   DispatchTime.now().uptimeNanoseconds < timeout {
                 Thread.sleep(forTimeInterval: 0.001)
             }
-        }
-
-        func setBypassed(_ isBypassed: Bool) {
-            requestedBypassEnabled.store(isBypassed, ordering: .releasing)
         }
 
         func muteOutputForTransition() {
@@ -959,7 +974,11 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             }
         }
 
-        private func applyPendingDSPConfig() {
+        private func beginPendingDSPTransitionIfPossible() {
+            guard activeDSPConfigPointer == 0,
+                  !dspTransition.isTransitioning else {
+                return
+            }
             let rawPointer = pendingDSPConfigPointer.exchange(
                 0,
                 ordering: .acquiringAndReleasing
@@ -972,31 +991,45 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             let box = Unmanaged<PreparedDSPConfigBox>
                 .fromOpaque(pointer)
                 .takeUnretainedValue()
-            box.retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(
-                box.config
-            )
+            guard let processor = box.processor,
+                  dspTransition.beginTransition(to: processor) else {
+                pushRetiredDSPConfigBox(rawPointer)
+                return
+            }
+            box.processor = nil
+            activeDSPConfigPointer = rawPointer
+        }
+
+        private func finishDSPTransition(_ result: EQTransitionRenderResult) {
+            guard result.completedTransition,
+                  activeDSPConfigPointer != 0,
+                  let pointer = UnsafeRawPointer(bitPattern: activeDSPConfigPointer) else {
+                return
+            }
+            let rawPointer = activeDSPConfigPointer
+            activeDSPConfigPointer = 0
+            let box = Unmanaged<PreparedDSPConfigBox>
+                .fromOpaque(pointer)
+                .takeUnretainedValue()
+            box.retiredProcessor = result.retiredProcessor
             activeSystemSoundPreampGains = box.systemSoundPreampGains
             pushRetiredDSPConfigBox(rawPointer)
         }
 
+        private func incomingSystemSoundPreampGains() -> (left: Float, right: Float)? {
+            guard activeDSPConfigPointer != 0,
+                  let pointer = UnsafeRawPointer(bitPattern: activeDSPConfigPointer) else {
+                return nil
+            }
+            return Unmanaged<PreparedDSPConfigBox>
+                .fromOpaque(pointer)
+                .takeUnretainedValue()
+                .systemSoundPreampGains
+        }
+
         private func prepareDSPAndOutputFade() {
-            let requestedBypass = requestedBypassEnabled.load(ordering: .acquiring)
-            if pendingDSPConfigPointer.load(ordering: .acquiring) != 0
-                || requestedBypass != activeBypassEnabled {
-                dspTransitionInProgress = true
-            }
-
-            if dspTransitionInProgress, outputFade.isMuted {
-                // Changed biquads reset state. Apply them only while the output is silent.
-                applyPendingDSPConfig()
-                activeBypassEnabled = requestedBypassEnabled.load(ordering: .acquiring)
-                dspTransitionInProgress = pendingDSPConfigPointer.load(ordering: .acquiring) != 0
-                    || requestedBypassEnabled.load(ordering: .acquiring) != activeBypassEnabled
-            }
-
-            let shouldMute = outputMutedForTransition.load(ordering: .acquiring)
-                || dspTransitionInProgress
-            outputFade.setMuted(shouldMute)
+            beginPendingDSPTransitionIfPossible()
+            outputFade.setMuted(outputMutedForTransition.load(ordering: .acquiring))
         }
 
         private func pushRetiredDSPConfigBox(_ rawPointer: UInt) {
@@ -1727,6 +1760,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 }
             }
 
+            if let installedTaps {
+                prepareTapSetForDirectPlayback(installedTaps)
+            }
+            let installedTapsMatch = installedTaps?.main == taps?.main
+                && installedTaps?.systemSounds == taps?.systemSounds
+            if let taps, !installedTapsMatch {
+                prepareTapSetForDirectPlayback(taps)
+            }
             if let preparedAggregate {
                 _ = disposeDetachedCombinedAggregate(
                     DetachedCombinedAggregate(
@@ -1747,8 +1788,6 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             if let installedTaps {
                 destroyTapSet(installedTaps)
             }
-            let installedTapsMatch = installedTaps?.main == taps?.main
-                && installedTaps?.systemSounds == taps?.systemSounds
             if let taps, !installedTapsMatch {
                 destroyTapSet(taps)
             }
@@ -2023,26 +2062,14 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             runtime.drainDSPConfigBoxes()
             runtime.publishPendingDSPConfig(
                 EQRenderConfiguration(
-                    profile: Self.dspProfile(from: profile),
+                    profile: profile,
                     sampleRate: runtime.sampleRate,
                     channelCount: runtime.channelCount,
                     maximumUsableFrequency: maximumUsableFrequency
                 )
             )
-            runtime.setBypassed(profile.isBypassed)
             state.activeProfile = profile
             return true
-        }
-    }
-
-    public func setBypassed(_ isBypassed: Bool) {
-        if activeBackend.withLock({ $0 }) == .separateClock {
-            separateClockBackend.setBypassed(isBypassed)
-            return
-        }
-        control.withLock { state in
-            state.runtime?.setBypassed(isBypassed)
-            state.activeProfile?.isBypassed = isBypassed
         }
     }
 
@@ -2069,7 +2096,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         topologyOperation.withLock { _ in
             promotedHeadsetRoute.withLock { $0 = nil }
             separateClockBackend.stop()
-            stopCombinedResourcesSerialized()
+            stopCombinedResourcesSerialized(restoringDirectPlayback: true)
             activeBackend.withLock { $0 = .combinedAggregate }
         }
     }
@@ -2119,7 +2146,19 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         separateClockBackend.setRuntimeFailureHandler(handler)
     }
 
-    private func stopCombinedResourcesSerialized() {
+    #if DEBUG
+    public func simulateRenderStallForTesting() {
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            separateClockBackend.simulateRenderStallForTesting()
+            return
+        }
+        control.withLock { $0.runtime }?.simulateRenderStallForTesting()
+    }
+    #endif
+
+    private func stopCombinedResourcesSerialized(
+        restoringDirectPlayback: Bool = false
+    ) {
         var detachedAggregate: DetachedCombinedAggregate?
         var detachedTaps: CombinedTapSet?
         control.withLock { state in
@@ -2129,8 +2168,17 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             state.state = .stopped
             state.status = .stopped
         }
+        // Once the IOProc stops reading a mutedWhenTapped tap, HAL resumes the source's
+        // direct route. Do this before dismantling the aggregate so active clients do not
+        // have to recover from an unread, always-muted tap.
+        if restoringDirectPlayback, let detachedTaps {
+            prepareTapSetForDirectPlayback(detachedTaps)
+        }
         if let detachedAggregate {
-            let records = disposeDetachedCombinedAggregate(detachedAggregate)
+            let records = disposeDetachedCombinedAggregate(
+                detachedAggregate,
+                fadeOut: !restoringDirectPlayback
+            )
             control.withLock { state in
                 state.lastTimestampProbeRecords = records
             }
@@ -2161,9 +2209,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
     }
 
     private func disposeDetachedCombinedAggregate(
-        _ detached: DetachedCombinedAggregate
+        _ detached: DetachedCombinedAggregate,
+        fadeOut: Bool = true
     ) -> [AudioTimestampProbeRecord] {
-        detached.runtime?.fadeOutForStop()
+        if fadeOut {
+            detached.runtime?.fadeOutForStop()
+        }
         detached.runtime?.markStopping()
         if detached.deviceID != kAudioObjectUnknown, let ioProcID = detached.ioProcID {
             _ = AudioDeviceStop(detached.deviceID, ioProcID)
@@ -2175,6 +2226,21 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         }
         detached.runtime?.drainDSPConfigBoxes()
         return records
+    }
+
+    private func prepareTapSetForDirectPlayback(_ taps: CombinedTapSet) {
+        if taps.main != kAudioObjectUnknown {
+            try? CoreAudioDeviceQuery.setProcessTapMuteBehavior(
+                .mutedWhenTapped,
+                tapID: taps.main
+            )
+        }
+        if taps.systemSounds != kAudioObjectUnknown {
+            try? CoreAudioDeviceQuery.setProcessTapMuteBehavior(
+                .mutedWhenTapped,
+                tapID: taps.systemSounds
+            )
+        }
     }
 
     private func detachTapSetLocked(_ state: inout ControlState) -> CombinedTapSet? {
@@ -2709,15 +2775,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         return processID
     }
 
-    private static func dspProfile(from profile: EQProfile) -> EQProfile {
-        var profile = profile
-        profile.isBypassed = false
-        return profile
-    }
-
     static func systemSoundPreampGains(
         for configuration: EQRenderConfiguration
     ) -> (left: Float, right: Float) {
+        guard !configuration.configuration.isBypassed else {
+            return (left: 1, right: 1)
+        }
         let channels = configuration.configuration.channelConfigurations
         let left = channels.first?.preampLinearGain
             ?? configuration.configuration.preampLinearGain
@@ -2756,29 +2819,18 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
     }
 
     static func canHotSwapDSP(
-        from activeProfile: EQProfile,
+        from _: EQProfile,
         to nextProfile: EQProfile,
         sampleRate: Double,
         channelCount: Int,
         maximumUsableFrequency: Double? = nil
     ) -> Bool {
-        guard activeProfile.mode == nextProfile.mode,
-              activeProfile.channelMode == nextProfile.channelMode else {
-            return false
-        }
-        return EQRenderConfiguration(
-            profile: dspProfile(from: nextProfile),
+        EQRenderConfiguration(
+            profile: nextProfile,
             sampleRate: sampleRate,
             channelCount: channelCount,
             maximumUsableFrequency: maximumUsableFrequency
-        ).hasRealtimeCompatibleTopology(
-            with: EQRenderConfiguration(
-                profile: dspProfile(from: activeProfile),
-                sampleRate: sampleRate,
-                channelCount: channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
-            )
-        )
+        ).isNumericallySafe
     }
 
     static func supportedRuntimeChannelCount(
@@ -3016,7 +3068,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         frameCount: Int,
         channelCount: Int,
         sourceChannelOffset: Int,
-        preampGains: (left: Float, right: Float)
+        preampGains: (left: Float, right: Float),
+        incomingPreampGains: (left: Float, right: Float)? = nil,
+        transition: EQTransitionRenderResult = EQTransitionRenderResult()
     ) -> UInt64 {
         guard frameCount > 0,
               channelCount > 0,
@@ -3026,10 +3080,18 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         }
 
         var saturatedSamples: UInt64 = 0
+        let targetPreampGains = incomingPreampGains ?? preampGains
         for frame in 0..<frameCount {
             let sampleBase = frame * channelCount
+            let incomingWeight = incomingPreampGains == nil
+                ? 0
+                : transition.incomingBlendWeight(frameOffset: frame)
+            let leftGain = preampGains.left
+                + (targetPreampGains.left - preampGains.left) * incomingWeight
+            let rightGain = preampGains.right
+                + (targetPreampGains.right - preampGains.right) * incomingWeight
             for channel in 0..<channelCount {
-                let gain = channel == 1 ? preampGains.right : preampGains.left
+                let gain = channel == 1 ? rightGain : leftGain
                 let additionalSample = inputSample(
                     from: buffers,
                     frame: frame,

--- a/Sources/GlassEQCore/Biquad.swift
+++ b/Sources/GlassEQCore/Biquad.swift
@@ -161,10 +161,23 @@ public struct BiquadState: Sendable {
     public init() {}
 
     mutating func process(_ input: Float, coefficients c: RenderBiquadCoefficients) -> Float {
+        processWithDiagnostics(input, coefficients: c).sample
+    }
+
+    mutating func processWithDiagnostics(
+        _ input: Float,
+        coefficients c: RenderBiquadCoefficients
+    ) -> (sample: Float, encounteredNonFinite: Bool) {
         let y = c.b0 * input + z1
-        z1 = Self.flushDenormal(c.b1 * input - c.a1 * y + z2)
-        z2 = Self.flushDenormal(c.b2 * input - c.a2 * y)
-        return Self.flushDenormal(y)
+        let nextZ1 = c.b1 * input - c.a1 * y + z2
+        let nextZ2 = c.b2 * input - c.a2 * y
+        let encounteredNonFinite = !input.isFinite
+            || !y.isFinite
+            || !nextZ1.isFinite
+            || !nextZ2.isFinite
+        z1 = Self.flushDenormal(nextZ1)
+        z2 = Self.flushDenormal(nextZ2)
+        return (Self.flushDenormal(y), encounteredNonFinite)
     }
 
     public mutating func process(_ input: Float, coefficients c: BiquadCoefficients) -> Float {

--- a/Sources/GlassEQCore/EQProcessor.swift
+++ b/Sources/GlassEQCore/EQProcessor.swift
@@ -134,27 +134,49 @@ public struct EQRenderConfiguration: Equatable, Sendable {
             && configuration.channelCount == other.configuration.channelCount
             && channelFilterCounts == other.channelFilterCounts
     }
+
+    public var isNumericallySafe: Bool {
+        configuration.sampleRate.isFinite
+            && configuration.sampleRate > 0
+            && configuration.channelCount > 0
+            && preampLinearGains.allSatisfy { $0.isFinite && $0 >= 0 }
+            && coefficients.allSatisfy(Self.isNumericallySafe)
+    }
+
+    private static func isNumericallySafe(_ coefficients: RenderBiquadCoefficients) -> Bool {
+        let values = [
+            coefficients.b0,
+            coefficients.b1,
+            coefficients.b2,
+            coefficients.a1,
+            coefficients.a2
+        ]
+        guard values.allSatisfy(\.isFinite) else {
+            return false
+        }
+
+        let a1 = Double(coefficients.a1)
+        let a2 = Double(coefficients.a2)
+        let discriminant = a1 * a1 - 4 * a2
+        let maximumPoleMagnitude: Double
+        if discriminant >= 0 {
+            let root = sqrt(discriminant)
+            maximumPoleMagnitude = max(
+                abs((-a1 + root) / 2),
+                abs((-a1 - root) / 2)
+            )
+        } else {
+            maximumPoleMagnitude = sqrt(max(a2, 0))
+        }
+        return maximumPoleMagnitude <= 1.000_001
+    }
 }
 
-public struct EQProcessorRetiredRenderStorage: Sendable {
-    private let configuration: EQConfiguration
-    private let coefficients: [RenderBiquadCoefficients]
-    private let channelStarts: [Int]
-    private let channelFilterCounts: [Int]
-    private let preampLinearGains: [Float]
+struct EQLinearRenderDiagnostics: Equatable, Sendable {
+    var nonFiniteSamples: UInt64
 
-    fileprivate init(
-        configuration: EQConfiguration,
-        coefficients: [RenderBiquadCoefficients],
-        channelStarts: [Int],
-        channelFilterCounts: [Int],
-        preampLinearGains: [Float]
-    ) {
-        self.configuration = configuration
-        self.coefficients = coefficients
-        self.channelStarts = channelStarts
-        self.channelFilterCounts = channelFilterCounts
-        self.preampLinearGains = preampLinearGains
+    init(nonFiniteSamples: UInt64 = 0) {
+        self.nonFiniteSamples = nonFiniteSamples
     }
 }
 
@@ -185,7 +207,6 @@ public struct EQProcessor: Sendable {
 
     public mutating func applyPreparedConfiguration(_ renderConfiguration: EQRenderConfiguration) {
         let previousCoefficients = coefficients
-        // Keep this comparison allocation-free; audio callbacks use it for same-topology DSP swaps.
         let needsStateReset = renderConfiguration.configuration.channelCount != self.configuration.channelCount
             || renderConfiguration.channelFilterCounts != channelFilterCounts
             || renderConfiguration.configuration.sampleRate != self.configuration.sampleRate
@@ -201,43 +222,6 @@ public struct EQProcessor: Sendable {
         } else {
             resetChangedFilterStates(previousCoefficients: previousCoefficients, nextCoefficients: renderConfiguration.coefficients)
         }
-    }
-
-    public mutating func applyRealtimeCompatiblePreparedConfiguration(
-        _ renderConfiguration: EQRenderConfiguration
-    ) -> EQProcessorRetiredRenderStorage? {
-        guard renderConfiguration.configuration.sampleRate == configuration.sampleRate,
-              renderConfiguration.configuration.channelCount == configuration.channelCount,
-              renderConfiguration.channelFilterCounts == channelFilterCounts,
-              renderConfiguration.coefficients.count == coefficients.count,
-              renderConfiguration.channelStarts.count == channelStarts.count,
-              renderConfiguration.preampLinearGains.count == preampLinearGains.count,
-              states.count == coefficients.count else {
-            return nil
-        }
-
-        let retiredStorage = EQProcessorRetiredRenderStorage(
-            configuration: configuration,
-            coefficients: coefficients,
-            channelStarts: channelStarts,
-            channelFilterCounts: channelFilterCounts,
-            preampLinearGains: preampLinearGains
-        )
-        let previousCoefficients = coefficients
-
-        configuration = renderConfiguration.configuration
-        coefficients = renderConfiguration.coefficients
-        channelStarts = renderConfiguration.channelStarts
-        channelFilterCounts = renderConfiguration.channelFilterCounts
-        preampLinearGains = renderConfiguration.preampLinearGains
-
-        for index in coefficients.indices {
-            if previousCoefficients[index] != coefficients[index] {
-                states[index] = BiquadState()
-            }
-        }
-
-        return retiredStorage
     }
 
     private mutating func resetChangedFilterStates(
@@ -327,6 +311,68 @@ public struct EQProcessor: Sendable {
             }
             return saturatedSamples
         }
+    }
+
+    mutating func processInterleavedLinearlyWithDiagnostics(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> EQLinearRenderDiagnostics {
+        let sourceChannelCount = max(channelCount, 1)
+        let availableFrames = min(frameCount, samples.count / sourceChannelCount)
+        guard availableFrames > 0 else {
+            return EQLinearRenderDiagnostics()
+        }
+
+        if configuration.isBypassed {
+            return Self.scanLinearSamples(
+                UnsafeBufferPointer(samples),
+                sampleCount: availableFrames * sourceChannelCount
+            )
+        }
+
+        return withRenderBuffers { stateBuffer, coefficientBuffer, channelStartBuffer, channelFilterCountBuffer, preampLinearGainBuffer in
+            var diagnostics = EQLinearRenderDiagnostics()
+            let channels = min(sourceChannelCount, channelStartBuffer.count)
+            var sampleIndex = 0
+            for _ in 0..<availableFrames {
+                for channel in 0..<channels {
+                    let processed = Self.processLinearSampleWithDiagnosticsUnchecked(
+                        samples[sampleIndex + channel],
+                        channel: channel,
+                        states: stateBuffer,
+                        coefficients: coefficientBuffer,
+                        channelStarts: channelStartBuffer,
+                        channelFilterCounts: channelFilterCountBuffer,
+                        preampLinearGains: preampLinearGainBuffer
+                    )
+                    samples[sampleIndex + channel] = processed.sample
+                    if processed.encounteredNonFinite {
+                        diagnostics.nonFiniteSamples += 1
+                    }
+                }
+                sampleIndex += sourceChannelCount
+            }
+            return diagnostics
+        }
+    }
+
+    static func protectInterleavedWithDiagnostics(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> UInt64 {
+        let channels = max(channelCount, 1)
+        let sampleCount = min(max(frameCount, 0) * channels, samples.count)
+        var saturatedSamples: UInt64 = 0
+        for index in 0..<sampleCount {
+            let protected = saturate(samples[index])
+            samples[index] = protected.sample
+            if protected.saturated {
+                saturatedSamples += 1
+            }
+        }
+        return saturatedSamples
     }
 
     public mutating func processNonInterleaved(_ channels: inout [[Float]]) {
@@ -474,6 +520,53 @@ public struct EQProcessor: Sendable {
         }
 
         return Self.saturate(value)
+    }
+
+    private static func processLinearSampleWithDiagnosticsUnchecked(
+        _ input: Float,
+        channel: Int,
+        states: UnsafeMutableBufferPointer<BiquadState>,
+        coefficients: UnsafeBufferPointer<RenderBiquadCoefficients>,
+        channelStarts: UnsafeBufferPointer<Int>,
+        channelFilterCounts: UnsafeBufferPointer<Int>,
+        preampLinearGains: UnsafeBufferPointer<Float>
+    ) -> (sample: Float, encounteredNonFinite: Bool) {
+        guard channel >= 0, channel < channelStarts.count else {
+            return (input.isFinite ? input : 0, !input.isFinite)
+        }
+        let start = channelStarts[channel]
+        let count = channelFilterCounts[channel]
+        var value = input * preampLinearGains[channel]
+        var encounteredNonFinite = !value.isFinite
+        if encounteredNonFinite {
+            value = 0
+        }
+
+        for filterOffset in 0..<count {
+            let index = start + filterOffset
+            let processed = states[index].processWithDiagnostics(
+                value,
+                coefficients: coefficients[index]
+            )
+            value = processed.sample
+            encounteredNonFinite = encounteredNonFinite || processed.encounteredNonFinite
+        }
+
+        return (value, encounteredNonFinite)
+    }
+
+    private static func scanLinearSamples(
+        _ samples: UnsafeBufferPointer<Float>,
+        sampleCount: Int
+    ) -> EQLinearRenderDiagnostics {
+        var diagnostics = EQLinearRenderDiagnostics()
+        for index in 0..<min(max(sampleCount, 0), samples.count) {
+            let sample = samples[index]
+            if !sample.isFinite {
+                diagnostics.nonFiniteSamples += 1
+            }
+        }
+        return diagnostics
     }
 
     private static func saturate(_ value: Float) -> (sample: Float, saturated: Bool) {

--- a/Sources/GlassEQCore/RealtimeEQTransition.swift
+++ b/Sources/GlassEQCore/RealtimeEQTransition.swift
@@ -1,0 +1,198 @@
+public struct EQTransitionRenderResult: Sendable {
+    public var saturatedSamples: UInt64
+    public var completedTransition: Bool
+    public var retiredProcessor: EQProcessor?
+    public var blendStartFrame: Int?
+    public var blendFrameCount: Int
+
+    public init(
+        saturatedSamples: UInt64 = 0,
+        completedTransition: Bool = false,
+        retiredProcessor: EQProcessor? = nil,
+        blendStartFrame: Int? = nil,
+        blendFrameCount: Int = 0
+    ) {
+        self.saturatedSamples = saturatedSamples
+        self.completedTransition = completedTransition
+        self.retiredProcessor = retiredProcessor
+        self.blendStartFrame = blendStartFrame
+        self.blendFrameCount = blendFrameCount
+    }
+
+    @inline(__always)
+    public func incomingBlendWeight(frameOffset: Int) -> Float {
+        guard let blendStartFrame,
+              blendFrameCount > 0 else {
+            return 0
+        }
+        if blendFrameCount == 1 {
+            return 1
+        }
+        let transitionFrame = min(
+            max(blendStartFrame + max(frameOffset, 0), 0),
+            blendFrameCount - 1
+        )
+        let linearProgress = Float(transitionFrame) / Float(blendFrameCount - 1)
+        return linearProgress * linearProgress * (3 - 2 * linearProgress)
+    }
+}
+
+public struct RealtimeEQTransition: Sendable {
+    public static let defaultWarmupSeconds = 0.020
+    public static let defaultBlendSeconds = 0.010
+
+    private var activeProcessor: EQProcessor
+    private var incomingProcessor: EQProcessor?
+    private var alternateSamples: [Float]
+    private let channelCount: Int
+    private let warmupFrameCount: Int
+    private let blendFrameCount: Int
+    private var warmupFramesRemaining = 0
+    private var blendedFrames = 0
+
+    public init(
+        activeProcessor: EQProcessor,
+        maximumFrameCount: Int,
+        channelCount: Int,
+        sampleRate: Double,
+        warmupSeconds: Double = Self.defaultWarmupSeconds,
+        blendSeconds: Double = Self.defaultBlendSeconds
+    ) {
+        let validSampleRate = sampleRate.isFinite && sampleRate > 0 ? sampleRate : 48_000
+        let validWarmup = warmupSeconds.isFinite && warmupSeconds >= 0
+            ? warmupSeconds
+            : Self.defaultWarmupSeconds
+        let validBlend = blendSeconds.isFinite && blendSeconds > 0
+            ? blendSeconds
+            : Self.defaultBlendSeconds
+        self.activeProcessor = activeProcessor
+        self.channelCount = max(channelCount, 1)
+        self.alternateSamples = Array(
+            repeating: 0,
+            count: max(maximumFrameCount, 1) * max(channelCount, 1)
+        )
+        self.warmupFrameCount = max(Int((validSampleRate * validWarmup).rounded()), 0)
+        self.blendFrameCount = max(Int((validSampleRate * validBlend).rounded()), 1)
+    }
+
+    public var isTransitioning: Bool {
+        incomingProcessor != nil
+    }
+
+    public var activeConfiguration: EQConfiguration {
+        activeProcessor.configuration
+    }
+
+    @discardableResult
+    public mutating func beginTransition(to processor: EQProcessor) -> Bool {
+        guard incomingProcessor == nil,
+              processor.configuration.sampleRate == activeProcessor.configuration.sampleRate,
+              processor.configuration.channelCount == activeProcessor.configuration.channelCount else {
+            return false
+        }
+        incomingProcessor = processor
+        warmupFramesRemaining = warmupFrameCount
+        blendedFrames = 0
+        return true
+    }
+
+    public mutating func processInterleavedWithDiagnostics(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> EQTransitionRenderResult {
+        let channels = max(channelCount, 1)
+        let availableFrames = min(max(frameCount, 0), samples.count / channels)
+        guard availableFrames > 0 else {
+            return EQTransitionRenderResult()
+        }
+        guard channels == self.channelCount,
+              incomingProcessor != nil,
+              availableFrames * channels <= alternateSamples.count else {
+            let saturated = activeProcessor.processInterleavedWithDiagnostics(
+                samples,
+                frameCount: availableFrames,
+                channelCount: channels
+            )
+            return EQTransitionRenderResult(saturatedSamples: saturated)
+        }
+
+        let sampleCount = availableFrames * channels
+        return alternateSamples.withUnsafeMutableBufferPointer { alternateStorage in
+            let alternate = UnsafeMutableBufferPointer(
+                start: alternateStorage.baseAddress,
+                count: sampleCount
+            )
+            for index in 0..<sampleCount {
+                alternate[index] = samples[index]
+            }
+
+            let activeDiagnostics = activeProcessor.processInterleavedLinearlyWithDiagnostics(
+                samples,
+                frameCount: availableFrames,
+                channelCount: channels
+            )
+            let incomingDiagnostics = self.incomingProcessor!.processInterleavedLinearlyWithDiagnostics(
+                alternate,
+                frameCount: availableFrames,
+                channelCount: channels
+            )
+
+            if warmupFramesRemaining > 0 {
+                warmupFramesRemaining = max(warmupFramesRemaining - availableFrames, 0)
+                let saturated = activeDiagnostics.nonFiniteSamples
+                    &+ incomingDiagnostics.nonFiniteSamples
+                    &+ EQProcessor.protectInterleavedWithDiagnostics(
+                        samples,
+                        frameCount: availableFrames,
+                        channelCount: channels
+                    )
+                return EQTransitionRenderResult(saturatedSamples: saturated)
+            }
+
+            let renderedBlendStartFrame = blendedFrames
+            let blendWindow = EQTransitionRenderResult(
+                blendStartFrame: renderedBlendStartFrame,
+                blendFrameCount: blendFrameCount
+            )
+            var sampleIndex = 0
+            for frame in 0..<availableFrames {
+                let incomingWeight = blendWindow.incomingBlendWeight(frameOffset: frame)
+                for channel in 0..<channels {
+                    let oldSample = samples[sampleIndex + channel]
+                    samples[sampleIndex + channel] = oldSample
+                        + (alternate[sampleIndex + channel] - oldSample) * incomingWeight
+                }
+                sampleIndex += channels
+            }
+            blendedFrames += availableFrames
+            let saturated = activeDiagnostics.nonFiniteSamples
+                &+ incomingDiagnostics.nonFiniteSamples
+                &+ EQProcessor.protectInterleavedWithDiagnostics(
+                    samples,
+                    frameCount: availableFrames,
+                    channelCount: channels
+                )
+
+            guard blendedFrames >= blendFrameCount,
+                  let completedProcessor = self.incomingProcessor else {
+                return EQTransitionRenderResult(
+                    saturatedSamples: saturated,
+                    blendStartFrame: renderedBlendStartFrame,
+                    blendFrameCount: blendFrameCount
+                )
+            }
+            let retiredProcessor = activeProcessor
+            activeProcessor = completedProcessor
+            self.incomingProcessor = nil
+            blendedFrames = 0
+            return EQTransitionRenderResult(
+                saturatedSamples: saturated,
+                completedTransition: true,
+                retiredProcessor: retiredProcessor,
+                blendStartFrame: renderedBlendStartFrame,
+                blendFrameCount: blendFrameCount
+            )
+        }
+    }
+}

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -468,6 +468,10 @@ private func runDSPBenchmark() {
     for benchmarkCase in cases {
         run(benchmarkCase)
     }
+    for transitionCase in cases where transitionCase.name.hasPrefix("31-band graphic")
+        && transitionCase.sampleRate != 96_000 {
+        runTransition(transitionCase)
+    }
 }
 
 private func run(_ benchmarkCase: DSPBenchmarkCase) {
@@ -516,6 +520,79 @@ private func run(_ benchmarkCase: DSPBenchmarkCase) {
     print(String(format: "  Avg DSP time: %.3f us/buffer", averageMicroseconds))
     print(String(format: "  Callback budget: %.3f us (%.3f%% used)", callbackBudgetMicroseconds, budgetPercent))
     print(String(format: "  Avg per sample: %.3f ns", perSampleNanoseconds))
+    print("  Saturated samples during benchmark: \(saturatedSamples)")
+    print("")
+}
+
+private func runTransition(_ benchmarkCase: DSPBenchmarkCase) {
+    let iterations = 20_000
+    let warmupIterations = 1_000
+    let originalSamples = makeStereoTestBlock(
+        frameCount: benchmarkCase.frameCount,
+        sampleRate: benchmarkCase.sampleRate
+    )
+    var samples = originalSamples
+    var transition = RealtimeEQTransition(
+        activeProcessor: EQProcessor(configuration: EQConfiguration(
+            profile: benchmarkCase.profile,
+            sampleRate: benchmarkCase.sampleRate,
+            channelCount: benchmarkCase.channelCount
+        )),
+        maximumFrameCount: benchmarkCase.frameCount,
+        channelCount: benchmarkCase.channelCount,
+        sampleRate: benchmarkCase.sampleRate,
+        warmupSeconds: 0,
+        blendSeconds: 3_600
+    )
+    precondition(transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
+        profile: benchmarkCase.profile,
+        sampleRate: benchmarkCase.sampleRate,
+        channelCount: benchmarkCase.channelCount
+    ))))
+
+    for _ in 0..<warmupIterations {
+        samples = originalSamples
+        samples.withUnsafeMutableBufferPointer {
+            _ = transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: benchmarkCase.frameCount,
+                channelCount: benchmarkCase.channelCount
+            )
+        }
+    }
+
+    let start = DispatchTime.now().uptimeNanoseconds
+    var saturatedSamples: UInt64 = 0
+    for _ in 0..<iterations {
+        samples = originalSamples
+        saturatedSamples &+= samples.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: benchmarkCase.frameCount,
+                channelCount: benchmarkCase.channelCount
+            ).saturatedSamples
+        }
+    }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+
+    let averageMicroseconds = Double(elapsed) / Double(iterations) / 1_000
+    let callbackBudgetMicroseconds = Double(benchmarkCase.frameCount)
+        / benchmarkCase.sampleRate * 1_000_000
+    let budgetPercent = averageMicroseconds / callbackBudgetMicroseconds * 100
+
+    print("Whole-bank transition: \(benchmarkCase.name)")
+    print(String(
+        format: "  Buffer: %d frames, %d channels, %.0f Hz",
+        benchmarkCase.frameCount,
+        benchmarkCase.channelCount,
+        benchmarkCase.sampleRate
+    ))
+    print(String(format: "  Avg DSP time: %.3f us/buffer", averageMicroseconds))
+    print(String(
+        format: "  Callback budget: %.3f us (%.3f%% used)",
+        callbackBudgetMicroseconds,
+        budgetPercent
+    ))
     print("  Saturated samples during benchmark: \(saturatedSamples)")
     print("")
 }

--- a/Tests/GlassEQAppTests/AudioRenderWatchdogTests.swift
+++ b/Tests/GlassEQAppTests/AudioRenderWatchdogTests.swift
@@ -1,0 +1,264 @@
+import Testing
+@testable import GlassEQApp
+
+@Suite
+struct AudioRenderWatchdogTests {
+    private let route = AudioRenderWatchdogRoute(
+        outputDeviceUID: "output-a",
+        nominalSampleRate: 48_000
+    )
+
+    @Test
+    func advancingRenderHeartbeatPreventsRecovery() {
+        var watchdog = AudioRenderWatchdog(
+            stallThreshold: .seconds(3),
+            repeatedFailureWindow: .seconds(60)
+        )
+        let start = ContinuousClock.now
+
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 100,
+            at: start
+        ) == nil)
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 200,
+            at: start.advanced(by: .seconds(2))
+        ) == nil)
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 200,
+            at: start.advanced(by: .seconds(4))
+        ) == nil)
+    }
+
+    @Test
+    func firstStallRestartsAndRepeatedStallStops() {
+        var watchdog = AudioRenderWatchdog(
+            stallThreshold: .seconds(3),
+            repeatedFailureWindow: .seconds(60)
+        )
+        let start = ContinuousClock.now
+
+        _ = watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 100,
+            at: start
+        )
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 100,
+            at: start.advanced(by: .seconds(3))
+        ) == .restart)
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 100,
+            at: start.advanced(by: .seconds(5))
+        ) == nil)
+
+        _ = watchdog.observe(
+            generation: 2,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(6))
+        )
+        #expect(watchdog.observe(
+            generation: 2,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(9))
+        ) == .stop)
+    }
+
+    @Test
+    func generationChangeAndPauseResetHeartbeatWithoutForgettingRecovery() {
+        var watchdog = AudioRenderWatchdog(
+            stallThreshold: .seconds(3),
+            repeatedFailureWindow: .seconds(60)
+        )
+        let start = ContinuousClock.now
+
+        _ = watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 10,
+            at: start
+        )
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 10,
+            at: start.advanced(by: .seconds(3))
+        ) == .restart)
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: false,
+            playedFrames: 10,
+            at: start.advanced(by: .seconds(4))
+        ) == nil)
+        #expect(watchdog.observe(
+            generation: 2,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(5))
+        ) == nil)
+        #expect(watchdog.observe(
+            generation: 2,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(8))
+        ) == .stop)
+    }
+
+    @Test
+    func recoveryHistoryDoesNotLeakAcrossRoutes() {
+        var watchdog = AudioRenderWatchdog(
+            stallThreshold: .seconds(3),
+            repeatedFailureWindow: .seconds(60)
+        )
+        let nextRoute = AudioRenderWatchdogRoute(
+            outputDeviceUID: "output-b",
+            nominalSampleRate: 48_000
+        )
+        let start = ContinuousClock.now
+
+        _ = watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start
+        )
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(3))
+        ) == .restart)
+        _ = watchdog.observe(
+            generation: 2,
+            route: nextRoute,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(4))
+        )
+
+        #expect(watchdog.observe(
+            generation: 2,
+            route: nextRoute,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(7))
+        ) == .restart)
+    }
+
+    @Test
+    func recoveryHistoryDoesNotLeakAcrossNativeStreams() {
+        var watchdog = AudioRenderWatchdog(
+            stallThreshold: .seconds(3),
+            repeatedFailureWindow: .seconds(60)
+        )
+        let firstStream = AudioRenderWatchdogRoute(
+            outputDeviceUID: "output-a",
+            nativeOutputStreamIndex: 0,
+            nominalSampleRate: 48_000
+        )
+        let secondStream = AudioRenderWatchdogRoute(
+            outputDeviceUID: "output-a",
+            nativeOutputStreamIndex: 1,
+            nominalSampleRate: 48_000
+        )
+        let start = ContinuousClock.now
+
+        _ = watchdog.observe(
+            generation: 1,
+            route: firstStream,
+            isRunning: true,
+            playedFrames: 0,
+            at: start
+        )
+        #expect(watchdog.observe(
+            generation: 1,
+            route: firstStream,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(3))
+        ) == .restart)
+        _ = watchdog.observe(
+            generation: 2,
+            route: secondStream,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(4))
+        )
+
+        #expect(watchdog.observe(
+            generation: 2,
+            route: secondStream,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(7))
+        ) == .restart)
+    }
+
+    @Test
+    func explicitResetForgetsAutomaticRecoveryHistory() {
+        var watchdog = AudioRenderWatchdog(
+            stallThreshold: .seconds(3),
+            repeatedFailureWindow: .seconds(60)
+        )
+        let start = ContinuousClock.now
+
+        _ = watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start
+        )
+        #expect(watchdog.observe(
+            generation: 1,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(3))
+        ) == .restart)
+
+        watchdog.reset()
+        _ = watchdog.observe(
+            generation: 2,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(4))
+        )
+        #expect(watchdog.observe(
+            generation: 2,
+            route: route,
+            isRunning: true,
+            playedFrames: 0,
+            at: start.advanced(by: .seconds(7))
+        ) == .restart)
+    }
+}

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -32,6 +32,54 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func renderWatchdogStopsTapBeforeOneAutomaticRebuild() async {
+        let output = makeOutput(uid: "watchdog-rebuild", name: "Watchdog Rebuild")
+        let engine = FakeAudioEngine()
+        let model = makeModel(
+            engine: engine,
+            lookup: FakeDefaultOutputLookup(.success(output)),
+            renderWatchdogStallThreshold: .milliseconds(50),
+            renderWatchdogRepeatedFailureWindow: .seconds(1),
+            renderWatchdogPollInterval: .milliseconds(5)
+        )
+
+        model.retryAudioEngine()
+        await waitUntil {
+            engine.startCalls.count == 2 && model.lifecycleState == .running
+        }
+
+        #expect(engine.events.prefix(3) == [
+            "start:\(output.uid)",
+            "stop",
+            "start:\(output.uid)"
+        ])
+        model.stop()
+    }
+
+    @Test
+    func repeatedRenderStallFailsOpenAndLeavesRetryAvailable() async {
+        let output = makeOutput(uid: "watchdog-stop", name: "Watchdog Stop")
+        let engine = FakeAudioEngine()
+        let model = makeModel(
+            engine: engine,
+            lookup: FakeDefaultOutputLookup(.success(output)),
+            renderWatchdogStallThreshold: .milliseconds(20),
+            renderWatchdogRepeatedFailureWindow: .seconds(1),
+            renderWatchdogPollInterval: .milliseconds(5)
+        )
+
+        model.retryAudioEngine()
+        await waitUntil {
+            engine.startCalls.count == 2
+                && engine.stopCallCount == 2
+                && model.lifecycleState == .stopped
+        }
+
+        #expect(!model.isRunning)
+        #expect(model.statusMessage.contains("stalled again"))
+    }
+
+    @Test
     func runtimeFailureDoesNotCancelNewerPendingRouteStart() async {
         let firstOutput = makeOutput(uid: "runtime-first", name: "Runtime First", id: 200)
         let secondOutput = makeOutput(uid: "runtime-second", name: "Runtime Second", id: 300)
@@ -1733,7 +1781,6 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.previewReturnProfile == nil)
         #expect(engine.updateCalls.isEmpty)
         #expect(engine.updateDSPCalls.isEmpty)
-        #expect(engine.setBypassedCalls.isEmpty)
         #expect(model.profileStore.profile(forOutputUID: output.uid).id == mapped.id)
 
         engine.unblockStart(for: output.uid)
@@ -1930,7 +1977,6 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.profileStore.profiles.first { $0.id == active.id }?.isBypassed == true)
         #expect(model.profileStore.profiles.first { $0.id == draft.id }?.isBypassed == false)
         #expect(engine.updateDSPCalls.isEmpty)
-        #expect(engine.setBypassedCalls.isEmpty)
         #expect(engine.stopCallCount == 1)
         #expect(!model.isRunning)
         #expect(model.lifecycleState == .stopped)
@@ -1962,7 +2008,6 @@ struct GlassEQAppModelLifecycleTests {
         #expect(model.draftProfile.isBypassed)
         #expect(model.profileStore.profiles.first { $0.id == active.id }?.isBypassed == true)
         #expect(engine.updateDSPCalls.isEmpty)
-        #expect(engine.setBypassedCalls.isEmpty)
         #expect(engine.stopCallCount == 1)
         #expect(!model.isRunning)
         #expect(model.lifecycleState == .stopped)
@@ -3021,6 +3066,9 @@ private func makeModel(
     aggregateStabilityDelay: Duration = .zero,
     aggregateCleanSessionDuration: Duration = .seconds(5 * 60),
     headsetAggregatePromotionDelay: Duration = .seconds(6),
+    renderWatchdogStallThreshold: Duration = AudioRenderWatchdog.defaultStallThreshold,
+    renderWatchdogRepeatedFailureWindow: Duration = AudioRenderWatchdog.defaultRepeatedFailureWindow,
+    renderWatchdogPollInterval: Duration = .milliseconds(500),
     aggregateBufferNotifier: (any AggregateBufferChangeNotifying)? = nil
 ) -> GlassEQAppModel {
     let store = normalizedStore(store ?? ProfileStore(profiles: [makeProfile(name: "Fallback")]))
@@ -3043,6 +3091,9 @@ private func makeModel(
         aggregateStabilitySettlingDelay: aggregateStabilityDelay,
         aggregateCleanSessionDuration: aggregateCleanSessionDuration,
         headsetAggregatePromotionDelay: headsetAggregatePromotionDelay,
+        renderWatchdogStallThreshold: renderWatchdogStallThreshold,
+        renderWatchdogRepeatedFailureWindow: renderWatchdogRepeatedFailureWindow,
+        renderWatchdogPollInterval: renderWatchdogPollInterval,
         aggregateBufferNotifier: aggregateBufferNotifier
     )
 }
@@ -3542,7 +3593,6 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private var _updateDSPCalls: [EQProfile] = []
     private var _stopCallCount = 0
     private var _muteOutputCallCount = 0
-    private var _setBypassedCalls: [Bool] = []
     private var _metrics = AudioEngineMetrics()
     private var _events: [String] = []
     private var _preferredAggregateBufferFrameSize: UInt32 = 16
@@ -3631,11 +3681,6 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private(set) var muteOutputCallCount: Int {
         get { withLock { _muteOutputCallCount } }
         set { withLock { _muteOutputCallCount = newValue } }
-    }
-
-    private(set) var setBypassedCalls: [Bool] {
-        get { withLock { _setBypassedCalls } }
-        set { withLock { _setBypassedCalls = newValue } }
     }
 
     var metrics: AudioEngineMetrics {
@@ -3815,13 +3860,6 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
             _events.append("updateDSP:\(profile.id)")
             _updateDSPCalls.append(profile)
             return _updateDSPResult
-        }
-    }
-
-    func setBypassed(_ isBypassed: Bool) {
-        withLock {
-            _events.append("bypass:\(isBypassed)")
-            _setBypassedCalls.append(isBypassed)
         }
     }
 

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -324,49 +324,53 @@ struct GlassEQAppModelLifecycleTests {
 
     @Test
     func automaticAggregateBufferRetriesLowerRungAfterThreeCleanRuns() async throws {
+        let storeURL = temporaryAppStoreURL()
+        defer { removeTemporaryStoreDirectory(for: storeURL) }
         let output = makeOutput(uid: "clean-aggregate", name: "Clean Aggregate")
+        let route = AggregateAudioRouteFingerprint(
+            outputDeviceUID: output.uid,
+            nativeOutputStreamIndex: 0,
+            nominalSampleRate: output.nominalSampleRate
+        )
+        let policyStoreURL = storeURL.deletingPathExtension()
+            .appendingPathExtension("aggregate-buffer-policy.json")
+        let policyStore = AggregateBufferPolicyStore(url: policyStoreURL)
+        #expect(try policyStore.recordAutomaticFailure(
+            for: route,
+            occurrences: 2
+        ) == 32)
+        #expect(try policyStore.recordCleanAutomaticSession(for: route) == nil)
+        #expect(try policyStore.recordCleanAutomaticSession(for: route) == nil)
+        #expect(AggregateBufferPolicyStore(url: policyStoreURL).selection(for: route).frameSize == 32)
+
         let engine = FakeAudioEngine()
+        #expect(try engine.aggregateRouteFingerprint(for: output) == route)
         engine.reflectPreferredAggregateBufferFrameSize = true
         let observers = FakeDefaultOutputObserverFactory()
         let model = makeModel(
+            storeURL: storeURL,
             engine: engine,
+            lookup: FakeDefaultOutputLookup(.success(output)),
             observers: observers,
             outputDelay: .zero,
-            aggregateCleanSessionDuration: .milliseconds(100)
+            aggregateCleanSessionDuration: .zero
         )
 
         model.start()
         observers.observers[0].emit(.success(output))
-        await waitUntil {
-            model.lifecycleState == .running && engine.startCalls.count == 1
-        }
-
-        var metrics = engine.metrics
-        metrics.qualifyingPairedTimestampDiscontinuities = 2
-        engine.metrics = metrics
-        await waitUntil {
+        let scheduledRetry = await waitUntil(maxAttempts: 500) {
             engine.startCalls.count == 2
-                && engine.startCalls[1].aggregateBufferFrameSize == 32
+        }
+        let completedRetry = await waitUntil(maxAttempts: 500) {
+            model.settingsSnapshot().currentOutputBufferFrameSize == 16
         }
 
-        try? await Task.sleep(for: .milliseconds(350))
-        try model.setAggregateBufferMode(.automatic)
-        await waitUntil {
-            engine.startCalls.count == 3
-                && engine.startCalls[2].aggregateBufferFrameSize == 32
-        }
-
-        try? await Task.sleep(for: .milliseconds(350))
-        try model.setAggregateBufferMode(.automatic)
-        await waitUntil {
-            engine.startCalls.count == 4
-                && engine.startCalls[3].aggregateBufferFrameSize == 32
-        }
-        await waitUntil {
-            engine.startCalls.count == 5
-                && engine.startCalls[4].aggregateBufferFrameSize == 16
-        }
-
+        #expect(scheduledRetry)
+        #expect(completedRetry)
+        #expect(engine.startCalls.count == 2)
+        #expect(engine.startCalls.first?.aggregateBufferFrameSize == 32)
+        #expect(engine.startCalls.last?.aggregateBufferFrameSize == 16)
+        #expect(model.settingsSnapshot().currentOutputBufferFrameSize == 16)
         #expect(model.settingsSnapshot().aggregateBuffer.automaticFrameSize == 16)
     }
 
@@ -3212,13 +3216,18 @@ private func settleAsyncWork() async {
 }
 
 @MainActor
-private func waitUntil(_ predicate: @MainActor () -> Bool) async {
-    for _ in 0..<100 {
+@discardableResult
+private func waitUntil(
+    maxAttempts: Int = 100,
+    _ predicate: @MainActor () -> Bool
+) async -> Bool {
+    for _ in 0..<maxAttempts {
         if predicate() {
-            return
+            return true
         }
         try? await Task.sleep(for: .milliseconds(10))
     }
+    return predicate()
 }
 
 private enum TestAudioError: Error, Equatable {

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -170,6 +170,27 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
+    func systemSoundPreampUsesUnityGainForBypassedProfile() {
+        var profile = EQProfile(
+            name: "Bypassed",
+            mode: .parametric,
+            preampDB: -24,
+            filters: []
+        )
+        profile.isBypassed = true
+        let configuration = EQRenderConfiguration(
+            profile: profile,
+            sampleRate: 48_000,
+            channelCount: 2
+        )
+
+        let gains = SystemTapAudioEngine.systemSoundPreampGains(for: configuration)
+
+        #expect(gains.left == 1)
+        #expect(gains.right == 1)
+    }
+
+    @Test
     func metadataValidationRejectsInvalidScalarValues() throws {
         expectInvalidMetadata {
             _ = try CoreAudioDeviceQuery.validatedSampleRate(.infinity, objectID: 42)
@@ -841,7 +862,7 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
-    func dspHotSwapRejectsTopologyChangingProfiles() {
+    func dspHotSwapAllowsWholeBankTopologyChanges() {
         let graphic = EQProfile(
             name: "Graphic",
             mode: .graphic10,
@@ -850,7 +871,7 @@ struct CoreAudioDeviceTests {
 
         var disabledBand = graphic
         disabledBand.filters[0].isEnabled = false
-        #expect(!SystemTapAudioEngine.canHotSwapDSP(
+        #expect(SystemTapAudioEngine.canHotSwapDSP(
             from: graphic,
             to: disabledBand,
             sampleRate: 48_000,
@@ -864,7 +885,7 @@ struct CoreAudioDeviceTests {
         )
         var addedFilter = parametric
         addedFilter.filters.append(EQFilter(kind: .peak, frequency: 2_000, gainDB: 0, q: 1))
-        #expect(!SystemTapAudioEngine.canHotSwapDSP(
+        #expect(SystemTapAudioEngine.canHotSwapDSP(
             from: parametric,
             to: addedFilter,
             sampleRate: 48_000,
@@ -876,7 +897,7 @@ struct CoreAudioDeviceTests {
             mode: .parametric,
             filters: graphic.filters
         )
-        #expect(!SystemTapAudioEngine.canHotSwapDSP(
+        #expect(SystemTapAudioEngine.canHotSwapDSP(
             from: graphic,
             to: modeSwitch,
             sampleRate: 48_000,
@@ -885,9 +906,23 @@ struct CoreAudioDeviceTests {
 
         var stereoSwitch = graphic
         stereoSwitch.channelMode = .stereo
-        #expect(!SystemTapAudioEngine.canHotSwapDSP(
+        #expect(SystemTapAudioEngine.canHotSwapDSP(
             from: graphic,
             to: stereoSwitch,
+            sampleRate: 48_000,
+            channelCount: 2
+        ))
+    }
+
+    @Test
+    func dspHotSwapRejectsNumericallyUnsafeBank() {
+        let active = EQProfile.flatParametric
+        var unsafe = active
+        unsafe.preampDB = .nan
+
+        #expect(!SystemTapAudioEngine.canHotSwapDSP(
+            from: active,
+            to: unsafe,
             sampleRate: 48_000,
             channelCount: 2
         ))

--- a/Tests/GlassEQAudioTests/MultiChannelOutputMappingTests.swift
+++ b/Tests/GlassEQAudioTests/MultiChannelOutputMappingTests.swift
@@ -1,6 +1,7 @@
 import CoreAudio
 import Foundation
 @testable import GlassEQAudio
+import GlassEQCore
 import Testing
 
 @Suite
@@ -404,6 +405,37 @@ struct MultiChannelOutputMappingTests {
         #expect(result.saturated == 2)
     }
 
+    @Test
+    func systemSoundPreampFollowsWholeBankTransitionRamp() {
+        let result = mixedInput(
+            input: [
+                0.1, 0.1,
+                0.1, 0.1,
+                0.1, 0.1,
+                0.1, 0.1
+            ],
+            inputChannelLayout: [2],
+            samples: [Float](repeating: 0, count: 8),
+            frameCount: 4,
+            channelCount: 2,
+            sourceChannelOffset: 0,
+            preampGains: (left: 1, right: 1),
+            incomingPreampGains: (left: 2, right: 3),
+            transition: EQTransitionRenderResult(
+                blendStartFrame: 0,
+                blendFrameCount: 4
+            )
+        )
+
+        #expect(abs(result.samples[0] - 0.1) < 0.000_001)
+        #expect(abs(result.samples[1] - 0.1) < 0.000_001)
+        #expect(result.samples[2] > result.samples[0])
+        #expect(result.samples[4] > result.samples[2])
+        #expect(abs(result.samples[6] - 0.2) < 0.000_001)
+        #expect(abs(result.samples[7] - 0.3) < 0.000_001)
+        #expect(result.saturated == 0)
+    }
+
     // MARK: - Helpers
 
     /// Builds an AudioBufferList with one garbage-prefilled buffer per channelLayout entry,
@@ -507,7 +539,9 @@ struct MultiChannelOutputMappingTests {
         frameCount: Int,
         channelCount: Int,
         sourceChannelOffset: Int,
-        preampGains: (left: Float, right: Float)
+        preampGains: (left: Float, right: Float),
+        incomingPreampGains: (left: Float, right: Float)? = nil,
+        transition: EQTransitionRenderResult = EQTransitionRenderResult()
     ) -> (samples: [Float], saturated: UInt64) {
         var inputOffset = 0
         var samples = samples
@@ -530,7 +564,9 @@ struct MultiChannelOutputMappingTests {
                     frameCount: frameCount,
                     channelCount: channelCount,
                     sourceChannelOffset: sourceChannelOffset,
-                    preampGains: preampGains
+                    preampGains: preampGains,
+                    incomingPreampGains: incomingPreampGains,
+                    transition: transition
                 )
             }
         }

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -361,26 +361,6 @@ struct EQCoreTests {
     }
 
     @Test
-    func dspCallbackPathStaysWithinGenerousDebugBudget() {
-        guard !isThreadSanitizerRuntimeLoaded else {
-            return
-        }
-        let profile = EQProfile.flatGraphic31
-        var processor = EQProcessor(configuration: EQConfiguration(profile: profile, sampleRate: 48_000, channelCount: 2))
-        var samples = makeStereoTestBlock(frameCount: 256, sampleRate: 48_000)
-        let clock = ContinuousClock()
-        let start = clock.now
-
-        for _ in 0..<256 {
-            _ = samples.withUnsafeMutableBufferPointer {
-                processor.processInterleavedWithDiagnostics($0, frameCount: 256, channelCount: 2)
-            }
-        }
-
-        #expect(start.duration(to: clock.now) < .seconds(2))
-    }
-
-    @Test
     func preparedRenderConfigurationMatchesConfigurationInitializer() {
         let profile = EQProfile(
             name: "Prepared",

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -454,83 +454,6 @@ struct EQCoreTests {
     }
 
     @Test
-    func realtimeCompatiblePreparedConfigurationUpdatesConfigAndResetsChangedState() throws {
-        let initial = EQProfile(
-            name: "Initial",
-            mode: .parametric,
-            preampDB: -2,
-            filters: [
-                EQFilter(kind: .peak, frequency: 500, gainDB: 8, q: 1),
-                EQFilter(kind: .highShelf, frequency: 8_000, gainDB: 1, q: 0.7)
-            ]
-        )
-        var updated = initial
-        updated.name = "Updated"
-        updated.preampDB = -4
-        updated.filters[0].frequency = 2_000
-        updated.filters[0].gainDB = -8
-        updated.filters[1].frequency = 10_000
-        updated.filters[1].gainDB = -3
-        updated.isBypassed = true
-
-        var processor = EQProcessor(configuration: EQConfiguration(profile: initial, sampleRate: 48_000, channelCount: 2))
-        var warmup = makeStereoTestBlock(frameCount: 512, sampleRate: 48_000)
-        processor.processInterleaved(&warmup, channelCount: 2)
-
-        let retiredStorage = processor.applyRealtimeCompatiblePreparedConfiguration(
-            EQRenderConfiguration(profile: updated, sampleRate: 48_000, channelCount: 2)
-        )
-
-        #expect(retiredStorage != nil)
-        #expect(processor.configuration.isBypassed)
-        #expect(processor.configuration.preampLinearGain == EQConfiguration(
-            profile: updated,
-            sampleRate: 48_000,
-            channelCount: 2
-        ).preampLinearGain)
-
-        updated.isBypassed = false
-        _ = processor.applyRealtimeCompatiblePreparedConfiguration(
-            EQRenderConfiguration(profile: updated, sampleRate: 48_000, channelCount: 2)
-        )
-        var fresh = EQProcessor(configuration: EQConfiguration(profile: updated, sampleRate: 48_000, channelCount: 2))
-        var warmedNext = makeStereoTestBlock(frameCount: 128, sampleRate: 48_000)
-        var freshNext = warmedNext
-
-        processor.processInterleaved(&warmedNext, channelCount: 2)
-        fresh.processInterleaved(&freshNext, channelCount: 2)
-
-        let maxDelta = zip(warmedNext, freshNext).map { abs($0 - $1) }.max() ?? 0
-        #expect(maxDelta < 0.000_001)
-    }
-
-    @Test
-    func identicalPreparedConfigurationPreservesWarmedState() {
-        let profile = EQProfile(
-            name: "Stateful",
-            mode: .parametric,
-            filters: [EQFilter(kind: .lowPass, frequency: 1_200, gainDB: 0, q: 0.707)]
-        )
-        var processor = EQProcessor(configuration: EQConfiguration(profile: profile, sampleRate: 48_000, channelCount: 2))
-        var warmup = makeStereoTestBlock(frameCount: 512, sampleRate: 48_000)
-        processor.processInterleaved(&warmup, channelCount: 2)
-
-        var withoutApply = processor
-        var withIdenticalApply = processor
-        let retiredStorage = withIdenticalApply.applyRealtimeCompatiblePreparedConfiguration(
-            EQRenderConfiguration(profile: profile, sampleRate: 48_000, channelCount: 2)
-        )
-
-        var expected = makeStereoTestBlock(frameCount: 128, sampleRate: 48_000)
-        var actual = expected
-        withoutApply.processInterleaved(&expected, channelCount: 2)
-        withIdenticalApply.processInterleaved(&actual, channelCount: 2)
-
-        #expect(retiredStorage != nil)
-        #expect(actual == expected)
-    }
-
-    @Test
     func processorCopiesKeepIndependentMutableState() {
         let profile = EQProfile(
             name: "Stateful",
@@ -558,6 +481,200 @@ struct EQCoreTests {
         let copiedOriginalDelta = zip(copiedNext, originalNext).map { abs($0 - $1) }.max() ?? 0
         #expect(copiedFreshDelta < 0.000_001)
         #expect(copiedOriginalDelta > 0.000_001)
+    }
+
+    @Test
+    func wholeBankTransitionUsesSampleAccurateSmoothstepBlend() {
+        let active = EQProfile(name: "Active", mode: .parametric, filters: [])
+        let incoming = EQProfile(
+            name: "Incoming",
+            mode: .parametric,
+            preampDB: 6.020_599_913,
+            filters: []
+        )
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: 1_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 4,
+            channelCount: 1,
+            sampleRate: 1_000,
+            warmupSeconds: 0,
+            blendSeconds: 0.004
+        )
+        let didBegin = transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
+            profile: incoming,
+            sampleRate: 1_000,
+            channelCount: 1
+        )))
+        #expect(didBegin)
+        var samples = [Float](repeating: 0.25, count: 4)
+
+        let result = samples.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+
+        #expect(abs(samples[0] - 0.25) < 0.000_001)
+        #expect(abs(samples[1] - 0.314_814_8) < 0.000_001)
+        #expect(abs(samples[2] - 0.435_185_2) < 0.000_001)
+        #expect(abs(samples[3] - 0.5) < 0.000_001)
+        #expect(result.completedTransition)
+        #expect(result.retiredProcessor != nil)
+        #expect(!transition.isTransitioning)
+    }
+
+    @Test
+    func wholeBankTransitionWarmsIncomingBankBeforeBlending() {
+        let active = EQProfile(name: "Active", mode: .parametric, filters: [])
+        let incoming = EQProfile(
+            name: "Incoming",
+            mode: .parametric,
+            preampDB: 6.020_599_913,
+            filters: []
+        )
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: 1_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 4,
+            channelCount: 1,
+            sampleRate: 1_000,
+            warmupSeconds: 0.004,
+            blendSeconds: 0.004
+        )
+        let didBegin = transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
+            profile: incoming,
+            sampleRate: 1_000,
+            channelCount: 1
+        )))
+        #expect(didBegin)
+        var warmup = [Float](repeating: 0.25, count: 4)
+
+        let warmupResult = warmup.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+
+        #expect(warmup == [0.25, 0.25, 0.25, 0.25])
+        #expect(!warmupResult.completedTransition)
+        #expect(transition.isTransitioning)
+    }
+
+    @Test
+    func wholeBankTransitionAllowsFilterTopologyChanges() {
+        let active = EQProfile(name: "Active", mode: .parametric, filters: [])
+        let incoming = EQProfile(
+            name: "Incoming",
+            mode: .parametric,
+            filters: [
+                EQFilter(kind: .lowShelf, frequency: 120, gainDB: 3, q: 0.7),
+                EQFilter(kind: .peak, frequency: 1_500, gainDB: -4, q: 2)
+            ]
+        )
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: 1_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 4,
+            channelCount: 1,
+            sampleRate: 1_000,
+            warmupSeconds: 0,
+            blendSeconds: 0.004
+        )
+
+        let didBegin = transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
+            profile: incoming,
+            sampleRate: 1_000,
+            channelCount: 1
+        )))
+        #expect(didBegin)
+
+        var samples = [Float](repeating: 0.1, count: 4)
+        let result = samples.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+
+        #expect(result.completedTransition)
+        #expect(transition.activeConfiguration.coefficients.count == 2)
+    }
+
+    @Test
+    func wholeBankTransitionCanBlendToBypass() {
+        let active = EQProfile(
+            name: "Active",
+            mode: .parametric,
+            preampDB: 6.020_599_913,
+            filters: []
+        )
+        var bypassed = active
+        bypassed.isBypassed = true
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: 1_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 4,
+            channelCount: 1,
+            sampleRate: 1_000,
+            warmupSeconds: 0,
+            blendSeconds: 0.004
+        )
+        let didBegin = transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
+            profile: bypassed,
+            sampleRate: 1_000,
+            channelCount: 1
+        )))
+        #expect(didBegin)
+        var samples = [Float](repeating: 0.25, count: 4)
+
+        let result = samples.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+
+        #expect(abs(samples[0] - 0.5) < 0.000_001)
+        #expect(abs(samples[3] - 0.25) < 0.000_001)
+        #expect(result.completedTransition)
+        #expect(transition.activeConfiguration.isBypassed)
+    }
+
+    @Test
+    func renderConfigurationRejectsNonFinitePreamp() {
+        let profile = EQProfile(
+            name: "Invalid",
+            mode: .parametric,
+            preampDB: .nan,
+            filters: []
+        )
+
+        let configuration = EQRenderConfiguration(
+            profile: profile,
+            sampleRate: 48_000,
+            channelCount: 2
+        )
+
+        #expect(!configuration.isNumericallySafe)
     }
 
     @Test


### PR DESCRIPTION
- DSP changes need click-free publication without allocating, locking, or releasing owned state in the render callback. Runtime stalls also need one bounded recovery attempt followed by safe dry playback.
- This adds prewarmed whole-bank transitions and a render watchdog so failed processing cannot leave system audio captured without a functioning output path.
- This pull request is stacked on experiment/aggregate-clock-sync.