### PR TITLE
feat(audio): add programme comparison and fixed-buffer recovery

### DIFF
--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -25,6 +25,8 @@ The audio render path must not allocate, lock, touch disk, log, parse text, muta
 
 A watchdog observes render progress outside the callback. One three-second steady-state stall stops the engine before rebuilding it once. Another stall within 60 seconds leaves GlassEQ stopped, restoring direct system audio until the user explicitly retries.
 
+Programme-loudness A/B comparison is another transient render mode, not a profile mutation. The renderer runs the draft profile and a filters-off reference in parallel; the reference retains the same linked or per-channel preamp gains. Both branches pass through BS.1770 K-weighting and a shared three-second rolling gate so they are measured over the same programme passages. GlassEQ attenuates only the louder branch, smooths match changes over 500 ms, and crossfades A/B selection over 10 ms. Starting and stopping the comparison reuse the whole-bank warm-up and transition path, including a gain restoration before returning to the saved active profile. The measured gains, selected branch, and filters-off reference are never persisted.
+
 ## Current Implementation Status
 
 This repository contains the SwiftPM project, DSP engine, importers, profile persistence, menu bar shell, the combined Core Audio tap/output fast path, and the transitional separate-clock Bluetooth headset backend. The Core Audio bridge is intentionally isolated under `GlassEQAudio` so device-format support and hardware QA can be hardened without disturbing UI/profile code.

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -25,6 +25,8 @@ The audio render path must not allocate, lock, touch disk, log, parse text, muta
 
 A watchdog observes render progress outside the callback. One three-second steady-state stall stops the engine before rebuilding it once. Another stall within 60 seconds leaves GlassEQ stopped, restoring direct system audio until the user explicitly retries.
 
+The render callback also counts callbacks that arrive or finish at least one complete callback period late. After the route has settled, three misses within one second form a deadline burst. Automatic mode continues to use its persisted route-specific reliability policy. A fixed mode rebuilds once at the selected size, then temporarily climbs through 32 and 64 frames if bursts recur within 60 seconds. The fixed preference is never overwritten. The temporary rung lasts until the route session ends or the user retries the fixed size. Another burst at 64 frames stops processing.
+
 Programme-loudness A/B comparison is another transient render mode, not a profile mutation. The renderer runs the draft profile and a filters-off reference in parallel; the reference retains the same linked or per-channel preamp gains. Both branches pass through BS.1770 K-weighting and a shared three-second rolling gate so they are measured over the same programme passages. GlassEQ attenuates only the louder branch, smooths match changes over 500 ms, and crossfades A/B selection over 10 ms. Starting and stopping the comparison reuse the whole-bank warm-up and transition path, including a gain restoration before returning to the saved active profile. The measured gains, selected branch, and filters-off reference are never persisted.
 
 ## Current Implementation Status
@@ -62,6 +64,7 @@ The command prints output device metadata and post-run callback metrics:
 - Playback underrun frames.
 - Input frames dropped because a callback exposed more input than output capacity.
 - Peak capture and output callback sizes.
+- Render callbacks that missed at least one complete callback period.
 - Average and range of tap-to-output latency from Core Audio's I/O timestamps.
 - Samples that reached the soft clipper.
 

--- a/Sources/GlassEQApp/AggregateBufferNotifier.swift
+++ b/Sources/GlassEQApp/AggregateBufferNotifier.swift
@@ -14,6 +14,15 @@ protocol AggregateBufferChangeNotifying: AnyObject {
         previousFrameSize: UInt32,
         newFrameSize: UInt32
     )
+    func notifyFixedBufferRebuild(
+        outputName: String,
+        frameSize: UInt32
+    )
+    func notifyTemporaryBufferIncrease(
+        outputName: String,
+        preferredFrameSize: UInt32,
+        runtimeFrameSize: UInt32
+    )
 }
 
 @MainActor
@@ -62,6 +71,40 @@ final class AggregateBufferNotifier: NSObject,
         previousFrameSize: UInt32,
         newFrameSize: UInt32
     ) {
+        notify(
+            title: localized("GlassEQ increased the audio buffer"),
+            body: localized(
+                "GlassEQ detected a timing interruption while \(outputName) was using \(previousFrameSize)-frame buffers. It switched this route to \(newFrameSize) frames for more reliable playback."
+            )
+        )
+    }
+
+    func notifyFixedBufferRebuild(
+        outputName: String,
+        frameSize: UInt32
+    ) {
+        notify(
+            title: localized("GlassEQ rebuilt the audio engine"),
+            body: localized(
+                "\(outputName) missed several audio deadlines at \(frameSize) frames. GlassEQ rebuilt the route at the same setting."
+            )
+        )
+    }
+
+    func notifyTemporaryBufferIncrease(
+        outputName: String,
+        preferredFrameSize: UInt32,
+        runtimeFrameSize: UInt32
+    ) {
+        notify(
+            title: localized("GlassEQ temporarily increased the audio buffer"),
+            body: localized(
+                "\(outputName) remained unstable at \(preferredFrameSize) frames. GlassEQ is using \(runtimeFrameSize) frames for this session. Your fixed setting was not changed."
+            )
+        )
+    }
+
+    private func notify(title: String, body: String) {
         guard Self.canUseUserNotifications() else {
             return
         }
@@ -73,14 +116,12 @@ final class AggregateBufferNotifier: NSObject,
                 return
             }
             let content = UNMutableNotificationContent()
-            content.title = localized("GlassEQ increased the audio buffer")
-            content.body = localized(
-                "GlassEQ detected a timing interruption while \(outputName) was using \(previousFrameSize)-frame buffers. It switched this route to \(newFrameSize) frames for more reliable playback."
-            )
+            content.title = title
+            content.body = body
             content.categoryIdentifier = Self.categoryIdentifier
             try? await center.add(
                 UNNotificationRequest(
-                    identifier: "glasseq-buffer-reliability-\(UUID().uuidString)",
+                    identifier: "glasseq-buffer-recovery-\(UUID().uuidString)",
                     content: content,
                     trigger: nil
                 )
@@ -118,6 +159,17 @@ final class NoopAggregateBufferNotifier: AggregateBufferChangeNotifying {
         outputName _: String,
         previousFrameSize _: UInt32,
         newFrameSize _: UInt32
+    ) {}
+
+    func notifyFixedBufferRebuild(
+        outputName _: String,
+        frameSize _: UInt32
+    ) {}
+
+    func notifyTemporaryBufferIncrease(
+        outputName _: String,
+        preferredFrameSize _: UInt32,
+        runtimeFrameSize _: UInt32
     ) {}
 }
 

--- a/Sources/GlassEQApp/AudioRenderWatchdog.swift
+++ b/Sources/GlassEQApp/AudioRenderWatchdog.swift
@@ -5,6 +5,96 @@ enum AudioRenderWatchdogAction: Equatable, Sendable {
     case stop
 }
 
+struct AudioRenderDeadlineBurstDetector: Sendable {
+    static let defaultRequiredMisses: UInt64 = 3
+    static let defaultWindow: Duration = .seconds(1)
+
+    private let requiredMisses: UInt64
+    private let window: Duration
+    private var windowStartedAt: ContinuousClock.Instant?
+    private var missesInWindow: UInt64 = 0
+
+    init(
+        requiredMisses: UInt64 = Self.defaultRequiredMisses,
+        window: Duration = Self.defaultWindow
+    ) {
+        self.requiredMisses = max(requiredMisses, 1)
+        self.window = window
+    }
+
+    mutating func observe(
+        newMisses: UInt64,
+        at now: ContinuousClock.Instant = .now
+    ) -> Bool {
+        guard newMisses > 0 else {
+            return false
+        }
+        if let windowStartedAt,
+           windowStartedAt.duration(to: now) <= window {
+            let sum = missesInWindow.addingReportingOverflow(newMisses)
+            missesInWindow = sum.overflow
+                ? requiredMisses
+                : min(sum.partialValue, requiredMisses)
+        } else {
+            windowStartedAt = now
+            missesInWindow = newMisses
+        }
+        guard missesInWindow >= requiredMisses else {
+            return false
+        }
+        reset()
+        return true
+    }
+
+    mutating func reset() {
+        windowStartedAt = nil
+        missesInWindow = 0
+    }
+}
+
+enum FixedBufferRecoveryAction: Equatable, Sendable {
+    case rebuild(frameSize: UInt32)
+    case temporarilyIncrease(frameSize: UInt32)
+    case stop
+}
+
+struct FixedBufferRecoverySession: Sendable {
+    static let defaultRepeatedFailureWindow: Duration = .seconds(60)
+
+    private(set) var runtimeFrameSize: UInt32
+    private let repeatedFailureWindow: Duration
+    private var lastFailureAt: ContinuousClock.Instant?
+
+    init(
+        runtimeFrameSize: UInt32,
+        repeatedFailureWindow: Duration = Self.defaultRepeatedFailureWindow
+    ) {
+        self.runtimeFrameSize = runtimeFrameSize
+        self.repeatedFailureWindow = repeatedFailureWindow
+    }
+
+    mutating func observeFailure(
+        at now: ContinuousClock.Instant = .now
+    ) -> FixedBufferRecoveryAction {
+        guard let lastFailureAt,
+              lastFailureAt.duration(to: now) <= repeatedFailureWindow else {
+            self.lastFailureAt = now
+            return .rebuild(frameSize: runtimeFrameSize)
+        }
+        self.lastFailureAt = now
+        switch runtimeFrameSize {
+        case ..<32:
+            runtimeFrameSize = 32
+            return .temporarilyIncrease(frameSize: 32)
+        case 32..<64:
+            runtimeFrameSize = 64
+            return .temporarilyIncrease(frameSize: 64)
+        default:
+            return .stop
+        }
+    }
+}
+
 struct AudioRenderWatchdogRoute: Equatable, Sendable {
     var outputDeviceUID: String
     var nativeOutputStreamIndex: Int?

--- a/Sources/GlassEQApp/AudioRenderWatchdog.swift
+++ b/Sources/GlassEQApp/AudioRenderWatchdog.swift
@@ -11,8 +11,8 @@ struct AudioRenderDeadlineBurstDetector: Sendable {
 
     private let requiredMisses: UInt64
     private let window: Duration
-    private var windowStartedAt: ContinuousClock.Instant?
-    private var missesInWindow: UInt64 = 0
+    private var observations: [(at: ContinuousClock.Instant, count: UInt64)] = []
+    private var observedMisses: UInt64 = 0
 
     init(
         requiredMisses: UInt64 = Self.defaultRequiredMisses,
@@ -29,26 +29,26 @@ struct AudioRenderDeadlineBurstDetector: Sendable {
         guard newMisses > 0 else {
             return false
         }
-        if let windowStartedAt,
-           windowStartedAt.duration(to: now) <= window {
-            let sum = missesInWindow.addingReportingOverflow(newMisses)
-            missesInWindow = sum.overflow
-                ? requiredMisses
-                : min(sum.partialValue, requiredMisses)
-        } else {
-            windowStartedAt = now
-            missesInWindow = newMisses
+
+        while let oldest = observations.first,
+              oldest.at.duration(to: now) > window {
+            observedMisses -= oldest.count
+            observations.removeFirst()
         }
-        guard missesInWindow >= requiredMisses else {
-            return false
+
+        if newMisses >= requiredMisses - observedMisses {
+            reset()
+            return true
         }
-        reset()
-        return true
+
+        observations.append((at: now, count: newMisses))
+        observedMisses += newMisses
+        return false
     }
 
     mutating func reset() {
-        windowStartedAt = nil
-        missesInWindow = 0
+        observations.removeAll(keepingCapacity: true)
+        observedMisses = 0
     }
 }
 

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -256,6 +256,9 @@ protocol AudioEngineControlling: AnyObject, Sendable {
     func setPreferredAggregateBufferFrameSize(_ frameSize: UInt32)
     func update(profile: EQProfile) throws
     @discardableResult func updateDSP(profile: EQProfile) -> Bool
+    @discardableResult func beginProgrammeComparison(profile: EQProfile) -> Bool
+    func setProgrammeComparisonSelection(_ selection: EQProgrammeComparisonSelection)
+    func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot
     func muteOutputForTransition()
     func stop()
     func snapshotMetrics() -> AudioEngineMetrics
@@ -267,6 +270,14 @@ protocol AudioEngineControlling: AnyObject, Sendable {
 }
 
 extension AudioEngineControlling {
+    func beginProgrammeComparison(profile _: EQProfile) -> Bool { false }
+
+    func setProgrammeComparisonSelection(_: EQProgrammeComparisonSelection) {}
+
+    func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot {
+        EQProgrammeComparisonSnapshot()
+    }
+
     func setRuntimeFailureHandler(
         _: (@Sendable (AudioEngineFailure) -> Void)?
     ) {}
@@ -430,6 +441,8 @@ final class GlassEQAppModel {
     var importText = ""
     var engineMetrics = AudioEngineMetrics()
     var previewReturnProfile: EQProfile?
+    var programmeComparison = EQProgrammeComparisonSnapshot()
+    private var programmeComparisonReturnProfile: EQProfile?
     private(set) var lifecycleState: GlassEQAppLifecycleState = .stopped
 
     private let engine: any AudioEngineControlling
@@ -442,6 +455,7 @@ final class GlassEQAppModel {
     private let saveDebounceDelay: Duration
     private var observer: (any DefaultOutputObserving)?
     private var metricsTask: Task<Void, Never>?
+    private var programmeComparisonTask: Task<Void, Never>?
     private var renderWatchdogTask: Task<Void, Never>?
     private var renderWatchdog: AudioRenderWatchdog
     private let renderWatchdogPollInterval: Duration
@@ -862,8 +876,18 @@ final class GlassEQAppModel {
             metrics: SettingsAudioMetricsDTO(engineMetrics),
             isRunning: isRunning,
             isPreviewing: previewReturnProfile != nil,
+            programmeComparison: settingsProgrammeComparisonSnapshot(),
             profileStoreProtection: profileStoreProtectionSnapshot()
         )
+    }
+
+    private func settingsProgrammeComparisonSnapshot() -> EQProgrammeComparisonSnapshot {
+        guard programmeComparisonReturnProfile != nil else {
+            return EQProgrammeComparisonSnapshot()
+        }
+        var snapshot = programmeComparison
+        snapshot.isActive = true
+        return snapshot
     }
 
     private func aggregateBufferSnapshot() -> SettingsAggregateBufferDTO {
@@ -997,6 +1021,7 @@ final class GlassEQAppModel {
         renderWatchdog.reset()
         scheduleEngineStop(updateMetrics: true)
         previewReturnProfile = nil
+        clearProgrammeComparisonSession()
         lifecycleState = .stopped
         isRunning = false
         statusMessage = localized("Stopped")
@@ -1202,6 +1227,9 @@ final class GlassEQAppModel {
     }
 
     func preview(profile: EQProfile) {
+        guard programmeComparisonReturnProfile == nil else {
+            return
+        }
         do {
             try ensureProfileStoreWritable()
         } catch {
@@ -1250,6 +1278,7 @@ final class GlassEQAppModel {
         }
         let rollback = profileRollback()
         previewReturnProfile = nil
+        clearProgrammeComparisonSession()
         activeProfile = profile
         selectedProfileID = profile.id
         draftProfile = profile
@@ -1264,6 +1293,103 @@ final class GlassEQAppModel {
             restartEngineWithActiveProfile(rollback: rollback)
         }
         notifyModelDidChange()
+    }
+
+    func startProgrammeComparison(profile: EQProfile) throws {
+        guard programmeComparisonReturnProfile == nil else {
+            return
+        }
+        guard previewReturnProfile == nil else {
+            throw SettingsCommandFailure(
+                message: localized("Stop the profile preview before starting A/B comparison.")
+            )
+        }
+        guard lifecycleState == .running,
+              isRunning,
+              engineStartTask == nil,
+              engineIsRunning else {
+            throw SettingsCommandFailure(
+                message: localized("Start GlassEQ before comparing the profile.")
+            )
+        }
+        guard !profile.isBypassed else {
+            throw SettingsCommandFailure(
+                message: localized("Enable the profile before comparing it.")
+            )
+        }
+
+        engine.setProgrammeComparisonSelection(.equalized)
+        guard engine.beginProgrammeComparison(profile: profile) else {
+            throw SettingsCommandFailure(
+                message: localized("The audio engine could not start A/B comparison.")
+            )
+        }
+
+        programmeComparisonReturnProfile = activeProfile
+        programmeComparison = EQProgrammeComparisonSnapshot(
+            isActive: true,
+            selection: .equalized
+        )
+        statusMessage = localized("Comparing EQ with filters off")
+        startProgrammeComparisonPolling()
+        notifyModelDidChange()
+    }
+
+    func selectProgrammeComparison(_ selection: EQProgrammeComparisonSelection) {
+        guard programmeComparisonReturnProfile != nil else {
+            return
+        }
+        programmeComparison.selection = selection
+        engine.setProgrammeComparisonSelection(selection)
+        notifyModelDidChange()
+    }
+
+    func stopProgrammeComparison() {
+        guard let returnProfile = programmeComparisonReturnProfile else {
+            return
+        }
+        engine.setProgrammeComparisonSelection(.equalized)
+        clearProgrammeComparisonSession()
+        if lifecycleState == .running,
+           isRunning,
+           engineStartTask == nil {
+            if engine.updateDSP(profile: returnProfile) {
+                statusMessage = processingStatus(
+                    outputName: currentOutputName,
+                    profileName: returnProfile.name
+                )
+            } else {
+                restartEngineWithActiveProfile()
+            }
+        }
+        notifyModelDidChange()
+    }
+
+    private func startProgrammeComparisonPolling() {
+        programmeComparisonTask?.cancel()
+        programmeComparisonTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(100))
+                guard let self,
+                      self.programmeComparisonReturnProfile != nil else {
+                    return
+                }
+                var next = self.engine.snapshotProgrammeComparison()
+                next.isActive = true
+                guard next != self.programmeComparison else {
+                    continue
+                }
+                self.programmeComparison = next
+                self.notifyModelDidChange()
+            }
+        }
+    }
+
+    private func clearProgrammeComparisonSession() {
+        programmeComparisonTask?.cancel()
+        programmeComparisonTask = nil
+        programmeComparisonReturnProfile = nil
+        programmeComparison = EQProgrammeComparisonSnapshot()
     }
 
     func resetDiagnostics() {
@@ -1650,6 +1776,7 @@ final class GlassEQAppModel {
     }
 
     private func disableActiveProfileProcessing(updateMetrics: Bool) {
+        clearProgrammeComparisonSession()
         let shouldStopEngine = isRunning || engineStartTask != nil || engineStateNeedsStop
         invalidatePendingOutputChange()
         invalidatePendingEngineStart()
@@ -2433,6 +2560,7 @@ final class GlassEQAppModel {
         selectedProfileID = activeProfile.id
         draftProfile = activeProfile
         previewReturnProfile = nil
+        clearProgrammeComparisonSession()
         statusMessage = localized("Profiles reset for this GlassEQ version; previous store backed up to \(result.backupURL.lastPathComponent).")
         notifyModelDidChange()
     }
@@ -2756,6 +2884,7 @@ final class GlassEQAppModel {
         stopObserver()
         scheduleEngineStop(updateMetrics: false)
         previewReturnProfile = nil
+        clearProgrammeComparisonSession()
         lifecycleState = .sleeping
         isRunning = false
         statusMessage = localized("Paused for system sleep")
@@ -2861,6 +2990,7 @@ final class GlassEQAppModel {
         metricsTask = nil
         stopObserver()
         previewReturnProfile = nil
+        clearProgrammeComparisonSession()
         isRunning = false
         if shutdownSettings {
             settingsCoordinator.shutdown()

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -1400,7 +1400,14 @@ final class GlassEQAppModel {
         }
     }
 
-    private func clearProgrammeComparisonSession() {
+    private func clearProgrammeComparisonSession(
+        restoringEqualizedRendererIfRunning: Bool = false
+    ) {
+        if restoringEqualizedRendererIfRunning,
+           programmeComparisonReturnProfile != nil,
+           case .running = engine.state {
+            engine.setProgrammeComparisonSelection(.equalized)
+        }
         programmeComparisonTask?.cancel()
         programmeComparisonTask = nil
         programmeComparisonReturnProfile = nil
@@ -1649,6 +1656,7 @@ final class GlassEQAppModel {
             return
         }
 
+        clearProgrammeComparisonSession(restoringEqualizedRendererIfRunning: true)
         let rollback = profileRollback()
         previewReturnProfile = nil
         switch result {
@@ -3227,6 +3235,7 @@ final class GlassEQAppModel {
               case .failed = engine.state else {
             return
         }
+        clearProgrammeComparisonSession(restoringEqualizedRendererIfRunning: true)
         invalidatePendingEngineStart()
         lifecycleState = .stopped
         isRunning = false

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -357,6 +357,7 @@ extension SettingsAudioMetricsDTO {
             outputTimestampDiscontinuities: metrics.outputTimestampDiscontinuities,
             maximumCaptureCallbackFrames: metrics.maximumCaptureCallbackFrames,
             maximumPlaybackCallbackFrames: metrics.maximumPlaybackCallbackFrames,
+            renderDeadlineMisses: metrics.renderDeadlineMisses,
             playbackTimestampDiscontinuities: metrics.playbackTimestampDiscontinuities,
             playbackBufferRenegotiations: metrics.playbackBufferRenegotiations,
             adaptivePlaybackRenderFailures: metrics.adaptivePlaybackRenderFailures,
@@ -482,6 +483,7 @@ final class GlassEQAppModel {
     private var headsetPromotionAttemptedOutputGeneration: Int?
     private let aggregateBufferNotifier: any AggregateBufferChangeNotifying
     private var pendingAggregateBufferIncrease: PendingAggregateBufferIncrease?
+    private var fixedBufferRecovery: FixedBufferRecovery?
     private let storeWriter: ProfileStoreWriter
     private var profilePersistenceMode: ProfilePersistenceMode = .normal
     @ObservationIgnored private let engineWorkExecutor = EngineWorkExecutor()
@@ -513,10 +515,23 @@ final class GlassEQAppModel {
     }
 
     private struct PendingAggregateBufferIncrease: Sendable {
+        enum Kind: Sendable {
+            case automatic
+            case fixedRebuild
+            case fixedTemporaryIncrease
+        }
+
         var route: AggregateAudioRouteFingerprint
         var outputName: String
         var previousFrameSize: UInt32
         var newFrameSize: UInt32
+        var kind: Kind = .automatic
+    }
+
+    private struct FixedBufferRecovery: Sendable {
+        var route: AggregateAudioRouteFingerprint
+        var preferredFrameSize: UInt32
+        var session: FixedBufferRecoverySession
     }
 
     private struct EngineProfileConfirmation: Sendable {
@@ -1731,7 +1746,7 @@ final class GlassEQAppModel {
     ) {
         let route = try? engine.aggregateRouteFingerprint(for: output)
         let frameSize = requestedFrameSize
-            ?? route.map { aggregateBufferPolicyStore.selection(for: $0).frameSize }
+            ?? route.map { aggregateBufferFrameSize(for: $0) }
             ?? 16
         scheduleEngineWork(.start(
             output: output,
@@ -1739,6 +1754,29 @@ final class GlassEQAppModel {
             rollback: rollback,
             aggregateBufferFrameSize: frameSize
         ))
+    }
+
+    private func aggregateBufferFrameSize(
+        for route: AggregateAudioRouteFingerprint
+    ) -> UInt32 {
+        let selection = aggregateBufferPolicyStore.selection(for: route)
+        guard selection.mode != .automatic,
+              let fixedBufferRecovery,
+              fixedBufferRecovery.route == route,
+              fixedBufferRecovery.preferredFrameSize == selection.frameSize else {
+            return selection.frameSize
+        }
+        return fixedBufferRecovery.session.runtimeFrameSize
+    }
+
+    private func clearFixedBufferRecoveryAndRestorePreference() {
+        guard let fixedBufferRecovery else {
+            return
+        }
+        engine.setPreferredAggregateBufferFrameSize(
+            fixedBufferRecovery.preferredFrameSize
+        )
+        self.fixedBufferRecovery = nil
     }
 
     private func synchronizeActiveProfileProcessing(rollback: ProfileRollback? = nil) {
@@ -1777,6 +1815,7 @@ final class GlassEQAppModel {
 
     private func disableActiveProfileProcessing(updateMetrics: Bool) {
         clearProgrammeComparisonSession()
+        clearFixedBufferRecoveryAndRestorePreference()
         let shouldStopEngine = isRunning || engineStartTask != nil || engineStateNeedsStop
         invalidatePendingOutputChange()
         invalidatePendingEngineStart()
@@ -1992,6 +2031,7 @@ final class GlassEQAppModel {
         case .success(let output):
             refreshCurrentOutputMetadata(from: output)
             activeAggregateRoute = try? engine.aggregateRouteFingerprint(for: output)
+            clearFixedBufferRecoveryIfRouteChanged()
             lifecycleState = .running
             isRunning = true
             wakeReconnectAttempts = 0
@@ -2013,6 +2053,7 @@ final class GlassEQAppModel {
         case .profileChangeNotApplied(_, let output, let reconciliation):
             refreshCurrentOutputMetadata(from: output)
             activeAggregateRoute = try? engine.aggregateRouteFingerprint(for: output)
+            clearFixedBufferRecoveryIfRouteChanged()
             if let reconciliation {
                 restoreEngineProfileReconciliation(reconciliation, persist: true)
                 confirmedEngineProfileState.acknowledge(reconciliation)
@@ -2051,6 +2092,18 @@ final class GlassEQAppModel {
         notifyModelDidChange()
     }
 
+    private func clearFixedBufferRecoveryIfRouteChanged() {
+        guard let fixedBufferRecovery else {
+            return
+        }
+        let selection = aggregateBufferPolicyStore.selection(for: fixedBufferRecovery.route)
+        if activeAggregateRoute != fixedBufferRecovery.route
+            || selection.mode == .automatic
+            || selection.frameSize != fixedBufferRecovery.preferredFrameSize {
+            self.fixedBufferRecovery = nil
+        }
+    }
+
     private func startAggregateStabilityMonitoring() {
         aggregateStabilityTask?.cancel()
         aggregateStabilityTask = nil
@@ -2058,9 +2111,6 @@ final class GlassEQAppModel {
             return
         }
         let selection = aggregateBufferPolicyStore.selection(for: route)
-        guard selection.mode == .automatic else {
-            return
-        }
         let engineGeneration = engineStartGeneration
         let outputGeneration = outputChangeGeneration
         let settlingDelay = aggregateStabilitySettlingDelay
@@ -2076,8 +2126,10 @@ final class GlassEQAppModel {
                   ) else {
                 return
             }
-            var qualifyingBaseline = self.engine.snapshotMetrics()
-                .qualifyingPairedTimestampDiscontinuities
+            let initialMetrics = self.engine.snapshotMetrics()
+            var qualifyingBaseline = initialMetrics.qualifyingPairedTimestampDiscontinuities
+            var deadlineBaseline = initialMetrics.renderDeadlineMisses
+            var deadlineBurstDetector = AudioRenderDeadlineBurstDetector()
             var sessionHadQualifyingInterruption = false
             var cleanSessionRecorded = false
             let cleanSessionDeadline = ContinuousClock.now.advanced(
@@ -2093,8 +2145,24 @@ final class GlassEQAppModel {
                       ) else {
                     return
                 }
-                let nextCount = self.engine.snapshotMetrics()
-                    .qualifyingPairedTimestampDiscontinuities
+                let metrics = self.engine.snapshotMetrics()
+                let nextDeadlineCount = metrics.renderDeadlineMisses
+                if selection.mode != .automatic {
+                    if nextDeadlineCount > deadlineBaseline {
+                        let newMisses = nextDeadlineCount - deadlineBaseline
+                        deadlineBaseline = nextDeadlineCount
+                        if deadlineBurstDetector.observe(newMisses: newMisses),
+                           self.handleFixedAggregateDeadlineBurst(on: route) {
+                            return
+                        }
+                    } else if nextDeadlineCount < deadlineBaseline {
+                        deadlineBaseline = nextDeadlineCount
+                        deadlineBurstDetector.reset()
+                    }
+                    continue
+                }
+
+                let nextCount = metrics.qualifyingPairedTimestampDiscontinuities
                 if nextCount > qualifyingBaseline {
                     let occurrenceCount = nextCount - qualifyingBaseline
                     qualifyingBaseline = nextCount
@@ -2226,6 +2294,90 @@ final class GlassEQAppModel {
             && Int64(currentOutputSampleRate.rounded()) == route.nominalSampleRate
     }
 
+    private func handleFixedAggregateDeadlineBurst(
+        on route: AggregateAudioRouteFingerprint
+    ) -> Bool {
+        guard activeAggregateRoute == route,
+              lifecycleState == .running,
+              engineStartTask == nil,
+              case .running(let output) = engine.state else {
+            return false
+        }
+        let selection = aggregateBufferPolicyStore.selection(for: route)
+        guard selection.mode != .automatic else {
+            return false
+        }
+
+        var recovery: FixedBufferRecovery
+        if let fixedBufferRecovery,
+           fixedBufferRecovery.route == route,
+           fixedBufferRecovery.preferredFrameSize == selection.frameSize {
+            recovery = fixedBufferRecovery
+        } else {
+            recovery = FixedBufferRecovery(
+                route: route,
+                preferredFrameSize: selection.frameSize,
+                session: FixedBufferRecoverySession(
+                    runtimeFrameSize: selection.frameSize
+                )
+            )
+        }
+        let previousFrameSize = recovery.session.runtimeFrameSize
+        let action = recovery.session.observeFailure()
+        fixedBufferRecovery = recovery
+
+        switch action {
+        case .rebuild(let frameSize):
+            pendingAggregateBufferIncrease = PendingAggregateBufferIncrease(
+                route: route,
+                outputName: output.name,
+                previousFrameSize: frameSize,
+                newFrameSize: frameSize,
+                kind: .fixedRebuild
+            )
+            statusMessage = localized(
+                "Audio deadlines were missed; rebuilding \(output.name) with \(frameSize)-frame buffers..."
+            )
+            notifyModelDidChange()
+            scheduleEngineStart(
+                output: output,
+                profile: activeProfile,
+                rollback: nil,
+                aggregateBufferFrameSize: frameSize
+            )
+        case .temporarilyIncrease(let frameSize):
+            pendingAggregateBufferIncrease = PendingAggregateBufferIncrease(
+                route: route,
+                outputName: output.name,
+                previousFrameSize: previousFrameSize,
+                newFrameSize: frameSize,
+                kind: .fixedTemporaryIncrease
+            )
+            statusMessage = localized(
+                "\(selection.frameSize)-frame processing became unstable; temporarily switching \(output.name) to \(frameSize)-frame buffers..."
+            )
+            notifyModelDidChange()
+            scheduleEngineStart(
+                output: output,
+                profile: activeProfile,
+                rollback: nil,
+                aggregateBufferFrameSize: frameSize
+            )
+        case .stop:
+            pendingAggregateBufferIncrease = nil
+            invalidatePendingEngineStart()
+            scheduleEngineStop(updateMetrics: true)
+            lifecycleState = .stopped
+            isRunning = false
+            renderWatchdog.pause()
+            statusMessage = localized(
+                "64-frame processing missed audio deadlines again, so GlassEQ stopped processing. Retry the audio engine when ready."
+            )
+            notifyModelDidChange()
+        }
+        return true
+    }
+
     private func handleQualifyingAggregateInterruption(
         on route: AggregateAudioRouteFingerprint,
         occurrences: UInt64
@@ -2329,11 +2481,28 @@ final class GlassEQAppModel {
             return
         }
         self.pendingAggregateBufferIncrease = nil
-        aggregateBufferNotifier.notifyBufferIncrease(
-            outputName: pendingAggregateBufferIncrease.outputName,
-            previousFrameSize: pendingAggregateBufferIncrease.previousFrameSize,
-            newFrameSize: pendingAggregateBufferIncrease.newFrameSize
-        )
+        switch pendingAggregateBufferIncrease.kind {
+        case .automatic:
+            aggregateBufferNotifier.notifyBufferIncrease(
+                outputName: pendingAggregateBufferIncrease.outputName,
+                previousFrameSize: pendingAggregateBufferIncrease.previousFrameSize,
+                newFrameSize: pendingAggregateBufferIncrease.newFrameSize
+            )
+        case .fixedRebuild:
+            aggregateBufferNotifier.notifyFixedBufferRebuild(
+                outputName: pendingAggregateBufferIncrease.outputName,
+                frameSize: pendingAggregateBufferIncrease.newFrameSize
+            )
+        case .fixedTemporaryIncrease:
+            let preferredFrameSize = aggregateBufferPolicyStore.selection(
+                for: pendingAggregateBufferIncrease.route
+            ).frameSize
+            aggregateBufferNotifier.notifyTemporaryBufferIncrease(
+                outputName: pendingAggregateBufferIncrease.outputName,
+                preferredFrameSize: preferredFrameSize,
+                runtimeFrameSize: pendingAggregateBufferIncrease.newFrameSize
+            )
+        }
     }
 
     private func restoreProfileRollback(_ rollback: ProfileRollback, persist: Bool) {
@@ -2597,6 +2766,23 @@ final class GlassEQAppModel {
             return
         }
         renderWatchdog.reset()
+        let restoredFixedFrameSize = fixedBufferRecovery?.preferredFrameSize
+        clearFixedBufferRecoveryAndRestorePreference()
+        if let restoredFixedFrameSize,
+           case .running(let output) = engine.state {
+            pendingAggregateBufferIncrease = nil
+            statusMessage = localized(
+                "Rebuilding \(output.name) with \(restoredFixedFrameSize)-frame buffers..."
+            )
+            notifyModelDidChange()
+            scheduleEngineStart(
+                output: output,
+                profile: activeProfile,
+                rollback: nil,
+                aggregateBufferFrameSize: restoredFixedFrameSize
+            )
+            return
+        }
         restartEngineWithActiveProfile()
     }
 
@@ -2610,6 +2796,7 @@ final class GlassEQAppModel {
                 message: localized("Automatic buffer tuning is unavailable on this output route.")
             )
         }
+        fixedBufferRecovery = nil
         try aggregateBufferPolicyStore.setMode(mode, for: activeAggregateRoute)
         let selection = aggregateBufferPolicyStore.selection(for: activeAggregateRoute)
         pendingAggregateBufferIncrease = nil
@@ -2635,6 +2822,7 @@ final class GlassEQAppModel {
                 message: localized("Automatic buffer tuning is unavailable on this output route.")
             )
         }
+        fixedBufferRecovery = nil
         try aggregateBufferPolicyStore.retryAutomaticBuffer(for: activeAggregateRoute)
         pendingAggregateBufferIncrease = nil
         statusMessage = localized(
@@ -2768,7 +2956,7 @@ final class GlassEQAppModel {
         switch action {
         case .restart:
             let frameSize = activeAggregateRoute.map {
-                aggregateBufferPolicyStore.selection(for: $0).frameSize
+                aggregateBufferFrameSize(for: $0)
             } ?? 16
             statusMessage = localized(
                 "Audio rendering stalled; rebuilding \(output.name)..."
@@ -2832,6 +3020,7 @@ final class GlassEQAppModel {
         pendingEngineStartOutput = nil
         activeAggregateRoute = nil
         pendingAggregateBufferIncrease = nil
+        fixedBufferRecovery = nil
     }
 
     private func installLifecycleObservers() {
@@ -2885,6 +3074,7 @@ final class GlassEQAppModel {
         scheduleEngineStop(updateMetrics: false)
         previewReturnProfile = nil
         clearProgrammeComparisonSession()
+        clearFixedBufferRecoveryAndRestorePreference()
         lifecycleState = .sleeping
         isRunning = false
         statusMessage = localized("Paused for system sleep")

--- a/Sources/GlassEQApp/SettingsCoordinator.swift
+++ b/Sources/GlassEQApp/SettingsCoordinator.swift
@@ -493,6 +493,10 @@ final class SettingsCoordinator: NSObject {
             patch.isPreviewing = snapshot.isPreviewing
             didPatch = true
         }
+        if previous.programmeComparison != snapshot.programmeComparison {
+            patch.programmeComparison = snapshot.programmeComparison
+            didPatch = true
+        }
         if previous.selectedProfileID != snapshot.selectedProfileID {
             patch.selectedProfileID = snapshot.selectedProfileID
             didPatch = true
@@ -1057,6 +1061,19 @@ extension GlassEQAppModel {
 
         case .stopPreview:
             stopPreview()
+            return SettingsCommandResponse(snapshot: settingsSnapshot())
+
+        case .startProgrammeComparison(let profile):
+            try validateIncomingProfile(profile)
+            try startProgrammeComparison(profile: profile)
+            return SettingsCommandResponse(snapshot: settingsSnapshot())
+
+        case .selectProgrammeComparison(let selection):
+            selectProgrammeComparison(selection)
+            return SettingsCommandResponse(snapshot: settingsSnapshot())
+
+        case .stopProgrammeComparison:
+            stopProgrammeComparison()
             return SettingsCommandResponse(snapshot: settingsSnapshot())
 
         case .resetDiagnostics:

--- a/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
+++ b/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
@@ -210,11 +210,23 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
     private final class PreparedDSPConfigBox: @unchecked Sendable {
         var processor: EQProcessor?
+        var comparisonReferenceProcessor: EQProcessor?
         var retiredProcessor: EQProcessor?
+        var secondRetiredProcessor: EQProcessor?
         var nextRetiredPointer: UInt = 0
 
         init(config: EQRenderConfiguration) {
             self.processor = EQProcessor(renderConfiguration: config)
+        }
+
+        init(
+            equalizedConfig: EQRenderConfiguration,
+            referenceConfig: EQRenderConfiguration
+        ) {
+            self.processor = EQProcessor(renderConfiguration: equalizedConfig)
+            self.comparisonReferenceProcessor = EQProcessor(
+                renderConfiguration: referenceConfig
+            )
         }
     }
 
@@ -281,6 +293,13 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         private let pendingDSPConfigPointer = Atomic<UInt>(0)
         private let retiredDSPConfigHeadPointer = Atomic<UInt>(0)
         private var activeDSPConfigPointer: UInt = 0
+        private let programmeComparisonSelection = Atomic<UInt>(
+            UInt(EQProgrammeComparisonSelection.equalized.rawValue)
+        )
+        private let programmeComparisonActive = Atomic<Bool>(false)
+        private let programmeComparisonReady = Atomic<Bool>(false)
+        private let equalizedAttenuationMilliDB = Atomic<Int64>(0)
+        private let filtersOffAttenuationMilliDB = Atomic<Int64>(0)
         private let stopping = Atomic<Bool>(false)
         private let captureInCallback = Atomic<Bool>(false)
         private let playbackInCallback = Atomic<Bool>(false)
@@ -527,6 +546,44 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
         func publishPendingDSPConfig(_ config: EQRenderConfiguration) {
             let box = PreparedDSPConfigBox(config: config)
+            publishPendingDSPConfigBox(box)
+        }
+
+        func publishPendingProgrammeComparison(
+            equalizedConfig: EQRenderConfiguration,
+            referenceConfig: EQRenderConfiguration
+        ) {
+            let box = PreparedDSPConfigBox(
+                equalizedConfig: equalizedConfig,
+                referenceConfig: referenceConfig
+            )
+            publishPendingDSPConfigBox(box)
+        }
+
+        func setProgrammeComparisonSelection(
+            _ selection: EQProgrammeComparisonSelection
+        ) {
+            programmeComparisonSelection.store(
+                UInt(selection.rawValue),
+                ordering: .releasing
+            )
+        }
+
+        func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot {
+            EQProgrammeComparisonSnapshot(
+                isActive: programmeComparisonActive.load(ordering: .acquiring),
+                isReady: programmeComparisonReady.load(ordering: .acquiring),
+                selection: selectedProgrammeComparisonBranch(),
+                equalizedAttenuationDB: Double(
+                    equalizedAttenuationMilliDB.load(ordering: .relaxed)
+                ) / 1_000,
+                filtersOffAttenuationDB: Double(
+                    filtersOffAttenuationMilliDB.load(ordering: .relaxed)
+                ) / 1_000
+            )
+        }
+
+        private func publishPendingDSPConfigBox(_ box: PreparedDSPConfigBox) {
             let rawPointer = UInt(bitPattern: Unmanaged.passRetained(box).toOpaque())
             let oldPointer = pendingDSPConfigPointer.exchange(rawPointer, ordering: .acquiringAndReleasing)
             releaseDSPConfigBox(oldPointer)
@@ -568,6 +625,11 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             }
 
             beginPendingDSPTransitionIfPossible()
+            if programmeComparisonActive.load(ordering: .relaxed) {
+                dspTransition.setProgrammeComparisonSelection(
+                    selectedProgrammeComparisonBranch()
+                )
+            }
 
             var saturatedSampleCount: UInt64 = 0
             captureScratchSamples.withUnsafeMutableBufferPointer { scratch in
@@ -591,6 +653,12 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
                         frameCount: chunkFrames,
                         channelCount: channelCount
                     )
+                    if transitionResult.programmeComparison.isActive
+                        || programmeComparisonActive.load(ordering: .relaxed) {
+                        publishProgrammeComparisonSnapshot(
+                            transitionResult.programmeComparison
+                        )
+                    }
                     finishDSPTransition(transitionResult)
                     saturatedSampleCount += transitionResult.saturatedSamples
                     recordWriteResult(
@@ -1068,12 +1136,25 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
             let pointer = UnsafeRawPointer(bitPattern: rawPointer)!
             let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
-            guard let processor = box.processor,
-                  dspTransition.beginTransition(to: processor) else {
+            guard let processor = box.processor else {
+                pushRetiredDSPConfigBox(rawPointer)
+                return
+            }
+            let didBegin: Bool
+            if let referenceProcessor = box.comparisonReferenceProcessor {
+                didBegin = dspTransition.beginProgrammeComparison(
+                    equalizedProcessor: processor,
+                    filtersOffProcessor: referenceProcessor
+                )
+            } else {
+                didBegin = dspTransition.beginTransition(to: processor)
+            }
+            guard didBegin else {
                 pushRetiredDSPConfigBox(rawPointer)
                 return
             }
             box.processor = nil
+            box.comparisonReferenceProcessor = nil
             activeDSPConfigPointer = rawPointer
         }
 
@@ -1087,7 +1168,31 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             activeDSPConfigPointer = 0
             let box = Unmanaged<PreparedDSPConfigBox>.fromOpaque(pointer).takeUnretainedValue()
             box.retiredProcessor = result.retiredProcessor
+            box.secondRetiredProcessor = result.secondRetiredProcessor
             pushRetiredDSPConfigBox(rawPointer)
+        }
+
+        private func selectedProgrammeComparisonBranch() -> EQProgrammeComparisonSelection {
+            EQProgrammeComparisonSelection(
+                rawValue: UInt8(
+                    programmeComparisonSelection.load(ordering: .acquiring)
+                )
+            ) ?? .equalized
+        }
+
+        private func publishProgrammeComparisonSnapshot(
+            _ snapshot: EQProgrammeComparisonSnapshot
+        ) {
+            programmeComparisonActive.store(snapshot.isActive, ordering: .releasing)
+            programmeComparisonReady.store(snapshot.isReady, ordering: .releasing)
+            equalizedAttenuationMilliDB.store(
+                Int64((snapshot.equalizedAttenuationDB * 1_000).rounded()),
+                ordering: .relaxed
+            )
+            filtersOffAttenuationMilliDB.store(
+                Int64((snapshot.filtersOffAttenuationDB * 1_000).rounded()),
+                ordering: .relaxed
+            )
         }
 
         private func pushRetiredDSPConfigBox(_ rawPointer: UInt) {
@@ -1651,6 +1756,57 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         }
     }
 
+    @discardableResult
+    public func beginProgrammeComparison(profile: EQProfile) -> Bool {
+        guard !profile.isBypassed else {
+            return false
+        }
+        return control.withLock { state in
+            guard let runtime = state.runtime else {
+                return false
+            }
+            let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+                sampleRate: state.activeOutput?.nominalSampleRate ?? runtime.sampleRate
+            )
+            let equalizedConfig = EQRenderConfiguration(
+                profile: profile,
+                sampleRate: runtime.sampleRate,
+                channelCount: runtime.channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            )
+            let referenceConfig = EQRenderConfiguration(
+                profile: profile.programmeComparisonReference,
+                sampleRate: runtime.sampleRate,
+                channelCount: runtime.channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            )
+            guard equalizedConfig.isNumericallySafe,
+                  referenceConfig.isNumericallySafe else {
+                return false
+            }
+            runtime.setProgrammeComparisonSelection(.equalized)
+            runtime.drainDSPConfigBoxes()
+            runtime.publishPendingProgrammeComparison(
+                equalizedConfig: equalizedConfig,
+                referenceConfig: referenceConfig
+            )
+            return true
+        }
+    }
+
+    public func setProgrammeComparisonSelection(
+        _ selection: EQProgrammeComparisonSelection
+    ) {
+        control.withLock { state in
+            state.runtime?.setProgrammeComparisonSelection(selection)
+        }
+    }
+
+    public func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot {
+        control.withLock { $0.runtime }?.snapshotProgrammeComparison()
+            ?? EQProgrammeComparisonSnapshot()
+    }
+
     private func updateDSPLocked(
         _ state: inout ControlState,
         profile: EQProfile,
@@ -1680,6 +1836,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             channelCount: runtime.channelCount,
             maximumUsableFrequency: maximumUsableFrequency
         )
+        runtime.setProgrammeComparisonSelection(.equalized)
         runtime.drainDSPConfigBoxes()
         runtime.publishPendingDSPConfig(preparedConfig)
         state.activeProfile = profile

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -479,14 +479,29 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
     private final class PreparedDSPConfigBox: @unchecked Sendable {
         var processor: EQProcessor?
+        var comparisonReferenceProcessor: EQProcessor?
         let systemSoundPreampGains: (left: Float, right: Float)
         var retiredProcessor: EQProcessor?
+        var secondRetiredProcessor: EQProcessor?
         var nextRetiredPointer: UInt = 0
 
         init(config: EQRenderConfiguration) {
             self.processor = EQProcessor(renderConfiguration: config)
             self.systemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
                 for: config
+            )
+        }
+
+        init(
+            equalizedConfig: EQRenderConfiguration,
+            referenceConfig: EQRenderConfiguration
+        ) {
+            self.processor = EQProcessor(renderConfiguration: equalizedConfig)
+            self.comparisonReferenceProcessor = EQProcessor(
+                renderConfiguration: referenceConfig
+            )
+            self.systemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
+                for: equalizedConfig
             )
         }
     }
@@ -561,6 +576,13 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let totalOutputLeadNanoseconds = Atomic<UInt64>(0)
         private let outputMutedForTransition = Atomic<Bool>(true)
         private let outputIsMuted = Atomic<Bool>(true)
+        private let programmeComparisonSelection = Atomic<UInt>(
+            UInt(EQProgrammeComparisonSelection.equalized.rawValue)
+        )
+        private let programmeComparisonActive = Atomic<Bool>(false)
+        private let programmeComparisonReady = Atomic<Bool>(false)
+        private let equalizedAttenuationMilliDB = Atomic<Int64>(0)
+        private let filtersOffAttenuationMilliDB = Atomic<Int64>(0)
         private let pendingDSPConfigPointer = Atomic<UInt>(0)
         private let retiredDSPConfigHeadPointer = Atomic<UInt>(0)
         private var activeDSPConfigPointer: UInt = 0
@@ -687,6 +709,11 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 outputTime: outputTime
             )
             prepareDSPAndOutputFade()
+            if programmeComparisonActive.load(ordering: .relaxed) {
+                dspTransition.setProgrammeComparisonSelection(
+                    selectedProgrammeComparisonBranch()
+                )
+            }
             let sampleCount = frameCount * channelCount
             scratchSamples.withUnsafeMutableBufferPointer { scratch in
                 let samples = UnsafeMutableBufferPointer(
@@ -706,6 +733,12 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     frameCount: frameCount,
                     channelCount: channelCount
                 )
+                if transitionResult.programmeComparison.isActive
+                    || programmeComparisonActive.load(ordering: .relaxed) {
+                    publishProgrammeComparisonSnapshot(
+                        transitionResult.programmeComparison
+                    )
+                }
                 if transitionResult.saturatedSamples > 0 {
                     saturatedSamples.wrappingAdd(
                         transitionResult.saturatedSamples,
@@ -944,6 +977,44 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
 
         func publishPendingDSPConfig(_ config: EQRenderConfiguration) {
             let box = PreparedDSPConfigBox(config: config)
+            publishPendingDSPConfigBox(box)
+        }
+
+        func publishPendingProgrammeComparison(
+            equalizedConfig: EQRenderConfiguration,
+            referenceConfig: EQRenderConfiguration
+        ) {
+            let box = PreparedDSPConfigBox(
+                equalizedConfig: equalizedConfig,
+                referenceConfig: referenceConfig
+            )
+            publishPendingDSPConfigBox(box)
+        }
+
+        func setProgrammeComparisonSelection(
+            _ selection: EQProgrammeComparisonSelection
+        ) {
+            programmeComparisonSelection.store(
+                UInt(selection.rawValue),
+                ordering: .releasing
+            )
+        }
+
+        func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot {
+            EQProgrammeComparisonSnapshot(
+                isActive: programmeComparisonActive.load(ordering: .acquiring),
+                isReady: programmeComparisonReady.load(ordering: .acquiring),
+                selection: selectedProgrammeComparisonBranch(),
+                equalizedAttenuationDB: Double(
+                    equalizedAttenuationMilliDB.load(ordering: .relaxed)
+                ) / 1_000,
+                filtersOffAttenuationDB: Double(
+                    filtersOffAttenuationMilliDB.load(ordering: .relaxed)
+                ) / 1_000
+            )
+        }
+
+        private func publishPendingDSPConfigBox(_ box: PreparedDSPConfigBox) {
             let rawPointer = UInt(bitPattern: Unmanaged.passRetained(box).toOpaque())
             let oldPointer = pendingDSPConfigPointer.exchange(
                 rawPointer,
@@ -991,12 +1062,25 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             let box = Unmanaged<PreparedDSPConfigBox>
                 .fromOpaque(pointer)
                 .takeUnretainedValue()
-            guard let processor = box.processor,
-                  dspTransition.beginTransition(to: processor) else {
+            guard let processor = box.processor else {
+                pushRetiredDSPConfigBox(rawPointer)
+                return
+            }
+            let didBegin: Bool
+            if let referenceProcessor = box.comparisonReferenceProcessor {
+                didBegin = dspTransition.beginProgrammeComparison(
+                    equalizedProcessor: processor,
+                    filtersOffProcessor: referenceProcessor
+                )
+            } else {
+                didBegin = dspTransition.beginTransition(to: processor)
+            }
+            guard didBegin else {
                 pushRetiredDSPConfigBox(rawPointer)
                 return
             }
             box.processor = nil
+            box.comparisonReferenceProcessor = nil
             activeDSPConfigPointer = rawPointer
         }
 
@@ -1012,8 +1096,32 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 .fromOpaque(pointer)
                 .takeUnretainedValue()
             box.retiredProcessor = result.retiredProcessor
+            box.secondRetiredProcessor = result.secondRetiredProcessor
             activeSystemSoundPreampGains = box.systemSoundPreampGains
             pushRetiredDSPConfigBox(rawPointer)
+        }
+
+        private func selectedProgrammeComparisonBranch() -> EQProgrammeComparisonSelection {
+            EQProgrammeComparisonSelection(
+                rawValue: UInt8(
+                    programmeComparisonSelection.load(ordering: .acquiring)
+                )
+            ) ?? .equalized
+        }
+
+        private func publishProgrammeComparisonSnapshot(
+            _ snapshot: EQProgrammeComparisonSnapshot
+        ) {
+            programmeComparisonActive.store(snapshot.isActive, ordering: .releasing)
+            programmeComparisonReady.store(snapshot.isReady, ordering: .releasing)
+            equalizedAttenuationMilliDB.store(
+                Int64((snapshot.equalizedAttenuationDB * 1_000).rounded()),
+                ordering: .relaxed
+            )
+            filtersOffAttenuationMilliDB.store(
+                Int64((snapshot.filtersOffAttenuationDB * 1_000).rounded()),
+                ordering: .relaxed
+            )
         }
 
         private func incomingSystemSoundPreampGains() -> (left: Float, right: Float)? {
@@ -2059,6 +2167,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             ) else {
                 return false
             }
+            runtime.setProgrammeComparisonSelection(.equalized)
             runtime.drainDSPConfigBoxes()
             runtime.publishPendingDSPConfig(
                 EQRenderConfiguration(
@@ -2071,6 +2180,67 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             state.activeProfile = profile
             return true
         }
+    }
+
+    @discardableResult
+    public func beginProgrammeComparison(profile: EQProfile) -> Bool {
+        guard !profile.isBypassed else {
+            return false
+        }
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            return separateClockBackend.beginProgrammeComparison(profile: profile)
+        }
+        return control.withLock { state in
+            guard let runtime = state.runtime else {
+                return false
+            }
+            let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+                sampleRate: runtime.sampleRate
+            )
+            let equalizedConfig = EQRenderConfiguration(
+                profile: profile,
+                sampleRate: runtime.sampleRate,
+                channelCount: runtime.channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            )
+            let referenceConfig = EQRenderConfiguration(
+                profile: profile.programmeComparisonReference,
+                sampleRate: runtime.sampleRate,
+                channelCount: runtime.channelCount,
+                maximumUsableFrequency: maximumUsableFrequency
+            )
+            guard equalizedConfig.isNumericallySafe,
+                  referenceConfig.isNumericallySafe else {
+                return false
+            }
+            runtime.setProgrammeComparisonSelection(.equalized)
+            runtime.drainDSPConfigBoxes()
+            runtime.publishPendingProgrammeComparison(
+                equalizedConfig: equalizedConfig,
+                referenceConfig: referenceConfig
+            )
+            return true
+        }
+    }
+
+    public func setProgrammeComparisonSelection(
+        _ selection: EQProgrammeComparisonSelection
+    ) {
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            separateClockBackend.setProgrammeComparisonSelection(selection)
+            return
+        }
+        control.withLock { state in
+            state.runtime?.setProgrammeComparisonSelection(selection)
+        }
+    }
+
+    public func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot {
+        if activeBackend.withLock({ $0 }) == .separateClock {
+            return separateClockBackend.snapshotProgrammeComparison()
+        }
+        return control.withLock { $0.runtime }?.snapshotProgrammeComparison()
+            ?? EQProgrammeComparisonSnapshot()
     }
 
     public func setPreferredAggregateBufferFrameSize(_ frameSize: UInt32) {

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -66,6 +66,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var averageTimestampJumpIntervalNanoseconds: Double
     public var maximumCaptureCallbackFrames: Int
     public var maximumPlaybackCallbackFrames: Int
+    public var renderDeadlineMisses: UInt64
     public var playbackTimestampDiscontinuities: UInt64
     public var playbackBufferRenegotiations: UInt64
     public var adaptivePlaybackRenderFailures: UInt64
@@ -115,6 +116,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         averageTimestampJumpIntervalNanoseconds: Double = 0,
         maximumCaptureCallbackFrames: Int = 0,
         maximumPlaybackCallbackFrames: Int = 0,
+        renderDeadlineMisses: UInt64 = 0,
         playbackTimestampDiscontinuities: UInt64 = 0,
         playbackBufferRenegotiations: UInt64 = 0,
         adaptivePlaybackRenderFailures: UInt64 = 0,
@@ -163,6 +165,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.averageTimestampJumpIntervalNanoseconds = averageTimestampJumpIntervalNanoseconds
         self.maximumCaptureCallbackFrames = maximumCaptureCallbackFrames
         self.maximumPlaybackCallbackFrames = maximumPlaybackCallbackFrames
+        self.renderDeadlineMisses = renderDeadlineMisses
         self.playbackTimestampDiscontinuities = playbackTimestampDiscontinuities
         self.playbackBufferRenegotiations = playbackBufferRenegotiations
         self.adaptivePlaybackRenderFailures = adaptivePlaybackRenderFailures
@@ -563,6 +566,9 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let totalTimestampJumpIntervalNanoseconds = Atomic<UInt64>(0)
         private let maxCaptureCallbackFrames = Atomic<Int>(0)
         private let maxPlaybackCallbackFrames = Atomic<Int>(0)
+        private let renderDeadlineMisses = Atomic<UInt64>(0)
+        private var previousRenderStartNanoseconds: UInt64?
+        private var previousRenderFrameCount = 0
         private let tapToOutputLatencyObservations = Atomic<UInt64>(0)
         private let minTapToOutputLatencyNanoseconds = Atomic<UInt64>(.max)
         private let maxTapToOutputLatencyNanoseconds = Atomic<UInt64>(0)
@@ -672,6 +678,38 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 ? mainInputFrameCount
                 : rawSystemSoundFrameCount
             let inputFrameCount = min(mainInputFrameCount, systemSoundFrameCount)
+
+            let renderStartNanoseconds = AudioConvertHostTimeToNanos(callbackHostTime)
+            let entryDeadlineMisses = previousRenderStartNanoseconds.map {
+                SystemTapAudioEngine.missedRenderDeadlines(
+                    elapsedNanoseconds: renderStartNanoseconds >= $0
+                        ? renderStartNanoseconds - $0
+                        : 0,
+                    frameCount: previousRenderFrameCount,
+                    sampleRate: sampleRate
+                )
+            } ?? 0
+            previousRenderStartNanoseconds = renderStartNanoseconds
+            previousRenderFrameCount = outputFrameCount
+            defer {
+                let renderEndNanoseconds = AudioConvertHostTimeToNanos(
+                    AudioGetCurrentHostTime()
+                )
+                let executionDeadlineMisses = SystemTapAudioEngine.missedRenderDeadlines(
+                    elapsedNanoseconds: renderEndNanoseconds >= renderStartNanoseconds
+                        ? renderEndNanoseconds - renderStartNanoseconds
+                        : 0,
+                    frameCount: outputFrameCount,
+                    sampleRate: sampleRate
+                )
+                let missedDeadlines = max(entryDeadlineMisses, executionDeadlineMisses)
+                if missedDeadlines > 0 {
+                    renderDeadlineMisses.wrappingAdd(
+                        1,
+                        ordering: .relaxed
+                    )
+                }
+            }
 
             recordTimestampContinuity(
                 inputTime: inputTime,
@@ -865,6 +903,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             totalTimestampJumpIntervalNanoseconds.store(0, ordering: .relaxed)
             maxCaptureCallbackFrames.store(0, ordering: .relaxed)
             maxPlaybackCallbackFrames.store(0, ordering: .relaxed)
+            renderDeadlineMisses.store(0, ordering: .relaxed)
             tapToOutputLatencyObservations.store(0, ordering: .relaxed)
             minTapToOutputLatencyNanoseconds.store(.max, ordering: .relaxed)
             maxTapToOutputLatencyNanoseconds.store(0, ordering: .relaxed)
@@ -935,6 +974,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     : Double(totalJumpInterval) / Double(jumpIntervalObservations),
                 maximumCaptureCallbackFrames: maxCaptureCallbackFrames.load(ordering: .relaxed),
                 maximumPlaybackCallbackFrames: maxPlaybackCallbackFrames.load(ordering: .relaxed),
+                renderDeadlineMisses: renderDeadlineMisses.load(ordering: .relaxed),
                 tapToOutputLatencyObservations: latencyObservations,
                 minimumTapToOutputLatencyNanoseconds: latencyObservations == 0 || minimumLatency == .max
                     ? 0
@@ -3496,6 +3536,23 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             }
             data[destinationIndex] = samples[sourceIndex]
         }
+    }
+
+    static func missedRenderDeadlines(
+        elapsedNanoseconds: UInt64,
+        frameCount: Int,
+        sampleRate: Double
+    ) -> UInt64 {
+        guard frameCount > 0,
+              sampleRate.isFinite,
+              sampleRate > 0 else {
+            return 0
+        }
+        let expectedNanoseconds = UInt64(
+            max((Double(frameCount) * 1_000_000_000 / sampleRate).rounded(), 1)
+        )
+        let elapsedPeriods = elapsedNanoseconds / expectedNanoseconds
+        return elapsedPeriods >= 2 ? elapsedPeriods - 1 : 0
     }
 
     static func preferredBufferFrameSize(for _: AudioOutputDevice) -> UInt32 {

--- a/Sources/GlassEQCore/ProgrammeLoudnessMatcher.swift
+++ b/Sources/GlassEQCore/ProgrammeLoudnessMatcher.swift
@@ -1,0 +1,381 @@
+import Foundation
+
+public extension EQProfile {
+    var programmeComparisonReference: EQProfile {
+        var reference = self
+        reference.filters = []
+        reference.leftFilters = []
+        reference.rightFilters = []
+        reference.isBypassed = false
+        return reference
+    }
+}
+
+public enum EQProgrammeComparisonSelection: UInt8, Codable, Equatable, Sendable {
+    case equalized
+    case filtersOff
+}
+
+public struct EQProgrammeComparisonSnapshot: Codable, Equatable, Sendable {
+    public var isActive: Bool
+    public var isReady: Bool
+    public var selection: EQProgrammeComparisonSelection
+    public var equalizedAttenuationDB: Double
+    public var filtersOffAttenuationDB: Double
+
+    public init(
+        isActive: Bool = false,
+        isReady: Bool = false,
+        selection: EQProgrammeComparisonSelection = .equalized,
+        equalizedAttenuationDB: Double = 0,
+        filtersOffAttenuationDB: Double = 0
+    ) {
+        self.isActive = isActive
+        self.isReady = isReady
+        self.selection = selection
+        self.equalizedAttenuationDB = equalizedAttenuationDB
+        self.filtersOffAttenuationDB = filtersOffAttenuationDB
+    }
+}
+
+struct ProgrammeLoudnessMatch: Equatable, Sendable {
+    var isReady = false
+    var equalizedGain: Float = 1
+    var filtersOffGain: Float = 1
+    var equalizedAttenuationDB = 0.0
+    var filtersOffAttenuationDB = 0.0
+}
+
+struct ProgrammeLoudnessGains: Equatable, Sendable {
+    var equalized: Float = 1
+    var filtersOff: Float = 1
+}
+
+struct RealtimeProgrammeLoudnessMatcher: Sendable {
+    private static let windowSegmentCount = 30
+    private static let gatingBlockSegmentCount = 4
+    private static let minimumGatedBlockCount = 4
+    private static let absoluteGateEnergy = pow(10, (-70.0 + 0.691) / 10)
+    private static let maximumAttenuationDB = -60.0
+
+    private var equalizedWeighting: [KWeightingChannel]
+    private var filtersOffWeighting: [KWeightingChannel]
+    private var equalizedSegmentEnergy = Array(
+        repeating: 0.0,
+        count: Self.windowSegmentCount
+    )
+    private var filtersOffSegmentEnergy = Array(
+        repeating: 0.0,
+        count: Self.windowSegmentCount
+    )
+    private let segmentFrameCount: Int
+    private let gainSmoothingCoefficient: Double
+    private var segmentFrames = 0
+    private var equalizedEnergyAccumulator = 0.0
+    private var filtersOffEnergyAccumulator = 0.0
+    private var segmentWriteIndex = 0
+    private var storedSegmentCount = 0
+    private var targetEqualizedGain = 1.0
+    private var targetFiltersOffGain = 1.0
+    private var currentEqualizedGain = 1.0
+    private var currentFiltersOffGain = 1.0
+    private(set) var isReady = false
+
+    init(
+        sampleRate: Double,
+        channelCount: Int,
+        gainSmoothingSeconds: Double = 0.5
+    ) {
+        let validSampleRate = sampleRate.isFinite && sampleRate > 0
+            ? sampleRate
+            : 48_000
+        let channels = max(channelCount, 1)
+        self.equalizedWeighting = (0..<channels).map { _ in
+            KWeightingChannel(sampleRate: validSampleRate)
+        }
+        self.filtersOffWeighting = (0..<channels).map { _ in
+            KWeightingChannel(sampleRate: validSampleRate)
+        }
+        self.segmentFrameCount = max(Int((validSampleRate * 0.1).rounded()), 1)
+        let smoothingSeconds = gainSmoothingSeconds.isFinite && gainSmoothingSeconds > 0
+            ? gainSmoothingSeconds
+            : 0.5
+        self.gainSmoothingCoefficient = 1 - exp(-1 / (validSampleRate * smoothingSeconds))
+    }
+
+    mutating func reset() {
+        for index in equalizedWeighting.indices {
+            equalizedWeighting[index].reset()
+            filtersOffWeighting[index].reset()
+        }
+        for index in equalizedSegmentEnergy.indices {
+            equalizedSegmentEnergy[index] = 0
+            filtersOffSegmentEnergy[index] = 0
+        }
+        segmentFrames = 0
+        equalizedEnergyAccumulator = 0
+        filtersOffEnergyAccumulator = 0
+        segmentWriteIndex = 0
+        storedSegmentCount = 0
+        targetEqualizedGain = 1
+        targetFiltersOffGain = 1
+        currentEqualizedGain = 1
+        currentFiltersOffGain = 1
+        isReady = false
+    }
+
+    mutating func observeFrame(
+        equalized: UnsafeBufferPointer<Float>,
+        filtersOff: UnsafeBufferPointer<Float>,
+        sampleOffset: Int,
+        channelCount: Int
+    ) -> ProgrammeLoudnessGains {
+        let availableSamples = min(
+            max(equalized.count - sampleOffset, 0),
+            max(filtersOff.count - sampleOffset, 0)
+        )
+        let weightingChannels = min(
+            equalizedWeighting.count,
+            filtersOffWeighting.count
+        )
+        let channels = min(
+            max(channelCount, 1),
+            min(weightingChannels, availableSamples)
+        )
+        if channels > 0 {
+            for channel in 0..<channels {
+                let equalizedSample = equalizedWeighting[channel].process(
+                    equalized[sampleOffset + channel]
+                )
+                let filtersOffSample = filtersOffWeighting[channel].process(
+                    filtersOff[sampleOffset + channel]
+                )
+                equalizedEnergyAccumulator += Double(equalizedSample * equalizedSample)
+                filtersOffEnergyAccumulator += Double(filtersOffSample * filtersOffSample)
+            }
+        }
+
+        segmentFrames += 1
+        if segmentFrames >= segmentFrameCount {
+            finishSegment()
+        }
+        advanceSmoothedGains()
+        return ProgrammeLoudnessGains(
+            equalized: Float(currentEqualizedGain),
+            filtersOff: Float(currentFiltersOffGain)
+        )
+    }
+
+    var snapshot: ProgrammeLoudnessMatch {
+        currentMatch()
+    }
+
+    private mutating func finishSegment() {
+        let divisor = Double(max(segmentFrames, 1))
+        equalizedSegmentEnergy[segmentWriteIndex] = equalizedEnergyAccumulator / divisor
+        filtersOffSegmentEnergy[segmentWriteIndex] = filtersOffEnergyAccumulator / divisor
+        segmentWriteIndex = (segmentWriteIndex + 1) % Self.windowSegmentCount
+        storedSegmentCount = min(storedSegmentCount + 1, Self.windowSegmentCount)
+        segmentFrames = 0
+        equalizedEnergyAccumulator = 0
+        filtersOffEnergyAccumulator = 0
+        updateTargetGains()
+    }
+
+    private mutating func updateTargetGains() {
+        guard storedSegmentCount >= Self.gatingBlockSegmentCount else {
+            return
+        }
+
+        // Gate both branches with the same programme windows. Independent gates could compare
+        // different passages and turn the matcher itself into an A/B bias.
+        var absoluteGatedJointEnergy = 0.0
+        var absoluteGatedBlockCount = 0
+        for blockEnd in (Self.gatingBlockSegmentCount - 1)..<storedSegmentCount {
+            let block = blockEnergy(endingAt: blockEnd)
+            let jointEnergy = max(block.equalized, block.filtersOff)
+            if jointEnergy >= Self.absoluteGateEnergy {
+                absoluteGatedJointEnergy += jointEnergy
+                absoluteGatedBlockCount += 1
+            }
+        }
+        guard absoluteGatedBlockCount > 0 else {
+            return
+        }
+
+        let relativeGate = absoluteGatedJointEnergy
+            / Double(absoluteGatedBlockCount)
+            * 0.1
+        let gate = max(Self.absoluteGateEnergy, relativeGate)
+        var equalizedEnergy = 0.0
+        var filtersOffEnergy = 0.0
+        var gatedBlockCount = 0
+        for blockEnd in (Self.gatingBlockSegmentCount - 1)..<storedSegmentCount {
+            let block = blockEnergy(endingAt: blockEnd)
+            guard max(block.equalized, block.filtersOff) >= gate else {
+                continue
+            }
+            equalizedEnergy += block.equalized
+            filtersOffEnergy += block.filtersOff
+            gatedBlockCount += 1
+        }
+        guard gatedBlockCount >= Self.minimumGatedBlockCount,
+              equalizedEnergy.isFinite,
+              filtersOffEnergy.isFinite,
+              equalizedEnergy > 0,
+              filtersOffEnergy > 0 else {
+            return
+        }
+
+        isReady = true
+        let differenceDB = 10 * log10(equalizedEnergy / filtersOffEnergy)
+        // Never boost the quieter branch: matching by attenuation preserves the profile's
+        // available headroom and cannot manufacture a new clipping path.
+        if differenceDB > 0 {
+            targetEqualizedGain = pow(
+                10,
+                max(-differenceDB, Self.maximumAttenuationDB) / 20
+            )
+            targetFiltersOffGain = 1
+        } else {
+            targetEqualizedGain = 1
+            targetFiltersOffGain = pow(
+                10,
+                max(differenceDB, Self.maximumAttenuationDB) / 20
+            )
+        }
+    }
+
+    private func blockEnergy(endingAt orderedEndIndex: Int) -> (
+        equalized: Double,
+        filtersOff: Double
+    ) {
+        var equalized = 0.0
+        var filtersOff = 0.0
+        let first = orderedEndIndex - Self.gatingBlockSegmentCount + 1
+        for orderedIndex in first...orderedEndIndex {
+            let storageIndex = segmentStorageIndex(forOrderedIndex: orderedIndex)
+            equalized += equalizedSegmentEnergy[storageIndex]
+            filtersOff += filtersOffSegmentEnergy[storageIndex]
+        }
+        let divisor = Double(Self.gatingBlockSegmentCount)
+        return (equalized / divisor, filtersOff / divisor)
+    }
+
+    private func segmentStorageIndex(forOrderedIndex orderedIndex: Int) -> Int {
+        let oldest = (segmentWriteIndex - storedSegmentCount + Self.windowSegmentCount)
+            % Self.windowSegmentCount
+        return (oldest + orderedIndex) % Self.windowSegmentCount
+    }
+
+    private mutating func advanceSmoothedGains() {
+        currentEqualizedGain += (
+            targetEqualizedGain - currentEqualizedGain
+        ) * gainSmoothingCoefficient
+        currentFiltersOffGain += (
+            targetFiltersOffGain - currentFiltersOffGain
+        ) * gainSmoothingCoefficient
+    }
+
+    private func currentMatch() -> ProgrammeLoudnessMatch {
+        ProgrammeLoudnessMatch(
+            isReady: isReady,
+            equalizedGain: Float(currentEqualizedGain),
+            filtersOffGain: Float(currentFiltersOffGain),
+            equalizedAttenuationDB: 20 * log10(max(currentEqualizedGain, .leastNonzeroMagnitude)),
+            filtersOffAttenuationDB: 20 * log10(max(currentFiltersOffGain, .leastNonzeroMagnitude))
+        )
+    }
+}
+
+private struct KWeightingChannel: Sendable {
+    private var shelf: KWeightingBiquad
+    private var highPass: KWeightingBiquad
+
+    init(sampleRate: Double) {
+        self.shelf = KWeightingBiquad(coefficients: .kWeightingShelf(sampleRate: sampleRate))
+        self.highPass = KWeightingBiquad(coefficients: .kWeightingHighPass(sampleRate: sampleRate))
+    }
+
+    mutating func process(_ sample: Float) -> Float {
+        highPass.process(shelf.process(sample))
+    }
+
+    mutating func reset() {
+        shelf.reset()
+        highPass.reset()
+    }
+}
+
+private struct KWeightingBiquad: Sendable {
+    private let coefficients: KWeightingCoefficients
+    private var z1: Float = 0
+    private var z2: Float = 0
+
+    init(coefficients: KWeightingCoefficients) {
+        self.coefficients = coefficients
+    }
+
+    mutating func process(_ input: Float) -> Float {
+        guard input.isFinite else {
+            z1 = 0
+            z2 = 0
+            return 0
+        }
+        let output = coefficients.b0 * input + z1
+        let nextZ1 = coefficients.b1 * input - coefficients.a1 * output + z2
+        let nextZ2 = coefficients.b2 * input - coefficients.a2 * output
+        guard output.isFinite, nextZ1.isFinite, nextZ2.isFinite else {
+            z1 = 0
+            z2 = 0
+            return 0
+        }
+        z1 = nextZ1
+        z2 = nextZ2
+        return output
+    }
+
+    mutating func reset() {
+        z1 = 0
+        z2 = 0
+    }
+}
+
+struct KWeightingCoefficients: Sendable {
+    var b0: Float
+    var b1: Float
+    var b2: Float
+    var a1: Float
+    var a2: Float
+
+    static func kWeightingShelf(sampleRate: Double) -> Self {
+        let frequency = 1_681.974_450_955_533
+        let gainDB = 3.999_843_853_973_347
+        let q = 0.707_175_236_955_419_6
+        let k = tan(.pi * frequency / sampleRate)
+        let highGain = pow(10, gainDB / 20)
+        let bandGain = pow(highGain, 0.499_666_774_154_541_6)
+        let denominator = 1 + k / q + k * k
+        return Self(
+            b0: Float((highGain + bandGain * k / q + k * k) / denominator),
+            b1: Float(2 * (k * k - highGain) / denominator),
+            b2: Float((highGain - bandGain * k / q + k * k) / denominator),
+            a1: Float(2 * (k * k - 1) / denominator),
+            a2: Float((1 - k / q + k * k) / denominator)
+        )
+    }
+
+    static func kWeightingHighPass(sampleRate: Double) -> Self {
+        let frequency = 38.135_470_876_024_44
+        let q = 0.500_327_037_323_877_3
+        let k = tan(.pi * frequency / sampleRate)
+        let denominator = 1 + k / q + k * k
+        return Self(
+            b0: 1,
+            b1: -2,
+            b2: 1,
+            a1: Float(2 * (k * k - 1) / denominator),
+            a2: Float((1 - k / q + k * k) / denominator)
+        )
+    }
+}

--- a/Sources/GlassEQCore/RealtimeEQTransition.swift
+++ b/Sources/GlassEQCore/RealtimeEQTransition.swift
@@ -2,21 +2,27 @@ public struct EQTransitionRenderResult: Sendable {
     public var saturatedSamples: UInt64
     public var completedTransition: Bool
     public var retiredProcessor: EQProcessor?
+    public var secondRetiredProcessor: EQProcessor?
     public var blendStartFrame: Int?
     public var blendFrameCount: Int
+    public var programmeComparison: EQProgrammeComparisonSnapshot
 
     public init(
         saturatedSamples: UInt64 = 0,
         completedTransition: Bool = false,
         retiredProcessor: EQProcessor? = nil,
+        secondRetiredProcessor: EQProcessor? = nil,
         blendStartFrame: Int? = nil,
-        blendFrameCount: Int = 0
+        blendFrameCount: Int = 0,
+        programmeComparison: EQProgrammeComparisonSnapshot = EQProgrammeComparisonSnapshot()
     ) {
         self.saturatedSamples = saturatedSamples
         self.completedTransition = completedTransition
         self.retiredProcessor = retiredProcessor
+        self.secondRetiredProcessor = secondRetiredProcessor
         self.blendStartFrame = blendStartFrame
         self.blendFrameCount = blendFrameCount
+        self.programmeComparison = programmeComparison
     }
 
     @inline(__always)
@@ -32,8 +38,14 @@ public struct EQTransitionRenderResult: Sendable {
             max(blendStartFrame + max(frameOffset, 0), 0),
             blendFrameCount - 1
         )
-        let linearProgress = Float(transitionFrame) / Float(blendFrameCount - 1)
-        return linearProgress * linearProgress * (3 - 2 * linearProgress)
+        return Self.smoothstep(
+            Float(transitionFrame) / Float(blendFrameCount - 1)
+        )
+    }
+
+    @inline(__always)
+    static func smoothstep(_ progress: Float) -> Float {
+        progress * progress * (3 - 2 * progress)
     }
 }
 
@@ -43,12 +55,24 @@ public struct RealtimeEQTransition: Sendable {
 
     private var activeProcessor: EQProcessor
     private var incomingProcessor: EQProcessor?
+    private var pendingComparisonReferenceProcessor: EQProcessor?
+    private var comparisonReferenceProcessor: EQProcessor?
+    private var retiredComparisonProcessor: EQProcessor?
     private var alternateSamples: [Float]
     private let channelCount: Int
     private let warmupFrameCount: Int
     private let blendFrameCount: Int
     private var warmupFramesRemaining = 0
     private var blendedFrames = 0
+    private var comparisonWarmupFramesRemaining = 0
+    private var comparisonSelection = EQProgrammeComparisonSelection.equalized
+    private var comparisonSelectionStartWeight: Float = 0
+    private var comparisonSelectionWeight: Float = 0
+    private var comparisonSelectionBlendedFrames = 0
+    private var comparisonExitRequested = false
+    private var comparisonExitGainStart: Float?
+    private var comparisonExitGainBlendedFrames = 0
+    private var programmeLoudnessMatcher: RealtimeProgrammeLoudnessMatcher
 
     public init(
         activeProcessor: EQProcessor,
@@ -73,10 +97,18 @@ public struct RealtimeEQTransition: Sendable {
         )
         self.warmupFrameCount = max(Int((validSampleRate * validWarmup).rounded()), 0)
         self.blendFrameCount = max(Int((validSampleRate * validBlend).rounded()), 1)
+        self.programmeLoudnessMatcher = RealtimeProgrammeLoudnessMatcher(
+            sampleRate: validSampleRate,
+            channelCount: self.channelCount
+        )
     }
 
     public var isTransitioning: Bool {
-        incomingProcessor != nil
+        incomingProcessor != nil || pendingComparisonReferenceProcessor != nil
+    }
+
+    public var isProgrammeComparisonActive: Bool {
+        pendingComparisonReferenceProcessor != nil || comparisonReferenceProcessor != nil
     }
 
     public var activeConfiguration: EQConfiguration {
@@ -91,9 +123,60 @@ public struct RealtimeEQTransition: Sendable {
             return false
         }
         incomingProcessor = processor
-        warmupFramesRemaining = warmupFrameCount
-        blendedFrames = 0
+        if comparisonReferenceProcessor != nil {
+            comparisonExitRequested = true
+            setProgrammeComparisonSelection(.equalized)
+        } else {
+            beginStandardTransition()
+        }
         return true
+    }
+
+    @discardableResult
+    public mutating func beginProgrammeComparison(
+        equalizedProcessor: EQProcessor,
+        filtersOffProcessor: EQProcessor
+    ) -> Bool {
+        guard incomingProcessor == nil,
+              comparisonReferenceProcessor == nil,
+              pendingComparisonReferenceProcessor == nil,
+              equalizedProcessor.configuration.sampleRate == activeProcessor.configuration.sampleRate,
+              filtersOffProcessor.configuration.sampleRate == activeProcessor.configuration.sampleRate,
+              equalizedProcessor.configuration.channelCount == activeProcessor.configuration.channelCount,
+              filtersOffProcessor.configuration.channelCount == activeProcessor.configuration.channelCount else {
+            return false
+        }
+        incomingProcessor = equalizedProcessor
+        pendingComparisonReferenceProcessor = filtersOffProcessor
+        beginStandardTransition()
+        return true
+    }
+
+    public mutating func setProgrammeComparisonSelection(
+        _ selection: EQProgrammeComparisonSelection
+    ) {
+        guard selection != comparisonSelection else {
+            return
+        }
+        comparisonSelection = selection
+        comparisonSelectionStartWeight = comparisonSelectionWeight
+        comparisonSelectionBlendedFrames = 0
+    }
+
+    public var programmeComparisonSnapshot: EQProgrammeComparisonSnapshot {
+        guard isProgrammeComparisonActive else {
+            return EQProgrammeComparisonSnapshot()
+        }
+        let match = programmeLoudnessMatcher.snapshot
+        return EQProgrammeComparisonSnapshot(
+            isActive: isProgrammeComparisonActive,
+            isReady: comparisonReferenceProcessor != nil
+                && comparisonWarmupFramesRemaining == 0
+                && match.isReady,
+            selection: comparisonSelection,
+            equalizedAttenuationDB: match.equalizedAttenuationDB,
+            filtersOffAttenuationDB: match.filtersOffAttenuationDB
+        )
     }
 
     public mutating func processInterleavedWithDiagnostics(
@@ -104,50 +187,78 @@ public struct RealtimeEQTransition: Sendable {
         let channels = max(channelCount, 1)
         let availableFrames = min(max(frameCount, 0), samples.count / channels)
         guard availableFrames > 0 else {
-            return EQTransitionRenderResult()
+            return EQTransitionRenderResult(programmeComparison: programmeComparisonSnapshot)
         }
         guard channels == self.channelCount,
-              incomingProcessor != nil,
               availableFrames * channels <= alternateSamples.count else {
             let saturated = activeProcessor.processInterleavedWithDiagnostics(
                 samples,
                 frameCount: availableFrames,
                 channelCount: channels
             )
-            return EQTransitionRenderResult(saturatedSamples: saturated)
+            return EQTransitionRenderResult(
+                saturatedSamples: saturated,
+                programmeComparison: programmeComparisonSnapshot
+            )
         }
 
-        let sampleCount = availableFrames * channels
-        return alternateSamples.withUnsafeMutableBufferPointer { alternateStorage in
-            let alternate = UnsafeMutableBufferPointer(
-                start: alternateStorage.baseAddress,
-                count: sampleCount
-            )
-            for index in 0..<sampleCount {
-                alternate[index] = samples[index]
-            }
-
-            let activeDiagnostics = activeProcessor.processInterleavedLinearlyWithDiagnostics(
+        if comparisonReferenceProcessor != nil {
+            return processProgrammeComparison(
                 samples,
                 frameCount: availableFrames,
                 channelCount: channels
             )
-            let incomingDiagnostics = self.incomingProcessor!.processInterleavedLinearlyWithDiagnostics(
-                alternate,
+        }
+        if incomingProcessor != nil {
+            return processStandardTransition(
+                samples,
                 frameCount: availableFrames,
                 channelCount: channels
             )
+        }
+
+        let saturated = activeProcessor.processInterleavedWithDiagnostics(
+            samples,
+            frameCount: availableFrames,
+            channelCount: channels
+        )
+        return EQTransitionRenderResult(
+            saturatedSamples: saturated,
+            programmeComparison: programmeComparisonSnapshot
+        )
+    }
+
+    private mutating func processStandardTransition(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> EQTransitionRenderResult {
+        let sampleCount = frameCount * channelCount
+        var result = alternateSamples.withUnsafeMutableBufferPointer { alternateStorage in
+            let alternate = UnsafeMutableBufferPointer(
+                start: alternateStorage.baseAddress,
+                count: sampleCount
+            )
+            Self.copy(samples, into: alternate, sampleCount: sampleCount)
+
+            let activeDiagnostics = activeProcessor.processInterleavedLinearlyWithDiagnostics(
+                samples,
+                frameCount: frameCount,
+                channelCount: channelCount
+            )
+            let incomingDiagnostics = incomingProcessor!.processInterleavedLinearlyWithDiagnostics(
+                alternate,
+                frameCount: frameCount,
+                channelCount: channelCount
+            )
 
             if warmupFramesRemaining > 0 {
-                warmupFramesRemaining = max(warmupFramesRemaining - availableFrames, 0)
-                let saturated = activeDiagnostics.nonFiniteSamples
-                    &+ incomingDiagnostics.nonFiniteSamples
-                    &+ EQProcessor.protectInterleavedWithDiagnostics(
-                        samples,
-                        frameCount: availableFrames,
-                        channelCount: channels
-                    )
-                return EQTransitionRenderResult(saturatedSamples: saturated)
+                warmupFramesRemaining = max(warmupFramesRemaining - frameCount, 0)
+                return EQTransitionRenderResult(
+                    saturatedSamples: activeDiagnostics.nonFiniteSamples
+                        &+ incomingDiagnostics.nonFiniteSamples
+                        &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
+                )
             }
 
             let renderedBlendStartFrame = blendedFrames
@@ -156,43 +267,250 @@ public struct RealtimeEQTransition: Sendable {
                 blendFrameCount: blendFrameCount
             )
             var sampleIndex = 0
-            for frame in 0..<availableFrames {
+            for frame in 0..<frameCount {
                 let incomingWeight = blendWindow.incomingBlendWeight(frameOffset: frame)
-                for channel in 0..<channels {
+                for channel in 0..<channelCount {
                     let oldSample = samples[sampleIndex + channel]
                     samples[sampleIndex + channel] = oldSample
                         + (alternate[sampleIndex + channel] - oldSample) * incomingWeight
                 }
-                sampleIndex += channels
+                sampleIndex += channelCount
             }
-            blendedFrames += availableFrames
+            blendedFrames += frameCount
             let saturated = activeDiagnostics.nonFiniteSamples
                 &+ incomingDiagnostics.nonFiniteSamples
-                &+ EQProcessor.protectInterleavedWithDiagnostics(
-                    samples,
-                    frameCount: availableFrames,
-                    channelCount: channels
-                )
+                &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
 
             guard blendedFrames >= blendFrameCount,
-                  let completedProcessor = self.incomingProcessor else {
+                  let completedProcessor = incomingProcessor else {
                 return EQTransitionRenderResult(
                     saturatedSamples: saturated,
                     blendStartFrame: renderedBlendStartFrame,
                     blendFrameCount: blendFrameCount
                 )
             }
+
             let retiredProcessor = activeProcessor
             activeProcessor = completedProcessor
-            self.incomingProcessor = nil
+            incomingProcessor = nil
             blendedFrames = 0
+            if let referenceProcessor = pendingComparisonReferenceProcessor {
+                pendingComparisonReferenceProcessor = nil
+                comparisonReferenceProcessor = referenceProcessor
+                comparisonWarmupFramesRemaining = warmupFrameCount
+                comparisonSelection = .equalized
+                comparisonSelectionStartWeight = 0
+                comparisonSelectionWeight = 0
+                comparisonSelectionBlendedFrames = blendFrameCount
+                comparisonExitRequested = false
+                comparisonExitGainStart = nil
+                comparisonExitGainBlendedFrames = 0
+                programmeLoudnessMatcher.reset()
+            }
+            let secondRetiredProcessor = retiredComparisonProcessor
+            retiredComparisonProcessor = nil
             return EQTransitionRenderResult(
                 saturatedSamples: saturated,
                 completedTransition: true,
                 retiredProcessor: retiredProcessor,
+                secondRetiredProcessor: secondRetiredProcessor,
                 blendStartFrame: renderedBlendStartFrame,
                 blendFrameCount: blendFrameCount
             )
         }
+        result.programmeComparison = programmeComparisonSnapshot
+        return result
+    }
+
+    private mutating func processProgrammeComparison(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> EQTransitionRenderResult {
+        if let gainStart = comparisonExitGainStart {
+            return processComparisonGainRestore(
+                samples,
+                frameCount: frameCount,
+                channelCount: channelCount,
+                gainStart: gainStart
+            )
+        }
+
+        let sampleCount = frameCount * channelCount
+        var shouldFinishComparison = false
+        var result = alternateSamples.withUnsafeMutableBufferPointer { alternateStorage in
+            let alternate = UnsafeMutableBufferPointer(
+                start: alternateStorage.baseAddress,
+                count: sampleCount
+            )
+            Self.copy(samples, into: alternate, sampleCount: sampleCount)
+            let equalizedDiagnostics = activeProcessor.processInterleavedLinearlyWithDiagnostics(
+                samples,
+                frameCount: frameCount,
+                channelCount: channelCount
+            )
+            let filtersOffDiagnostics = comparisonReferenceProcessor!
+                .processInterleavedLinearlyWithDiagnostics(
+                    alternate,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+
+            if comparisonWarmupFramesRemaining > 0 {
+                comparisonWarmupFramesRemaining = max(
+                    comparisonWarmupFramesRemaining - frameCount,
+                    0
+                )
+                if comparisonExitRequested {
+                    shouldFinishComparison = true
+                }
+                return EQTransitionRenderResult(
+                    saturatedSamples: equalizedDiagnostics.nonFiniteSamples
+                        &+ filtersOffDiagnostics.nonFiniteSamples
+                        &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
+                )
+            }
+
+            let equalized = UnsafeBufferPointer(samples)
+            let filtersOff = UnsafeBufferPointer(alternate)
+            var sampleIndex = 0
+            for _ in 0..<frameCount {
+                let match = programmeLoudnessMatcher.observeFrame(
+                    equalized: equalized,
+                    filtersOff: filtersOff,
+                    sampleOffset: sampleIndex,
+                    channelCount: channelCount
+                )
+                let selectionTarget: Float = comparisonSelection == .filtersOff ? 1 : 0
+                let filtersOffWeight: Float
+                if comparisonSelectionBlendedFrames >= blendFrameCount {
+                    comparisonSelectionWeight = selectionTarget
+                    filtersOffWeight = selectionTarget
+                } else {
+                    let progress = blendFrameCount == 1
+                        ? 1
+                        : EQTransitionRenderResult.smoothstep(
+                            Float(comparisonSelectionBlendedFrames)
+                                / Float(blendFrameCount - 1)
+                        )
+                    comparisonSelectionWeight = comparisonSelectionStartWeight
+                        + (selectionTarget - comparisonSelectionStartWeight) * progress
+                    comparisonSelectionBlendedFrames += 1
+                    if comparisonSelectionBlendedFrames >= blendFrameCount {
+                        comparisonSelectionWeight = selectionTarget
+                    }
+                    filtersOffWeight = comparisonSelectionWeight
+                }
+                for channel in 0..<channelCount {
+                    let equalizedSample = samples[sampleIndex + channel] * match.equalized
+                    let filtersOffSample = alternate[sampleIndex + channel] * match.filtersOff
+                    samples[sampleIndex + channel] = equalizedSample
+                        + (filtersOffSample - equalizedSample) * filtersOffWeight
+                }
+                sampleIndex += channelCount
+            }
+
+            if comparisonExitRequested,
+               comparisonSelection == .equalized,
+               comparisonSelectionBlendedFrames >= blendFrameCount {
+                let gain = programmeLoudnessMatcher.snapshot.equalizedGain
+                if abs(gain - 1) < 0.000_001 {
+                    shouldFinishComparison = true
+                } else {
+                    comparisonExitGainStart = gain
+                    comparisonExitGainBlendedFrames = 0
+                }
+            }
+            return EQTransitionRenderResult(
+                saturatedSamples: equalizedDiagnostics.nonFiniteSamples
+                    &+ filtersOffDiagnostics.nonFiniteSamples
+                    &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
+            )
+        }
+        if shouldFinishComparison {
+            finishProgrammeComparison()
+        }
+        result.programmeComparison = programmeComparisonSnapshot
+        return result
+    }
+
+    private mutating func processComparisonGainRestore(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int,
+        gainStart: Float
+    ) -> EQTransitionRenderResult {
+        let diagnostics = activeProcessor.processInterleavedLinearlyWithDiagnostics(
+            samples,
+            frameCount: frameCount,
+            channelCount: channelCount
+        )
+        var sampleIndex = 0
+        for frame in 0..<frameCount {
+            let transitionFrame = min(
+                comparisonExitGainBlendedFrames + frame,
+                blendFrameCount - 1
+            )
+            let progress = blendFrameCount == 1
+                ? 1
+                : EQTransitionRenderResult.smoothstep(
+                    Float(transitionFrame) / Float(blendFrameCount - 1)
+                )
+            let gain = gainStart + (1 - gainStart) * progress
+            for channel in 0..<channelCount {
+                samples[sampleIndex + channel] *= gain
+            }
+            sampleIndex += channelCount
+        }
+        comparisonExitGainBlendedFrames += frameCount
+        if comparisonExitGainBlendedFrames >= blendFrameCount {
+            finishProgrammeComparison()
+        }
+        return EQTransitionRenderResult(
+            saturatedSamples: diagnostics.nonFiniteSamples
+                &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount),
+            programmeComparison: programmeComparisonSnapshot
+        )
+    }
+
+    private mutating func finishProgrammeComparison() {
+        retiredComparisonProcessor = comparisonReferenceProcessor
+        comparisonReferenceProcessor = nil
+        comparisonWarmupFramesRemaining = 0
+        comparisonExitRequested = false
+        comparisonExitGainStart = nil
+        comparisonExitGainBlendedFrames = 0
+        comparisonSelection = .equalized
+        comparisonSelectionStartWeight = 0
+        comparisonSelectionWeight = 0
+        comparisonSelectionBlendedFrames = blendFrameCount
+        beginStandardTransition()
+    }
+
+    private mutating func beginStandardTransition() {
+        warmupFramesRemaining = warmupFrameCount
+        blendedFrames = 0
+    }
+
+    private static func copy(
+        _ source: UnsafeMutableBufferPointer<Float>,
+        into destination: UnsafeMutableBufferPointer<Float>,
+        sampleCount: Int
+    ) {
+        for index in 0..<sampleCount {
+            destination[index] = source[index]
+        }
+    }
+
+    private static func protect(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> UInt64 {
+        EQProcessor.protectInterleavedWithDiagnostics(
+            samples,
+            frameCount: frameCount,
+            channelCount: channelCount
+        )
     }
 }

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -353,6 +353,7 @@ private func printMetrics(_ metrics: AudioEngineMetrics, sampleRate: Double) {
     }
     print("Max capture callback frames: \(metrics.maximumCaptureCallbackFrames)")
     print("Max playback callback frames: \(metrics.maximumPlaybackCallbackFrames)")
+    print("Render deadline misses: \(metrics.renderDeadlineMisses)")
     if metrics.tapToOutputLatencyObservations > 0 {
         print(String(
             format: "Tap-to-output latency: %.3f ms average, %.3f to %.3f ms",

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -305,6 +305,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
     public var statusMessage: String?
     public var isRunning: Bool?
     public var isPreviewing: Bool?
+    public var programmeComparison: EQProgrammeComparisonSnapshot?
     public var selectedProfileID: UUID?
     public var draftProfile: EQProfile?
     public var activeProfileID: UUID?
@@ -319,6 +320,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
         statusMessage: String? = nil,
         isRunning: Bool? = nil,
         isPreviewing: Bool? = nil,
+        programmeComparison: EQProgrammeComparisonSnapshot? = nil,
         selectedProfileID: UUID? = nil,
         draftProfile: EQProfile? = nil,
         activeProfileID: UUID? = nil,
@@ -332,6 +334,7 @@ public struct SettingsSnapshotPatchDTO: Codable, Equatable, Sendable {
         self.statusMessage = statusMessage
         self.isRunning = isRunning
         self.isPreviewing = isPreviewing
+        self.programmeComparison = programmeComparison
         self.selectedProfileID = selectedProfileID
         self.draftProfile = draftProfile
         self.activeProfileID = activeProfileID
@@ -362,6 +365,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
     public var metrics: SettingsAudioMetricsDTO
     public var isRunning: Bool
     public var isPreviewing: Bool
+    public var programmeComparison: EQProgrammeComparisonSnapshot
     public var profileStoreProtection: SettingsProfileStoreProtectionDTO
 
     private enum CodingKeys: String, CodingKey {
@@ -382,6 +386,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         case metrics
         case isRunning
         case isPreviewing
+        case programmeComparison
         case profileStoreProtection
     }
 
@@ -403,6 +408,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         metrics: SettingsAudioMetricsDTO,
         isRunning: Bool,
         isPreviewing: Bool,
+        programmeComparison: EQProgrammeComparisonSnapshot = EQProgrammeComparisonSnapshot(),
         profileStoreProtection: SettingsProfileStoreProtectionDTO = .unprotected
     ) {
         self.profiles = profiles
@@ -422,6 +428,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
         self.metrics = metrics
         self.isRunning = isRunning
         self.isPreviewing = isPreviewing
+        self.programmeComparison = programmeComparison
         self.profileStoreProtection = profileStoreProtection
     }
 
@@ -448,6 +455,10 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
             metrics: try container.decode(SettingsAudioMetricsDTO.self, forKey: .metrics),
             isRunning: try container.decodeIfPresent(Bool.self, forKey: .isRunning) ?? false,
             isPreviewing: try container.decode(Bool.self, forKey: .isPreviewing),
+            programmeComparison: try container.decodeIfPresent(
+                EQProgrammeComparisonSnapshot.self,
+                forKey: .programmeComparison
+            ) ?? EQProgrammeComparisonSnapshot(),
             profileStoreProtection: try container.decode(
                 SettingsProfileStoreProtectionDTO.self,
                 forKey: .profileStoreProtection
@@ -475,6 +486,7 @@ public struct SettingsSnapshotDTO: Codable, Equatable, Sendable {
             metrics: SettingsAudioMetricsDTO(),
             isRunning: false,
             isPreviewing: false,
+            programmeComparison: EQProgrammeComparisonSnapshot(),
             profileStoreProtection: .unprotected
         )
     }
@@ -490,6 +502,9 @@ public enum SettingsCommand: Codable, Equatable, Sendable {
     case importProfile(format: SettingsImportFormat, name: String, text: String)
     case preview(EQProfile)
     case stopPreview
+    case startProgrammeComparison(EQProfile)
+    case selectProgrammeComparison(EQProgrammeComparisonSelection)
+    case stopProgrammeComparison
     case resetDiagnostics
     case setAggregateBufferMode(SettingsAggregateBufferMode)
     case retryAutomaticAggregateBuffer

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -112,6 +112,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var outputTimestampDiscontinuities: UInt64
     public var maximumCaptureCallbackFrames: Int
     public var maximumPlaybackCallbackFrames: Int
+    public var renderDeadlineMisses: UInt64
     public var playbackTimestampDiscontinuities: UInt64
     public var playbackBufferRenegotiations: UInt64
     public var adaptivePlaybackRenderFailures: UInt64
@@ -144,6 +145,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case outputTimestampDiscontinuities
         case maximumCaptureCallbackFrames
         case maximumPlaybackCallbackFrames
+        case renderDeadlineMisses
         case playbackTimestampDiscontinuities
         case playbackBufferRenegotiations
         case adaptivePlaybackRenderFailures
@@ -177,6 +179,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         outputTimestampDiscontinuities: UInt64 = 0,
         maximumCaptureCallbackFrames: Int = 0,
         maximumPlaybackCallbackFrames: Int = 0,
+        renderDeadlineMisses: UInt64 = 0,
         playbackTimestampDiscontinuities: UInt64 = 0,
         playbackBufferRenegotiations: UInt64 = 0,
         adaptivePlaybackRenderFailures: UInt64 = 0,
@@ -208,6 +211,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.outputTimestampDiscontinuities = outputTimestampDiscontinuities
         self.maximumCaptureCallbackFrames = maximumCaptureCallbackFrames
         self.maximumPlaybackCallbackFrames = maximumPlaybackCallbackFrames
+        self.renderDeadlineMisses = renderDeadlineMisses
         self.playbackTimestampDiscontinuities = playbackTimestampDiscontinuities
         self.playbackBufferRenegotiations = playbackBufferRenegotiations
         self.adaptivePlaybackRenderFailures = adaptivePlaybackRenderFailures
@@ -243,6 +247,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             outputTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .outputTimestampDiscontinuities) ?? 0,
             maximumCaptureCallbackFrames: try container.decodeIfPresent(Int.self, forKey: .maximumCaptureCallbackFrames) ?? 0,
             maximumPlaybackCallbackFrames: try container.decodeIfPresent(Int.self, forKey: .maximumPlaybackCallbackFrames) ?? 0,
+            renderDeadlineMisses: try container.decodeIfPresent(UInt64.self, forKey: .renderDeadlineMisses) ?? 0,
             playbackTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .playbackTimestampDiscontinuities) ?? 0,
             playbackBufferRenegotiations: try container.decodeIfPresent(UInt64.self, forKey: .playbackBufferRenegotiations) ?? 0,
             adaptivePlaybackRenderFailures: try container.decodeIfPresent(UInt64.self, forKey: .adaptivePlaybackRenderFailures) ?? 0,

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -182,6 +182,7 @@ func settingsCanDeleteSelectedProfile(_ snapshot: SettingsSnapshot) -> Bool {
     !snapshot.profileStoreProtection.isProtected
         && snapshot.profiles.count > 1
         && !snapshot.isPreviewing
+        && !snapshot.programmeComparison.isActive
         && snapshot.selectedProfileID != snapshot.activeProfileID
 }
 
@@ -271,7 +272,7 @@ public struct SettingsView: View {
                 onDuplicate: duplicateSelectedProfile,
                 onDelete: deleteSelectedProfile,
                 canDeleteSelectedProfile: canDeleteSelectedProfile,
-                isReadOnly: isProfileStoreProtected
+                isReadOnly: isProfileStoreProtected || snapshot.programmeComparison.isActive
             )
                 .frame(width: 260)
 
@@ -288,6 +289,9 @@ public struct SettingsView: View {
                 onImport: importProfile,
                 onPreview: previewDraft,
                 onStopPreview: stopPreview,
+                onStartProgrammeComparison: startProgrammeComparison,
+                onSelectProgrammeComparison: selectProgrammeComparison,
+                onStopProgrammeComparison: stopProgrammeComparison,
                 onResetDiagnostics: resetDiagnostics,
                 onSetAggregateBufferMode: setAggregateBufferMode,
                 onRetryAutomaticAggregateBuffer: retryAutomaticAggregateBuffer,
@@ -397,6 +401,20 @@ public struct SettingsView: View {
 
     private func stopPreview() {
         perform(.stopPreview)
+    }
+
+    private func startProgrammeComparison() {
+        perform(.startProgrammeComparison(snapshot.draftProfile))
+    }
+
+    private func selectProgrammeComparison(
+        _ selection: EQProgrammeComparisonSelection
+    ) {
+        perform(.selectProgrammeComparison(selection))
+    }
+
+    private func stopProgrammeComparison() {
+        perform(.stopProgrammeComparison)
     }
 
     private func resetDiagnostics() {
@@ -971,6 +989,9 @@ private struct ProfileDetail: View {
     var onImport: (ImportFormat, String, String) async -> Bool
     var onPreview: () -> Void
     var onStopPreview: () -> Void
+    var onStartProgrammeComparison: () -> Void
+    var onSelectProgrammeComparison: (EQProgrammeComparisonSelection) -> Void
+    var onStopProgrammeComparison: () -> Void
     var onResetDiagnostics: () -> Void
     var onSetAggregateBufferMode: (SettingsAggregateBufferMode) -> Void
     var onRetryAutomaticAggregateBuffer: () -> Void
@@ -986,6 +1007,7 @@ private struct ProfileDetail: View {
                     draftProfile: $draftProfile,
                     tab: $tab,
                     isReadOnly: isProfileStoreProtected
+                        || snapshot.programmeComparison.isActive
                 )
             }
 
@@ -1009,7 +1031,10 @@ private struct ProfileDetail: View {
                                 sampleRate: snapshot.currentOutputSampleRate,
                                 draftEditGeneration: draftEditGeneration
                             )
-                            .disabled(isProfileStoreProtected)
+                            .disabled(
+                                isProfileStoreProtected
+                                    || snapshot.programmeComparison.isActive
+                            )
                         case .importer:
                             ImportTab(
                                 profile: draftProfile,
@@ -1047,11 +1072,16 @@ private struct ProfileDetail: View {
                         hasUnsavedDraft: hasUnsavedDraft,
                         currentOutputUID: snapshot.currentOutputUID,
                         isPreviewing: snapshot.isPreviewing,
+                        isRunning: snapshot.isRunning,
+                        programmeComparison: snapshot.programmeComparison,
                         isReadOnly: isProfileStoreProtected,
                         onApply: onApply,
                         onRevert: onRevert,
                         onPreview: onPreview,
                         onStopPreview: onStopPreview,
+                        onStartProgrammeComparison: onStartProgrammeComparison,
+                        onSelectProgrammeComparison: onSelectProgrammeComparison,
+                        onStopProgrammeComparison: onStopProgrammeComparison,
                         onUseForCurrentOutput: onUseForCurrentOutput
                     )
                     .cardPanel(padding: 16)
@@ -1519,48 +1549,123 @@ private struct ApplyBar: View {
     var hasUnsavedDraft: Bool
     var currentOutputUID: String
     var isPreviewing: Bool
+    var isRunning: Bool
+    var programmeComparison: EQProgrammeComparisonSnapshot
     var isReadOnly: Bool
     var onApply: () -> Void
     var onRevert: () -> Void
     var onPreview: () -> Void
     var onStopPreview: () -> Void
+    var onStartProgrammeComparison: () -> Void
+    var onSelectProgrammeComparison: (EQProgrammeComparisonSelection) -> Void
+    var onStopProgrammeComparison: () -> Void
     var onUseForCurrentOutput: () -> Void
 
     var body: some View {
-        HStack {
-            Text(hasUnsavedDraft ? localized("Unsaved changes") : localized("All changes saved"))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .accessibilityLabel(Text(localized("Profile edit state")))
-                .accessibilityValue(Text(hasUnsavedDraft ? localized("Unsaved changes") : localized("All changes saved")))
-            Spacer()
-            Button(localized("Revert")) {
-                onRevert()
-            }
-            .disabled(!hasUnsavedDraft)
-            .buttonStyle(ToolbarButtonStyle())
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(localized("Programme-loudness A/B"))
+                        .font(.caption.weight(.semibold))
+                    Text(comparisonDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if programmeComparison.isActive {
+                    Picker(
+                        localized("A/B branch"),
+                        selection: Binding(
+                            get: { programmeComparison.selection },
+                            set: { selection in
+                                onSelectProgrammeComparison(selection)
+                            }
+                        )
+                    ) {
+                        Text(localized("A · EQ"))
+                            .tag(EQProgrammeComparisonSelection.equalized)
+                        Text(localized("B · Filters off"))
+                            .tag(EQProgrammeComparisonSelection.filtersOff)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .frame(width: 210)
 
-            Button(localized("Apply")) {
-                onApply()
+                    Button(localized("Stop A/B")) {
+                        onStopProgrammeComparison()
+                    }
+                    .buttonStyle(ToolbarButtonStyle())
+                } else {
+                    Button(localized("Start A/B")) {
+                        onStartProgrammeComparison()
+                    }
+                    .disabled(isReadOnly || isPreviewing || !isRunning)
+                    .buttonStyle(ToolbarButtonStyle())
+                    .help(localized("Compares the draft EQ with its filters disabled while preserving the same preamp."))
+                }
             }
-            .keyboardShortcut(.return, modifiers: .command)
-            .disabled(isReadOnly || !hasUnsavedDraft)
-            .buttonStyle(ToolbarButtonStyle(prominent: true))
 
-            Button(isPreviewing ? localized("Stop Preview") : localized("Preview")) {
-                isPreviewing ? onStopPreview() : onPreview()
-            }
-            .disabled(isReadOnly && !isPreviewing)
-            .buttonStyle(ToolbarButtonStyle())
-            .accessibilityValue(Text(isPreviewing ? localized("Previewing") : localized("Not previewing")))
+            Divider()
 
-            Button(localized("Assign to current output")) {
-                onUseForCurrentOutput()
+            HStack {
+                Text(hasUnsavedDraft ? localized("Unsaved changes") : localized("All changes saved"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(Text(localized("Profile edit state")))
+                    .accessibilityValue(Text(hasUnsavedDraft ? localized("Unsaved changes") : localized("All changes saved")))
+                Spacer()
+                Button(localized("Revert")) {
+                    onRevert()
+                }
+                .disabled(!hasUnsavedDraft || programmeComparison.isActive)
+                .buttonStyle(ToolbarButtonStyle())
+
+                Button(localized("Apply")) {
+                    onApply()
+                }
+                .keyboardShortcut(.return, modifiers: .command)
+                .disabled(isReadOnly || !hasUnsavedDraft || programmeComparison.isActive)
+                .buttonStyle(ToolbarButtonStyle(prominent: true))
+
+                Button(isPreviewing ? localized("Stop Preview") : localized("Preview")) {
+                    isPreviewing ? onStopPreview() : onPreview()
+                }
+                .disabled((isReadOnly && !isPreviewing) || programmeComparison.isActive)
+                .buttonStyle(ToolbarButtonStyle())
+                .accessibilityValue(Text(isPreviewing ? localized("Previewing") : localized("Not previewing")))
+
+                Button(localized("Assign to current output")) {
+                    onUseForCurrentOutput()
+                }
+                .disabled(
+                    isReadOnly
+                        || currentOutputUID.isEmpty
+                        || programmeComparison.isActive
+                )
+                .buttonStyle(ToolbarButtonStyle())
+                .accessibilityHint(Text(currentOutputUID.isEmpty ? localized("No current output is available") : localized("Maps the selected profile to the current output device")))
             }
-            .disabled(isReadOnly || currentOutputUID.isEmpty)
-            .buttonStyle(ToolbarButtonStyle())
-            .accessibilityHint(Text(currentOutputUID.isEmpty ? localized("No current output is available") : localized("Maps the selected profile to the current output device")))
         }
+    }
+
+    private var comparisonDescription: String {
+        guard programmeComparison.isActive else {
+            return localized("Compare the draft EQ with filters off. Preamp stays enabled in both.")
+        }
+        guard programmeComparison.isReady else {
+            return localized("Measuring the current programme…")
+        }
+        if programmeComparison.equalizedAttenuationDB < -0.05 {
+            return localized(
+                "Matched · EQ \(localizedDecibels(programmeComparison.equalizedAttenuationDB))"
+            )
+        }
+        if programmeComparison.filtersOffAttenuationDB < -0.05 {
+            return localized(
+                "Matched · Filters off \(localizedDecibels(programmeComparison.filtersOffAttenuationDB))"
+            )
+        }
+        return localized("Matched · no level adjustment needed")
     }
 }
 

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -2490,6 +2490,12 @@ private struct OutputTab: View {
                             onRetryAutomaticAggregateBuffer()
                         }
                         .controlSize(.large)
+                    } else if let fixedFrameSize,
+                              snapshot.currentOutputBufferFrameSize > fixedFrameSize {
+                        Button(localized("Retry \(fixedFrameSize) frames")) {
+                            onSetAggregateBufferMode(snapshot.aggregateBuffer.mode)
+                        }
+                        .controlSize(.large)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -2566,6 +2572,7 @@ private struct OutputTab: View {
                         LabeledContent(localized("Bridge Latency"), value: bridgeLatencyLabel)
                         LabeledContent(localized("Bridge Latency Range"), value: bridgeLatencyRangeLabel)
                     } else {
+                        LabeledContent(localized("Render Deadline Misses"), value: localizedInteger(snapshot.metrics.renderDeadlineMisses))
                         LabeledContent(localized("Input Timestamp Jumps"), value: localizedInteger(snapshot.metrics.inputTimestampDiscontinuities))
                         LabeledContent(localized("Output Timestamp Jumps"), value: localizedInteger(snapshot.metrics.outputTimestampDiscontinuities))
                         LabeledContent(localized("Tap-to-Output Latency"), value: tapToOutputLatencyLabel)
@@ -2601,9 +2608,28 @@ private struct OutputTab: View {
                 "Automatic uses the smallest buffer proven reliable for this device stream and sample rate. It is currently \(snapshot.aggregateBuffer.automaticFrameSize) frames."
             )
         }
+        if let fixedFrameSize,
+           snapshot.currentOutputBufferFrameSize > fixedFrameSize {
+            return localized(
+                "The fixed \(fixedFrameSize)-frame setting became unstable. GlassEQ is temporarily using \(snapshot.currentOutputBufferFrameSize) frames for this session."
+            )
+        }
         return localized(
-            "A fixed buffer disables automatic reliability fallback for this route."
+            "A fixed buffer keeps this preference. GlassEQ may temporarily use a safer buffer if repeated deadline misses continue after a rebuild."
         )
+    }
+
+    private var fixedFrameSize: UInt32? {
+        switch snapshot.aggregateBuffer.mode {
+        case .automatic:
+            nil
+        case .frames16:
+            16
+        case .frames32:
+            32
+        case .frames64:
+            64
+        }
     }
 
     private var sampleRateLabel: String {

--- a/Sources/GlassEQSettingsUI/SettingsViewModel.swift
+++ b/Sources/GlassEQSettingsUI/SettingsViewModel.swift
@@ -44,6 +44,9 @@ public final class GlassEQSettingsViewModel {
         if let isPreviewing = patch.isPreviewing {
             snapshot.isPreviewing = isPreviewing
         }
+        if let programmeComparison = patch.programmeComparison {
+            snapshot.programmeComparison = programmeComparison
+        }
         if let selectedProfileID = patch.selectedProfileID {
             snapshot.selectedProfileID = selectedProfileID
         }

--- a/Tests/GlassEQAppTests/AudioRenderWatchdogTests.swift
+++ b/Tests/GlassEQAppTests/AudioRenderWatchdogTests.swift
@@ -296,6 +296,34 @@ struct AudioRenderWatchdogTests {
     }
 
     @Test
+    func deadlineBurstUsesARollingWindow() {
+        var detector = AudioRenderDeadlineBurstDetector(
+            requiredMisses: 3,
+            window: .seconds(1)
+        )
+        let start = ContinuousClock.now
+
+        let first = detector.observe(newMisses: 1, at: start)
+        let second = detector.observe(
+            newMisses: 1,
+            at: start.advanced(by: .milliseconds(900))
+        )
+        let third = detector.observe(
+            newMisses: 1,
+            at: start.advanced(by: .milliseconds(1_100))
+        )
+        let fourth = detector.observe(
+            newMisses: 1,
+            at: start.advanced(by: .milliseconds(1_200))
+        )
+
+        #expect(!first)
+        #expect(!second)
+        #expect(!third)
+        #expect(fourth)
+    }
+
+    @Test
     func fixedBufferRecoveryRebuildsThenClimbsWithoutChangingPreference() {
         var recovery = FixedBufferRecoverySession(
             runtimeFrameSize: 16,

--- a/Tests/GlassEQAppTests/AudioRenderWatchdogTests.swift
+++ b/Tests/GlassEQAppTests/AudioRenderWatchdogTests.swift
@@ -261,4 +261,79 @@ struct AudioRenderWatchdogTests {
             at: start.advanced(by: .seconds(7))
         ) == .restart)
     }
+
+    @Test
+    func deadlineBurstRequiresThreeMissesInsideOneSecond() {
+        var detector = AudioRenderDeadlineBurstDetector(
+            requiredMisses: 3,
+            window: .seconds(1)
+        )
+        let start = ContinuousClock.now
+
+        let first = detector.observe(newMisses: 1, at: start)
+        let second = detector.observe(
+            newMisses: 1,
+            at: start.advanced(by: .milliseconds(500))
+        )
+        let third = detector.observe(
+            newMisses: 1,
+            at: start.advanced(by: .milliseconds(900))
+        )
+        let fourth = detector.observe(
+            newMisses: 2,
+            at: start.advanced(by: .seconds(2))
+        )
+        let fifth = detector.observe(
+            newMisses: 1,
+            at: start.advanced(by: .seconds(4))
+        )
+
+        #expect(!first)
+        #expect(!second)
+        #expect(third)
+        #expect(!fourth)
+        #expect(!fifth)
+    }
+
+    @Test
+    func fixedBufferRecoveryRebuildsThenClimbsWithoutChangingPreference() {
+        var recovery = FixedBufferRecoverySession(
+            runtimeFrameSize: 16,
+            repeatedFailureWindow: .seconds(60)
+        )
+        let start = ContinuousClock.now
+
+        let first = recovery.observeFailure(at: start)
+        let second = recovery.observeFailure(
+            at: start.advanced(by: .seconds(10))
+        )
+        #expect(first == .rebuild(frameSize: 16))
+        #expect(second == .temporarilyIncrease(frameSize: 32))
+        #expect(recovery.runtimeFrameSize == 32)
+        let third = recovery.observeFailure(
+            at: start.advanced(by: .seconds(20))
+        )
+        #expect(third == .temporarilyIncrease(frameSize: 64))
+        #expect(recovery.runtimeFrameSize == 64)
+        let fourth = recovery.observeFailure(
+            at: start.advanced(by: .seconds(30))
+        )
+        #expect(fourth == .stop)
+    }
+
+    @Test
+    func fixedBufferRecoveryRebuildsCurrentRuntimeRungAfterQuietWindow() {
+        var recovery = FixedBufferRecoverySession(
+            runtimeFrameSize: 32,
+            repeatedFailureWindow: .seconds(60)
+        )
+        let start = ContinuousClock.now
+
+        let first = recovery.observeFailure(at: start)
+        let second = recovery.observeFailure(
+            at: start.advanced(by: .seconds(61))
+        )
+        #expect(first == .rebuild(frameSize: 32))
+        #expect(second == .rebuild(frameSize: 32))
+    }
 }

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -296,6 +296,65 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func fixedBufferRebuildsOnceThenUsesTemporarySaferRung() async throws {
+        let output = makeOutput(uid: "fixed-recovery", name: "Fixed Recovery")
+        let engine = FakeAudioEngine()
+        engine.reflectPreferredAggregateBufferFrameSize = true
+        let notifier = FakeAggregateBufferNotifier()
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            engine: engine,
+            observers: observers,
+            outputDelay: .zero,
+            aggregateBufferNotifier: notifier
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+        try model.setAggregateBufferMode(.frames16)
+        await waitUntil {
+            engine.startCalls.count == 2
+                && engine.startCalls[1].aggregateBufferFrameSize == 16
+        }
+        try? await Task.sleep(for: .milliseconds(50))
+
+        var metrics = engine.metrics
+        metrics.renderDeadlineMisses = 3
+        engine.metrics = metrics
+        await waitUntil {
+            engine.startCalls.count == 3
+                && engine.startCalls[2].aggregateBufferFrameSize == 16
+                && notifier.calls.last?.kind == .fixedRebuild
+        }
+        try? await Task.sleep(for: .milliseconds(50))
+
+        metrics = engine.metrics
+        metrics.renderDeadlineMisses = 6
+        engine.metrics = metrics
+        await waitUntil {
+            engine.startCalls.count == 4
+                && engine.startCalls[3].aggregateBufferFrameSize == 32
+                && notifier.calls.last?.kind == .fixedTemporaryIncrease
+        }
+
+        let temporarySnapshot = model.settingsSnapshot()
+        #expect(temporarySnapshot.aggregateBuffer.mode == .frames16)
+        #expect(temporarySnapshot.currentOutputBufferFrameSize == 32)
+
+        model.retryAudioEngine()
+        await waitUntil {
+            engine.startCalls.count == 5
+                && engine.startCalls[4].aggregateBufferFrameSize == 16
+                && model.settingsSnapshot().currentOutputBufferFrameSize == 16
+        }
+        #expect(model.settingsSnapshot().aggregateBuffer.mode == .frames16)
+        #expect(model.settingsSnapshot().currentOutputBufferFrameSize == 16)
+    }
+
+    @Test
     func automaticAggregateBufferIgnoresInterruptionsBeforeRouteSettles() async {
         let output = makeOutput(uid: "settling-aggregate", name: "Settling Aggregate")
         let engine = FakeAudioEngine()
@@ -4031,9 +4090,16 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
 @MainActor
 private final class FakeAggregateBufferNotifier: AggregateBufferChangeNotifying {
     struct Call: Equatable {
+        enum Kind: Equatable {
+            case automatic
+            case fixedRebuild
+            case fixedTemporaryIncrease
+        }
+
         var outputName: String
         var previousFrameSize: UInt32
         var newFrameSize: UInt32
+        var kind: Kind = .automatic
     }
 
     private(set) var calls: [Call] = []
@@ -4047,6 +4113,31 @@ private final class FakeAggregateBufferNotifier: AggregateBufferChangeNotifying 
             outputName: outputName,
             previousFrameSize: previousFrameSize,
             newFrameSize: newFrameSize
+        ))
+    }
+
+    func notifyFixedBufferRebuild(
+        outputName: String,
+        frameSize: UInt32
+    ) {
+        calls.append(Call(
+            outputName: outputName,
+            previousFrameSize: frameSize,
+            newFrameSize: frameSize,
+            kind: .fixedRebuild
+        ))
+    }
+
+    func notifyTemporaryBufferIncrease(
+        outputName: String,
+        preferredFrameSize: UInt32,
+        runtimeFrameSize: UInt32
+    ) {
+        calls.append(Call(
+            outputName: outputName,
+            previousFrameSize: preferredFrameSize,
+            newFrameSize: runtimeFrameSize,
+            kind: .fixedTemporaryIncrease
         ))
     }
 }

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1396,8 +1396,6 @@ struct GlassEQAppModelLifecycleTests {
             engine.muteOutputCallCount == 1
         }
         #expect(engine.muteOutputCallCount == 1)
-        #expect(model.statusMessage == localized("Audio output changed; rebuilding..."))
-        #expect(engine.startCalls.map(\.output) == [speakers])
 
         await waitUntil {
             engine.startCalls.map(\.output) == [speakers, scarlett]
@@ -1448,8 +1446,6 @@ struct GlassEQAppModelLifecycleTests {
             engine.muteOutputCallCount == 1
         }
         #expect(engine.muteOutputCallCount == 1)
-        #expect(model.statusMessage == localized("Audio output format changed; rebuilding..."))
-        #expect(engine.startCalls.map(\.output) == [initialOutput])
 
         await waitUntil {
             engine.startCalls.map(\.output) == [initialOutput, changedOutput]
@@ -1457,6 +1453,7 @@ struct GlassEQAppModelLifecycleTests {
 
         #expect(model.currentOutputSampleRate == changedOutput.nominalSampleRate)
         #expect(model.currentOutputBufferFrameSize == changedOutput.bufferFrameSize)
+        #expect(engine.events == ["start:\(initialOutput.uid)", "mute", "start:\(changedOutput.uid)"])
     }
 
     @Test

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1164,6 +1164,108 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func outputChangeClearsProgrammeComparisonWithoutRestoringThePreviousRouteProfile() async throws {
+        let firstProfile = makeProfile(name: "First Route")
+        let secondProfile = makeProfile(name: "Second Route")
+        let firstOutput = makeOutput(uid: "comparison-first-output", name: "First Output")
+        let secondOutput = makeOutput(uid: "comparison-second-output", name: "Second Output")
+        let store = ProfileStore(
+            profiles: [firstProfile, secondProfile],
+            outputMappings: [
+                OutputDeviceProfileMapping(
+                    outputDeviceUID: secondOutput.uid,
+                    profileID: secondProfile.id
+                )
+            ],
+            fallbackProfileID: firstProfile.id
+        )
+        let engine = FakeAudioEngine()
+        let lookup = FakeDefaultOutputLookup(.success(firstOutput))
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            store: store,
+            engine: engine,
+            lookup: lookup,
+            observers: observers,
+            outputDelay: .zero
+        )
+
+        model.start()
+        let observer = observers.observers[0]
+        observer.emit(.success(firstOutput))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        var comparisonProfile = firstProfile
+        comparisonProfile.preampDB = -6
+        try model.startProgrammeComparison(profile: comparisonProfile)
+        model.selectProgrammeComparison(.filtersOff)
+
+        lookup.result = .success(secondOutput)
+        observer.emit(.success(secondOutput))
+        await waitUntil {
+            model.lifecycleState == .running
+                && model.currentOutputUID == secondOutput.uid
+                && engine.startCalls.count == 2
+        }
+
+        #expect(!model.settingsSnapshot().programmeComparison.isActive)
+        #expect(model.activeProfile == secondProfile)
+        #expect(engine.programmeComparisonSelections == [
+            .equalized,
+            .filtersOff,
+            .equalized
+        ])
+
+        let updatesBeforeStop = engine.updateDSPCalls
+        model.stopProgrammeComparison()
+
+        #expect(engine.updateDSPCalls == updatesBeforeStop)
+        #expect(model.activeProfile == secondProfile)
+    }
+
+    @Test
+    func runtimeFailureClearsProgrammeComparisonAndLaterStopIsNoOp() async throws {
+        let active = makeProfile(name: "Runtime Comparison")
+        let output = makeOutput(uid: "runtime-comparison-output", name: "Runtime Output")
+        let engine = FakeAudioEngine()
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            store: ProfileStore(profiles: [active], fallbackProfileID: active.id),
+            engine: engine,
+            lookup: FakeDefaultOutputLookup(.success(output)),
+            observers: observers,
+            outputDelay: .zero
+        )
+
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        var comparisonProfile = active
+        comparisonProfile.preampDB = -6
+        try model.startProgrammeComparison(profile: comparisonProfile)
+        model.selectProgrammeComparison(.filtersOff)
+
+        engine.emitRuntimeFailure(adaptiveRenderFailure)
+        await waitUntil {
+            model.lifecycleState == .stopped
+        }
+
+        #expect(!model.settingsSnapshot().programmeComparison.isActive)
+        #expect(model.activeProfile == active)
+
+        let updatesBeforeStop = engine.updateDSPCalls
+        model.stopProgrammeComparison()
+
+        #expect(engine.updateDSPCalls == updatesBeforeStop)
+        #expect(model.activeProfile == active)
+    }
+
+    @Test
     func outputChangeToBypassedProfileDoesNotStartEngine() async {
         let fallback = makeProfile(name: "Fallback")
         var disabled = makeProfile(name: "Disabled")

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -1046,6 +1046,65 @@ struct GlassEQAppModelLifecycleTests {
     }
 
     @Test
+    func programmeComparisonKeepsTheActiveProfileAndReturnsThroughDSPTransition() async throws {
+        let active = makeProfile(name: "Active")
+        let output = makeOutput(uid: "comparison-output", name: "Comparison Output")
+        let engine = FakeAudioEngine()
+        let observers = FakeDefaultOutputObserverFactory()
+        let model = makeModel(
+            store: ProfileStore(profiles: [active], fallbackProfileID: active.id),
+            engine: engine,
+            lookup: FakeDefaultOutputLookup(.success(output)),
+            observers: observers,
+            outputDelay: .zero
+        )
+        model.start()
+        observers.observers[0].emit(.success(output))
+        await waitUntil {
+            model.lifecycleState == .running && engine.startCalls.count == 1
+        }
+
+        var draft = active
+        draft.preampDB = -6
+        draft.filters = [
+            EQFilter(kind: .peak, frequency: 1_000, gainDB: 5, q: 1)
+        ]
+        try model.startProgrammeComparison(profile: draft)
+
+        #expect(engine.programmeComparisonCalls == [draft])
+        #expect(engine.programmeComparisonSelections == [.equalized])
+        #expect(model.activeProfile == active)
+        #expect(model.settingsSnapshot().programmeComparison.isActive)
+
+        model.selectProgrammeComparison(.filtersOff)
+        #expect(engine.programmeComparisonSelections == [.equalized, .filtersOff])
+        #expect(model.settingsSnapshot().programmeComparison.selection == .filtersOff)
+
+        engine.programmeComparisonSnapshot = EQProgrammeComparisonSnapshot(
+            isActive: true,
+            isReady: true,
+            selection: .filtersOff,
+            equalizedAttenuationDB: -3.25
+        )
+        await waitUntil {
+            model.settingsSnapshot().programmeComparison.isReady
+        }
+        #expect(
+            abs(
+                model.settingsSnapshot().programmeComparison.equalizedAttenuationDB
+                    + 3.25
+            ) < 0.001
+        )
+
+        model.stopProgrammeComparison()
+
+        #expect(engine.programmeComparisonSelections.last == .equalized)
+        #expect(engine.updateDSPCalls.last == active)
+        #expect(!model.settingsSnapshot().programmeComparison.isActive)
+        #expect(model.activeProfile == active)
+    }
+
+    @Test
     func outputChangeToBypassedProfileDoesNotStartEngine() async {
         let fallback = makeProfile(name: "Fallback")
         var disabled = makeProfile(name: "Disabled")
@@ -3584,6 +3643,7 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private var _updateError: Error?
     private var _updateErrorPreservesRunningState = false
     private var _updateDSPResult = true
+    private var _beginProgrammeComparisonResult = true
     private var _startDelaySeconds: TimeInterval = 0
     private var _startDelaySecondsByUID: [String: TimeInterval] = [:]
     private var _startBlockersByUID: [String: FakeStartBlocker] = [:]
@@ -3591,6 +3651,9 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private var _startCalls: [StartCall] = []
     private var _updateCalls: [EQProfile] = []
     private var _updateDSPCalls: [EQProfile] = []
+    private var _programmeComparisonCalls: [EQProfile] = []
+    private var _programmeComparisonSelections: [EQProgrammeComparisonSelection] = []
+    private var _programmeComparisonSnapshot = EQProgrammeComparisonSnapshot()
     private var _stopCallCount = 0
     private var _muteOutputCallCount = 0
     private var _metrics = AudioEngineMetrics()
@@ -3648,6 +3711,11 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
         set { withLock { _updateDSPResult = newValue } }
     }
 
+    var beginProgrammeComparisonResult: Bool {
+        get { withLock { _beginProgrammeComparisonResult } }
+        set { withLock { _beginProgrammeComparisonResult = newValue } }
+    }
+
     var startDelaySeconds: TimeInterval {
         get { withLock { _startDelaySeconds } }
         set { withLock { _startDelaySeconds = newValue } }
@@ -3671,6 +3739,21 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
     private(set) var updateDSPCalls: [EQProfile] {
         get { withLock { _updateDSPCalls } }
         set { withLock { _updateDSPCalls = newValue } }
+    }
+
+    private(set) var programmeComparisonCalls: [EQProfile] {
+        get { withLock { _programmeComparisonCalls } }
+        set { withLock { _programmeComparisonCalls = newValue } }
+    }
+
+    private(set) var programmeComparisonSelections: [EQProgrammeComparisonSelection] {
+        get { withLock { _programmeComparisonSelections } }
+        set { withLock { _programmeComparisonSelections = newValue } }
+    }
+
+    var programmeComparisonSnapshot: EQProgrammeComparisonSnapshot {
+        get { withLock { _programmeComparisonSnapshot } }
+        set { withLock { _programmeComparisonSnapshot = newValue } }
     }
 
     private(set) var stopCallCount: Int {
@@ -3860,6 +3943,34 @@ private final class FakeAudioEngine: AudioEngineControlling, @unchecked Sendable
             _events.append("updateDSP:\(profile.id)")
             _updateDSPCalls.append(profile)
             return _updateDSPResult
+        }
+    }
+
+    func beginProgrammeComparison(profile: EQProfile) -> Bool {
+        withLock {
+            _programmeComparisonCalls.append(profile)
+            if _beginProgrammeComparisonResult {
+                _programmeComparisonSnapshot = EQProgrammeComparisonSnapshot(
+                    isActive: true,
+                    selection: .equalized
+                )
+            }
+            return _beginProgrammeComparisonResult
+        }
+    }
+
+    func setProgrammeComparisonSelection(
+        _ selection: EQProgrammeComparisonSelection
+    ) {
+        withLock {
+            _programmeComparisonSelections.append(selection)
+            _programmeComparisonSnapshot.selection = selection
+        }
+    }
+
+    func snapshotProgrammeComparison() -> EQProgrammeComparisonSnapshot {
+        withLock {
+            _programmeComparisonSnapshot
         }
     }
 

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -654,6 +654,25 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
+    func renderDeadlineMissesRequireAtLeastTwoCallbackPeriods() {
+        #expect(SystemTapAudioEngine.missedRenderDeadlines(
+            elapsedNanoseconds: 650_000,
+            frameCount: 16,
+            sampleRate: 48_000
+        ) == 0)
+        #expect(SystemTapAudioEngine.missedRenderDeadlines(
+            elapsedNanoseconds: 700_000,
+            frameCount: 16,
+            sampleRate: 48_000
+        ) == 1)
+        #expect(SystemTapAudioEngine.missedRenderDeadlines(
+            elapsedNanoseconds: 4_500_000,
+            frameCount: 16,
+            sampleRate: 48_000
+        ) == 12)
+    }
+
+    @Test
     func aggregateTimestampSlopeQualificationRequiresStableNominalTiming() {
         #expect(SystemTapAudioEngine.timestampSlopeAgrees(
             frameCount: 16,

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -1,5 +1,5 @@
 import Darwin
-import GlassEQCore
+@testable import GlassEQCore
 import Foundation
 import Testing
 
@@ -381,6 +381,61 @@ struct EQCoreTests {
     }
 
     @Test
+    func programmeComparisonCallbackPathStaysWithinGenerousDebugBudget() {
+        guard !isThreadSanitizerRuntimeLoaded else {
+            return
+        }
+        let profile = EQProfile.flatGraphic31
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: profile,
+                sampleRate: 48_000,
+                channelCount: 2
+            )),
+            maximumFrameCount: 64,
+            channelCount: 2,
+            sampleRate: 48_000
+        )
+        let didBegin = transition.beginProgrammeComparison(
+            equalizedProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: profile,
+                sampleRate: 48_000,
+                channelCount: 2
+            )),
+            filtersOffProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: profile.programmeComparisonReference,
+                sampleRate: 48_000,
+                channelCount: 2
+            ))
+        )
+        #expect(didBegin)
+        var samples = makeStereoTestBlock(frameCount: 64, sampleRate: 48_000)
+        for _ in 0..<24 {
+            _ = samples.withUnsafeMutableBufferPointer {
+                transition.processInterleavedWithDiagnostics(
+                    $0,
+                    frameCount: 64,
+                    channelCount: 2
+                )
+            }
+        }
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        for _ in 0..<1_024 {
+            _ = samples.withUnsafeMutableBufferPointer {
+                transition.processInterleavedWithDiagnostics(
+                    $0,
+                    frameCount: 64,
+                    channelCount: 2
+                )
+            }
+        }
+
+        #expect(start.duration(to: clock.now) < .seconds(4))
+    }
+
+    @Test
     func preparedRenderConfigurationMatchesConfigurationInitializer() {
         let profile = EQProfile(
             name: "Prepared",
@@ -657,6 +712,248 @@ struct EQCoreTests {
         #expect(abs(samples[3] - 0.25) < 0.000_001)
         #expect(result.completedTransition)
         #expect(transition.activeConfiguration.isBypassed)
+    }
+
+    @Test
+    func programmeComparisonReferenceKeepsPreampAndDisablesOnlyFilters() {
+        let profile = EQProfile(
+            name: "Stereo",
+            mode: .parametric,
+            channelMode: .stereo,
+            preampDB: -7,
+            filters: [
+                EQFilter(kind: .peak, frequency: 1_000, gainDB: 4, q: 1)
+            ],
+            leftPreampDB: -5,
+            leftFilters: [
+                EQFilter(kind: .lowShelf, frequency: 100, gainDB: 3, q: 0.7)
+            ],
+            rightPreampDB: -9,
+            rightFilters: [
+                EQFilter(kind: .highShelf, frequency: 8_000, gainDB: -2, q: 0.7)
+            ]
+        )
+        var bypassed = profile
+        bypassed.isBypassed = true
+
+        let reference = bypassed.programmeComparisonReference
+
+        #expect(reference.preampDB == -7)
+        #expect(reference.leftPreampDB == -5)
+        #expect(reference.rightPreampDB == -9)
+        #expect(reference.channelMode == .stereo)
+        #expect(reference.filters.isEmpty)
+        #expect(reference.leftFilters.isEmpty)
+        #expect(reference.rightFilters.isEmpty)
+        #expect(!reference.isBypassed)
+    }
+
+    @Test
+    func programmeLoudnessMatcherAttenuatesOnlyTheLouderBranch() {
+        let sampleRate = 48_000.0
+        let frameCount = Int(sampleRate * 4)
+        var equalized = [Float](repeating: 0, count: frameCount * 2)
+        var filtersOff = [Float](repeating: 0, count: frameCount * 2)
+        for frame in 0..<frameCount {
+            let sample = Float(sin(2 * Double.pi * 1_000 * Double(frame) / sampleRate))
+            equalized[frame * 2] = sample * 0.2
+            equalized[frame * 2 + 1] = sample * 0.2
+            filtersOff[frame * 2] = sample * 0.1
+            filtersOff[frame * 2 + 1] = sample * 0.1
+        }
+        var matcher = RealtimeProgrammeLoudnessMatcher(
+            sampleRate: sampleRate,
+            channelCount: 2
+        )
+
+        equalized.withUnsafeBufferPointer { equalizedSamples in
+            filtersOff.withUnsafeBufferPointer { filtersOffSamples in
+                for frame in 0..<frameCount {
+                    _ = matcher.observeFrame(
+                        equalized: equalizedSamples,
+                        filtersOff: filtersOffSamples,
+                        sampleOffset: frame * 2,
+                        channelCount: 2
+                    )
+                }
+            }
+        }
+
+        let match = matcher.snapshot
+        #expect(match.isReady)
+        #expect(abs(match.equalizedAttenuationDB + 6.0206) < 0.02)
+        #expect(abs(match.filtersOffAttenuationDB) < 0.000_001)
+    }
+
+    @Test
+    func kWeightingCoefficientsMatchBS1770At48KHz() {
+        let shelf = KWeightingCoefficients.kWeightingShelf(sampleRate: 48_000)
+        #expect(abs(shelf.b0 - 1.535_124_9) < 0.000_001)
+        #expect(abs(shelf.b1 + 2.691_696_2) < 0.000_001)
+        #expect(abs(shelf.b2 - 1.198_392_9) < 0.000_001)
+        #expect(abs(shelf.a1 + 1.690_659_3) < 0.000_001)
+        #expect(abs(shelf.a2 - 0.732_480_76) < 0.000_001)
+
+        let highPass = KWeightingCoefficients.kWeightingHighPass(sampleRate: 48_000)
+        #expect(highPass.b0 == 1)
+        #expect(highPass.b1 == -2)
+        #expect(highPass.b2 == 1)
+        #expect(abs(highPass.a1 + 1.990_047_5) < 0.000_001)
+        #expect(abs(highPass.a2 - 0.990_072_25) < 0.000_001)
+    }
+
+    @Test
+    func programmeComparisonTransitionsIntoBothBranchesAndBackOut() {
+        let active = EQProfile(name: "Active", mode: .parametric, filters: [])
+        let equalized = EQProfile(
+            name: "Equalized",
+            mode: .parametric,
+            preampDB: 6.020_599_913,
+            filters: []
+        )
+        let filtersOff = EQProfile(name: "Filters off", mode: .parametric, filters: [])
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: 48_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 4,
+            channelCount: 1,
+            sampleRate: 48_000,
+            warmupSeconds: 0,
+            blendSeconds: 4.0 / 48_000
+        )
+
+        let didBeginComparison = transition.beginProgrammeComparison(
+            equalizedProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: equalized,
+                sampleRate: 48_000,
+                channelCount: 1
+            )),
+            filtersOffProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: filtersOff,
+                sampleRate: 48_000,
+                channelCount: 1
+            ))
+        )
+        #expect(didBeginComparison)
+        var entry = [Float](repeating: 0.25, count: 4)
+        let entryResult = entry.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+        #expect(entryResult.completedTransition)
+        #expect(entryResult.programmeComparison.isActive)
+        #expect(abs(entry[0] - 0.25) < 0.000_001)
+        #expect(abs(entry[3] - 0.5) < 0.000_001)
+
+        transition.setProgrammeComparisonSelection(.filtersOff)
+        var comparison = [Float](repeating: 0.25, count: 4)
+        let comparisonResult = comparison.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+        #expect(comparisonResult.programmeComparison.isActive)
+        #expect(abs(comparison[0] - 0.5) < 0.000_001)
+        #expect(abs(comparison[3] - 0.25) < 0.000_001)
+
+        let didBeginExit = transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
+            profile: active,
+            sampleRate: 48_000,
+            channelCount: 1
+        )))
+        #expect(didBeginExit)
+        var exitSelection = [Float](repeating: 0.25, count: 4)
+        _ = exitSelection.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+        var exitProfile = [Float](repeating: 0.25, count: 4)
+        let exitResult = exitProfile.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+        #expect(exitResult.completedTransition)
+        #expect(exitResult.retiredProcessor != nil)
+        #expect(exitResult.secondRetiredProcessor != nil)
+        #expect(!exitResult.programmeComparison.isActive)
+        #expect(abs(exitProfile[0] - 0.5) < 0.000_001)
+        #expect(abs(exitProfile[3] - 0.25) < 0.000_001)
+    }
+
+    @Test
+    func programmeComparisonPublishesReadinessDuringSteadyStateRendering() {
+        let sampleRate = 48_000.0
+        let blockFrames = 4_800
+        let active = EQProfile(name: "Active", mode: .parametric, filters: [])
+        let equalized = EQProfile(
+            name: "Equalized",
+            mode: .parametric,
+            preampDB: 6.020_599_913,
+            filters: []
+        )
+        let filtersOff = EQProfile(name: "Filters off", mode: .parametric, filters: [])
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: sampleRate,
+                channelCount: 1
+            )),
+            maximumFrameCount: blockFrames,
+            channelCount: 1,
+            sampleRate: sampleRate,
+            warmupSeconds: 0,
+            blendSeconds: Double(blockFrames) / sampleRate
+        )
+        let didBegin = transition.beginProgrammeComparison(
+            equalizedProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: equalized,
+                sampleRate: sampleRate,
+                channelCount: 1
+            )),
+            filtersOffProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: filtersOff,
+                sampleRate: sampleRate,
+                channelCount: 1
+            ))
+        )
+        #expect(didBegin)
+
+        var lastResult = EQTransitionRenderResult()
+        for block in 0..<40 {
+            var samples = (0..<blockFrames).map { frame in
+                Float(sin(
+                    2 * Double.pi * 1_000
+                        * Double(block * blockFrames + frame)
+                        / sampleRate
+                )) * 0.1
+            }
+            lastResult = samples.withUnsafeMutableBufferPointer {
+                transition.processInterleavedWithDiagnostics(
+                    $0,
+                    frameCount: blockFrames,
+                    channelCount: 1
+                )
+            }
+        }
+
+        #expect(lastResult.programmeComparison.isActive)
+        #expect(lastResult.programmeComparison.isReady)
+        #expect(lastResult.programmeComparison.equalizedAttenuationDB < -5.9)
+        #expect(abs(lastResult.programmeComparison.filtersOffAttenuationDB) < 0.001)
     }
 
     @Test

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -45,6 +45,9 @@ struct SettingsIPCTests {
 
         snapshot.isPreviewing = false
         #expect(settingsCanDeleteSelectedProfile(snapshot))
+
+        snapshot.programmeComparison.isActive = true
+        #expect(!settingsCanDeleteSelectedProfile(snapshot))
     }
 
     @Test
@@ -277,6 +280,28 @@ struct SettingsIPCTests {
         ]
 
         for message in messages {
+            let encoded = try SettingsPipeCodec.encodeLine(message)
+            let decoded = try SettingsPipeCodec.decodeLine(Data(encoded.dropLast()))
+            #expect(decoded == message)
+        }
+    }
+
+    @Test
+    func programmeComparisonCommandsRoundTrip() throws {
+        let profile = EQProfile(name: "Draft", mode: .parametric, filters: [])
+        let commands: [SettingsCommand] = [
+            .startProgrammeComparison(profile),
+            .selectProgrammeComparison(.filtersOff),
+            .stopProgrammeComparison
+        ]
+
+        for (index, command) in commands.enumerated() {
+            let message = SettingsPipeMessage.request(
+                sessionToken: "token",
+                id: "comparison-\(index)",
+                kind: .command,
+                command: command
+            )
             let encoded = try SettingsPipeCodec.encodeLine(message)
             let decoded = try SettingsPipeCodec.decodeLine(Data(encoded.dropLast()))
             #expect(decoded == message)
@@ -653,6 +678,12 @@ struct SettingsIPCTests {
         let patch = SettingsSnapshotPatchDTO(
             statusMessage: "Running",
             isRunning: true,
+            programmeComparison: EQProgrammeComparisonSnapshot(
+                isActive: true,
+                isReady: true,
+                selection: .filtersOff,
+                equalizedAttenuationDB: -2.5
+            ),
             activeProfileID: profileID,
             activeProfileName: "Flat",
             currentOutput: SettingsOutputDTO(
@@ -683,6 +714,7 @@ struct SettingsIPCTests {
         let encoded = try JSONEncoder().encode(snapshot)
         var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
         object.removeValue(forKey: "isRunning")
+        object.removeValue(forKey: "programmeComparison")
 
         let decoded = try JSONDecoder().decode(
             SettingsSnapshotDTO.self,
@@ -690,6 +722,7 @@ struct SettingsIPCTests {
         )
 
         #expect(!decoded.isRunning)
+        #expect(decoded.programmeComparison == EQProgrammeComparisonSnapshot())
     }
 
     @Test

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -339,6 +339,7 @@ struct SettingsIPCTests {
         #expect(metrics.saturatedSamples == 2)
         #expect(metrics.maximumCaptureCallbackFrames == 0)
         #expect(metrics.maximumPlaybackCallbackFrames == 0)
+        #expect(metrics.renderDeadlineMisses == 0)
         #expect(metrics.droppedInputFrames == 0)
         #expect(metrics.tapToOutputLatencyObservations == 0)
         #expect(metrics.minimumTapToOutputLatencyNanoseconds == 0)
@@ -349,6 +350,7 @@ struct SettingsIPCTests {
     @Test
     func audioMetricsRoundTripTapToOutputLatency() throws {
         let metrics = SettingsAudioMetricsDTO(
+            renderDeadlineMisses: 7,
             tapToOutputLatencyObservations: 500,
             minimumTapToOutputLatencyNanoseconds: 1_250_000,
             maximumTapToOutputLatencyNanoseconds: 2_750_000,


### PR DESCRIPTION
- Comparing profiles at different loudness levels makes the louder profile sound better even when its response is not. Some routes also need a controlled temporary buffer increase when their fixed setting proves unstable.
- This adds loudness-matched A/B comparison and preserves explicit buffer preferences while allowing bounded recovery for unstable fixed-buffer routes.
- This pull request is stacked on pr/audio-render-resilience.