### PR TITLE
feat(eq): add minimum-phase response curve convolution

### DIFF
--- a/Docs/AggregateClockExperiment.md
+++ b/Docs/AggregateClockExperiment.md
@@ -1,0 +1,616 @@
+# Aggregate clock experiment: findings
+
+## Experiment
+
+I tested replacing GlassEQ's separate capture and playback paths with one private Core Audio aggregate containing both the process tap and the physical output.
+
+The aggregate architecture worked remarkably well on normal-rate routes. It survived output switching, Bluetooth switching, sleep and wake, notifications, and both the D10s and Scarlett Solo. Capture and playback callbacks remained small, I observed no underruns, and the release app used roughly 1 to 2 percent CPU.
+
+It also removed a substantial amount of application complexity:
+
+- Separate capture and playback clocks
+- Ring-buffer occupancy control
+- Drift servo
+- Hermite resampler
+- Priming and underrun recovery logic
+
+Core Audio's drift compensation handled the tap clock cleanly on those routes. Disabling it did not change the latency of the first aggregate design.
+
+The latency result initially appeared to rule out the architecture. A later change to the tap itself reversed that conclusion.
+
+This file is deliberately a workbook rather than a polished final report. It retains failed hypotheses, superseded implementations, live hardware observations, and the reasoning that connected them. Later sections record changes built on top of the aggregate architecture, especially where they expose another realtime limit.
+
+## What the latency figures measure
+
+The figures below measure tap-to-output latency. The input timestamp marks the first process-tap frame available to GlassEQ, and the output timestamp marks when the first processed frame is scheduled for the physical output.
+
+They do not include latency before the process tap or after the output reaches the hardware. The DAC, amplifier, speaker, and acoustic path are outside the measurement.
+
+## First result: global tap in the combined aggregate
+
+The first combined aggregate used GlassEQ's existing global stereo tap. On the Scarlett Solo at 48 kHz with 64-frame callbacks, it was slower than the reference architecture:
+
+| Measurement | Global-tap combined aggregate | Reference GlassEQ design |
+| --- | ---: | ---: |
+| Input age when processing begins | 21.114 ms | 22.655 ms |
+| Application bridge and reservoir | None | 2.054 ms |
+| Output scheduling lead | 22.386 ms | 1.635 ms |
+| Total tap-to-output latency | 43.500 ms | 26.345 ms |
+
+The reference design was about 17.2 ms faster. The same 43.5 ms combined-aggregate result appeared on the D10s, which ruled out the Scarlett as the cause.
+
+### Why the first aggregate was slower
+
+The 64-frame callback size controls callback cadence. At 48 kHz, each callback represents 1.333 ms. It does not determine the complete pipeline depth.
+
+Core Audio reported these relevant latency margins:
+
+| Path | Reported margin |
+| --- | ---: |
+| Global-tap combined aggregate input | 74 frames of input latency plus a 950-frame safety offset, totalling 1,024 frames |
+| Global-tap combined aggregate output | 14 frames of output latency plus a 1,010-frame safety offset, totalling 1,024 frames |
+| Tap-only aggregate input | 1,024-frame safety offset |
+| Physical Scarlett output | 14 frames of output latency |
+
+The callback timestamps aligned with the active safety margin plus one callback block:
+
+- Combined input: `(950 + 64) / 48,000 = 21.125 ms`
+- Combined output: `(1,010 + 64) / 48,000 = 22.375 ms`
+- Reference capture: `(1,024 + 64) / 48,000 = 22.667 ms`
+- Reference output: `(14 + 64) / 48,000 = 1.625 ms`
+
+Core Audio appeared to align both sides of the combined aggregate with the global process tap's 1,024-frame latency budget. On the output side, it preserved the Scarlett's 14-frame device latency and raised the aggregate safety offset to 1,010 frames.
+
+The reference architecture kept the tap in its own aggregate but drove the physical output directly. It still paid the process tap's large capture margin, then crossed into the physical output's much smaller scheduling margin. Its ring buffer, servo, and resampler cost about 2 ms, but they avoided roughly 21 ms of aggregate output lead.
+
+At this point, the reference design's complexity looked justified. That conclusion was correct for a global tap, but the global tap turned out to be the wrong comparison.
+
+## The breakthrough: bind the tap to the output stream
+
+Core Audio can create a process tap for one selected stream on one selected output device. Replacing the global stereo tap with this device-scoped tap changed the timing completely.
+
+On the same Scarlett Solo route, still at 48 kHz with 64-frame callbacks:
+
+| Measurement | Device-scoped combined aggregate | Global-tap combined aggregate | Reference GlassEQ design |
+| --- | ---: | ---: | ---: |
+| Input age when processing begins | 2.864 ms | 21.114 ms | 22.655 ms |
+| Application bridge and reservoir | None | None | 2.054 ms |
+| Output scheduling lead | 1.636 ms | 22.386 ms | 1.635 ms |
+| Total tap-to-output latency | 4.500 ms | 43.500 ms | 26.345 ms |
+
+The device-scoped aggregate reported 74 input safety frames and 14 output safety frames. With one 64-frame callback on each side, those values predict the measured result closely:
+
+- Input: `(74 + 64) / 48,000 = 2.875 ms`
+- Output: `(14 + 64) / 48,000 = 1.625 ms`
+- Total: `(74 + 64 + 14 + 64) / 48,000 = 4.500 ms`
+
+The application bridge disappeared, and Core Audio stopped imposing the global tap's 1,024-frame budget on both halves of the aggregate. The combined architecture became about 21.8 ms faster than the reference GlassEQ design and 39 ms faster than the first aggregate.
+
+The physical-output lead remained effectively identical to the reference design, 1.636 ms versus 1.635 ms. The entire gain came from reducing the age of the tapped input and removing the application-managed bridge.
+
+## A 32-frame aggregate can sit on a 512-frame physical device
+
+The first 32-frame experiment exposed an important distinction between the physical output device and the private aggregate.
+
+While the release app was running on the Scarlett, a separate read-only Core Audio query reported:
+
+- Physical Scarlett object: 512 buffer frames
+- GlassEQ capture callback peak: 32 frames
+- GlassEQ output callback peak: 32 frames
+- Tap-to-output latency: 3.17 ms
+- Captured and played: 9,154,720 frames each
+- Underruns, dropped input, and saturated samples: zero
+
+The callback timing matches the same latency model with 32-frame quanta:
+
+`(74 + 32 + 14 + 32) / 48,000 = 3.167 ms`
+
+This is not a cosmetic 32-frame setting. The aggregate IOProc was receiving and producing 32-frame callbacks even though `kAudioDevicePropertyBufferFrameSize` on the physical Scarlett reported 512 frames to another process.
+
+The Output pane's Buffer field alone does not prove the active callback size. GlassEQ caches that value from the engine's output metadata. The capture and output callback peaks are the direct runtime evidence.
+
+The practical lesson is that the physical subdevice's buffer-frame property is not a reliable proxy for a private aggregate's IOProc quantum. Diagnostics must query the aggregate from its owning process or measure the frames delivered to its callbacks. Private aggregate devices are not visible to an external Core Audio device enumeration.
+
+## The first 16-frame failure was not a 16-frame limit
+
+The first Scarlett run at 16 frames crackled badly and produced a brief high-pitched tone when GlassEQ started and stopped. GlassEQ still reported 16-frame capture and output callbacks, 2.500 ms tap-to-output latency, and zero underruns, dropped input frames, or saturated samples.
+
+Reducing the callback size therefore looked like the cause, but returning to 32 frames did not fix the crackle. That run also reported clean application counters despite audible corruption. The failure was outside the parts of the path those counters observe.
+
+The startup timing in Core Audio's log distinguished the bad and good runs:
+
+- A previously clean 32-frame aggregate began its IO work loop about 36 ms after activation.
+- The crackling 32-frame aggregate took about 1.28 seconds and coincided with an audio I/O overload on Music's 512-frame USB route.
+- After a verified device-idle reset, a clean 32-frame aggregate started in about 28 ms with no startup overload.
+
+We then repeated the 16-frame test after the same reset. It ran cleanly with 16-frame capture and output callback peaks, fixed 2.500 ms tap-to-output latency, 1,888,608 frames captured and played, and zero application counters. This result strongly suggests that the initial 16-frame run inherited a bad route state. It does not prove that 16 frames will be reliable on every startup or output device.
+
+## The 74-frame term belongs to the output device, not its input topology
+
+The Scarlett result initially suggested that its physical input caused the aggregate's 74-frame input-side margin. A route comparison disproved that hypothesis.
+
+GlassEQ now samples the host clock at callback entry and splits the tap-to-output timestamp interval into input age and output scheduling lead. At 48 kHz with 16-frame aggregate callbacks, the results were:
+
+| Physical output | Physical input streams | Input safety | Output safety | Measured input age | Measured output lead | Tap to output |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| D10s | None | 74 frames | 14 frames | 90.023 frames | 29.978 frames | 120 frames / 2.500 ms |
+| Scarlett Solo | 2 channels | 74 frames | 14 frames | 89.938 frames | 30.061 frames | 120 frames / 2.500 ms |
+| MacBook Pro Speakers | None | 36 frames | 48 frames | 51.593 frames | 64.407 frames | 116 frames / 2.417 ms |
+| LEN Y27q-20 DisplayPort | None | 0 frames | 320 frames | 15.576 frames | 336.423 frames | 352 frames / 7.333 ms |
+
+The physical device and private aggregate reported the same safety offsets on every route. The callback timings followed:
+
+`input safety + one input quantum + output safety + one output quantum`
+
+The separate device-latency properties were not added to this timestamp interval. This is clearest on the built-in speakers, which reported 21 frames of input latency and 60 frames of output latency but measured exactly the safety-offset model.
+
+The D10s is the decisive case. It is an output-only device with no physical input streams, but it still publishes a 74-frame input-scoped safety offset. The private aggregate inherits that value from the D10s as its main subdevice. The Scarlett microphone topology therefore caused the microphone indicator, but it did not cause the 74-frame scheduling term.
+
+Both safety-offset properties were read-only on the D10s and its aggregate. An isolated aggregate-description test also assigned `-74` frames of extra input latency to the D10s subdevice. Core Audio accepted the description but left both the reported offsets and measured 90/30-frame timing unchanged. The earlier negative sub-tap latency test made the aggregate unusable.
+
+There is no supported direct override left to try. Removing the D10s's 74-frame term would require changing which device supplies the aggregate's timing metadata, probably through another clock-master or virtual-device layer. That would reintroduce another clock domain or a custom Core Audio driver to save 1.542 ms, with no evidence that the resulting path would remain stable. The practical floor is therefore device-specific: GlassEQ can minimize its callback quanta, but the main output device supplies the fixed safety margins.
+
+### The deeper 74-frame investigation
+
+The follow-up investigation in [AggregateSafetyOffsetInvestigation.md](AggregateSafetyOffsetInvestigation.md) tested the remaining supported aggregate controls and several useful negative controls.
+
+Three USB audio devices, including two output-only engines, all reported an input safety offset of exactly 74 frames. Their output offsets differed. Built-in and DisplayPort outputs published different input margins, and a third-party aggregate mirrored its main subdevice's values even when another USB subdevice was present. The common 74-frame value is therefore a policy of Apple's USB audio driver family, not a measurement of a microphone path.
+
+The aggregate experiments narrowed the model further:
+
+- Single-subdevice aggregates mirrored the main subdevice.
+- Setting `channels-in` to zero did not change the offset. HAL could also restore the physical input channels in the composition readback.
+- A stacked aggregate suppressed the phantom Scarlett input channels, but retained the 74-frame input safety offset.
+- Adding subdevices never reduced the main device's margin. It could only raise the other scope.
+- A TimeSync clock doubled the Scarlett margins from 74/14 to 148/28 and made the physical output a drift-corrected member.
+- Negative extra-latency values clamped at zero. Positive values raised the aggregate safety offset exactly.
+- Aggregate buffer sizes of 16, 512, and 4,096 frames did not change either safety offset.
+- The aggregate safety-offset property was not writable.
+
+The last genuinely supported candidate was `AudioHardwareAggregateDevice.setClockSource(_:)`. Apple permits a device, clock, or tap as the requested clock source, so a device-scoped tap looked like a possible way to retain the physical output stream without importing the whole device's input margin.
+
+It did not work. On both the Scarlett and D10s, asking for the tap before I/O, during I/O, or through the aggregate composition still published the backing physical device as the clock source and retained 74/14. A tap-only aggregate published no clock source but kept the same margins. Neither USB device exposed a separate `AudioHardwareClock` object. The device-scoped tap carries its backing device's timing margins with it.
+
+This closes the supported app-level design space. The aggregate's tap-to-output scheduling cost is:
+
+`input safety offset + one callback + output safety offset + one callback`
+
+GlassEQ controls the callback size. The physical output driver controls both safety offsets. Removing the USB driver's 74 frames would require a custom audio driver or system extension, which would add installation, approval, maintenance, and probably another clock domain to recover 1.542 ms at 48 kHz. That is not a sensible product trade.
+
+## Silent Core Audio clients can prevent a route reset
+
+Stopping GlassEQ and pausing Music did not make the Scarlett idle. `kAudioDevicePropertyDeviceIsRunningSomewhere` remained set for more than 40 seconds.
+
+A query of Core Audio's process objects identified Firefox as a running output client. Firefox was not producing audible sound, but it still claimed the default output route. After Firefox quit, the Scarlett immediately became idle. We held that state for five seconds, then started GlassEQ. Both the 32-frame and subsequent 16-frame runs were clean.
+
+This is useful diagnostic evidence, but it is not an acceptable startup constraint. GlassEQ cannot require users to close browsers, media players, or other silent clients before it starts.
+
+### Aggregate-only buffer tuning fixes the shared-device startup problem
+
+The most suspicious shared-state mutation was GlassEQ's physical-device buffer tuning. The first startup path wrote the preferred frame count to the physical output before creating the aggregate, then applied the resulting size to the private aggregate as well. Changing the physical device could disturb every client using the route.
+
+The Scarlett measurements showed that this coupling was unnecessary. The physical device continued to report a 512-frame buffer while GlassEQ's private aggregate delivered stable 32-frame and 16-frame callbacks.
+
+GlassEQ now leaves the physical device's buffer-frame property alone and requests 16 frames only on its private aggregate. This passed the cases that had previously exposed the bad route state:
+
+- The physical Scarlett remained at 512 frames while the aggregate delivered 16-frame callbacks.
+- The physical AirPods route remained at its Core Audio-owned size while the aggregate delivered 16-frame callbacks.
+- GlassEQ no longer waits for the physical device to become idle or requires a silent Firefox client to release it.
+- Normal playback, restarts, and output switching remained clean.
+
+HAL still owns any internal work needed to connect the aggregate to its subdevice, but GlassEQ no longer mutates shared physical-device state. Waiting for `DeviceIsRunningSomewhere == 0` remains a diagnostic reset procedure, not product behavior.
+
+## AirPods also accept 16-frame aggregate callbacks
+
+We removed the Bluetooth-specific 64-frame preference and started the release app on an active AirPods Pro route at 48 kHz. Core Audio accepted the request rather than clamping it:
+
+- Capture callback peak: 16 frames
+- Output callback peak: 16 frames
+- Tap-to-output latency: 0.667 ms
+- Captured and played: 3,288,864 frames each
+- Underruns, dropped input, and saturated samples: zero
+- Subjective playback: clean, with no crackle heard
+
+The latency number ends at the Bluetooth output timestamp. It does not include the AirPods codec, radio, or internal playback buffering, so it is not an estimate of acoustic latency. The result does show that GlassEQ can feed the Bluetooth route in 16-frame aggregate callbacks without adding a larger application-visible scheduling quantum.
+
+## Headset mode exposes a combined-aggregate clock failure
+
+Normal 48 kHz AirPods playback remained clean at 16 frames. When a conferencing app switched the same device into its bidirectional 24 kHz headset mode, the combined aggregate produced an audible timing disturbance about every 60 ms.
+
+The failure did not look like ordinary starvation:
+
+- Audio kept playing rather than dropping out completely.
+- Capture and output callbacks continued at their expected sizes.
+- Underrun, dropped-frame, and saturation counters remained at zero.
+- Input and output timestamp-discontinuity counters accumulated together.
+- Leaving headset mode immediately restored clean 48 kHz playback without a persistent fault.
+
+Increasing the aggregate target, disabling tap drift compensation, and enabling tap mixdown did not fix the disturbance. Mixdown also carries the severe latency penalty described above. Aggregate-only buffer tuning kept the physical headset route at its Core Audio-owned 480-frame buffer and the private aggregate at 16 frames, but the periodic timestamp jumps remained.
+
+The preserved separate-clock GlassEQ implementation was clean on the same 24 kHz route. In that run it used 64-frame tap capture, a 480-frame physical-output callback, 48-to-24 kHz conversion, about -1.4 ppm of clock correction, and a 2,047-to-2,048-frame reservoir. Its occupancy-derived bridge latency was about 42.65 ms.
+
+This points to a route-specific combined-aggregate timeline problem, not a general inability to run the device or process its low-rate format. The application-managed bridge is slower, but it prevents the aggregate's input and output timestamp jumps from reaching the physical output as audible jitter.
+
+GlassEQ therefore starts Bluetooth routes at 24 kHz or below on the separate-clock backend. Entering headset mode switches to that backend; leaving it restores the normal combined aggregate. The original hybrid release switched both ways without a relaunch, and subjective playback in headset mode was clean.
+
+### Timestamp probe confirms a transitional HAL clock mismatch
+
+A forced-combined diagnostic recorded the raw input and output `AudioTimeStamp` values for every discontinuity. The callback wrote into a preallocated 64-record circular buffer and copied it only after Core Audio stopped.
+
+The first run began on the 48 kHz AirPods route and captured the switch into 24 kHz headset mode. The next run started while the physical device and combined aggregate both reported 24 kHz. During the broken period it recorded:
+
+- 95 input jumps and 95 output jumps, paired in the same callbacks
+- A repeating jump cadence of approximately 50 ms, 50 ms, and 60 ms
+- 16-frame input and output callbacks throughout
+- Zero underruns and dropped frames
+- Identical sample-time and host-time errors on input and output
+- `mRateScalar` fixed at `1.0`
+- `mFlags` fixed at `0x7`, marking sample time, host time, and rate scalar as valid
+
+The raw timestamps exposed the inconsistency. Between jump records, `mSampleTime` advanced at 48,000 units per second even though both devices advertised 24 kHz. At each discontinuity, the callback arrived 11.667 to 18.333 ms later than its 16-frame cadence predicted, and `mSampleTime` skipped the corresponding interval on the same 48 kHz scale. The recurring positive sample-time errors were 576, 736, and 896 frames.
+
+After roughly five seconds, Core Audio issued one large negative sample-time reset of 238,828 frames. The periodic jumps then stopped. A later forced-combined run started only after Teams headset mode had fully settled. Both the physical device and aggregate reported 24 kHz, 239,584 frames passed in ten seconds, and the probe recorded no timestamp discontinuities.
+
+The headset failure is therefore transitional rather than an inherent inability to run a combined aggregate at 24 kHz. HAL can publish the new nominal rate before the aggregate timeline has stopped advancing on the old 48 kHz scale. It reports the timestamps as valid and keeps `mRateScalar` at `1.0`, so the application receives no metadata warning. Since the aggregate presents one input/output callback, the same clock correction reaches both sides and becomes audible.
+
+The separate-clock fallback remains the safe behavior during the transition. The experimental policy now uses it while the headset route settles, verifies the physical device clock, and only then tries the combined aggregate. The clean steady-state test makes that plausible, but repeated hardware transition testing is still required before treating it as proven product behavior.
+
+### Experimental transitional headset promotion
+
+The first implementation keeps the compatibility backend running for six seconds after a low-rate Bluetooth route starts. It then samples the physical device clock for another 500 ms and requires `mSampleTime` to advance within two percent of the advertised sample rate. A valid `mRateScalar` must also remain within two percent of `1.0`.
+
+If the clock agrees, GlassEQ creates the combined aggregate and watches its paired input/output timestamp-discontinuity counter for 750 ms before accepting it. A failed clock check or an immediate aggregate jump restores the already-proven separate-clock backend. GlassEQ makes only one promotion attempt per output transition, so a rejection cannot create a rebuild loop.
+
+After promotion, the normal settled-route timestamp monitor remains active. One qualifying paired input/output discontinuity returns that route to compatibility mode for the rest of the output generation. This failure is deliberately kept out of the ordinary 16-to-32-to-64 aggregate-buffer ladder: the headset fault is a clock-domain transition problem, not evidence that the callback quantum is too small.
+
+This policy avoids maintaining the bridge as the permanent low-rate playback path while retaining it as a bounded transition and recovery mechanism. It is covered by lifecycle and clock-slope tests. A real AirPods and Teams test confirmed that the route can settle in compatibility mode and promote to the combined aggregate. The first handoff caused a small playback jump, but steady combined playback was clean. The refined handoff now prepares the replacement output before quiescing the old backend; the remaining transition artifact stays on the hardware soak checklist.
+
+### Teams can publish its own output route
+
+Teams did not always switch the existing physical device into another format. With the Scarlett active, it exposed a separate `Microsoft Teams Audio` output with UID `MSLoopbackDriverDevice_UID`. Core Audio reported one channel at 48 kHz, GlassEQ obtained 32-frame capture and output callbacks, and tap-to-output measured 1.33 ms with clean counters.
+
+GlassEQ treated it as an ordinary output device and used the fallback profile because it had its own UID. This is the right behavior. Conferencing mode should follow the actual Core Audio route, transport, format, and clock evidence. An application denylist would miss virtual devices like this and would disable working routes for no technical reason.
+
+## The `isMixdown` trap
+
+The device-scoped tap must use the selected hardware stream's native format. Setting `CATapDescription.isMixdown` to `true` looked like a reasonable way to retain support for multichannel streams, but it restored the old 43.500 ms latency on the Scarlett.
+
+Removing `isMixdown` immediately restored 4.500 ms under otherwise identical conditions.
+
+This was the decisive variable. The low latency does not come merely from naming a device in the tap description. It requires all of the following:
+
+- A device-scoped tap
+- One selected output stream
+- The stream's native format
+- No Core Audio tap mixdown
+
+The current implementation therefore accepts native mono and stereo output streams and rejects wider streams. It does not silently fall back to the high-latency mixdown path.
+
+## Scarlett microphone indicator
+
+The combined aggregate exposed the Scarlett's physical input before the process-tap input, even though the aggregate description requested zero physical input channels. Its 74-frame input-side margin happened to match the Scarlett input metadata, which initially made the two look causally related. The output-only D10s later reported and imposed the same 74 frames.
+
+The initial device-scoped experiment caused macOS to show the microphone-use indicator. This was a real input activation, not merely a misleading icon.
+
+GlassEQ now configures `kAudioDevicePropertyIOProcStreamUsage` for its aggregate IOProc. On the Scarlett, the input usage mask is `[0, 1]`: the physical input stream is off and the process-tap stream is on. GlassEQ reads the property back and refuses to start unless Core Audio applied the requested mask.
+
+Disabling the physical stream did not change the 4.500 ms latency. It removed the microphone indicator, retained 64-frame callbacks, and produced null data for the disabled physical-input buffer. The callback skips that buffer and reads the following tap stream.
+
+An audible test also passed. Both test phrases reached the Scarlett output with the physical input disabled.
+
+## Experiments that did not explain the result
+
+Several plausible explanations turned out to be wrong:
+
+- Disabling aggregate drift compensation did not change the original 43.500 ms result.
+- The Scarlett's physical input explained the microphone indicator, but not the 74-frame scheduling term. The output-only D10s imposed the same term, and disabling the Scarlett input did not change latency.
+- The sub-tap runtime latency property was absent or not writable.
+- Adding 64 frames to the aggregate composition's sub-tap latency was retained in metadata but did not change callback timing.
+- A negative sub-tap latency made the aggregate unusable. It exposed no valid latency metadata and delivered no callbacks.
+
+The scope and format of the process tap were what mattered.
+
+## Ad hoc builds can lose capture permission until relaunched
+
+The first launch of the hybrid release produced one saturated sample, then complete silence, at the same time macOS displayed a new permission prompt. System Settings showed that the prompt was for System Audio Recording, not microphone access. GlassEQ was enabled there and was absent from the Microphone permission list.
+
+The newly ad hoc-signed bundle had received permission while the process was already running. Its callbacks continued, but the process tap delivered silence. Relaunching the same build after the grant restored clean audio. The saturated sample did not cause the silence.
+
+Development builds have a code-directory-hash designated requirement, so rebuilding an ad hoc app can make macOS treat it as a new capture identity. A stable Developer ID signature should avoid this per-build identity churn. During development, a new system-audio prompt means the running process must be relaunched before audio results are meaningful.
+
+## System alerts need a separate low-latency path
+
+The preference-based scheme in this section was the first working mitigation. The later two-tap experiment superseded it, but the intermediate result remains useful because it established how `systemsoundserverd`, direct I/O, and the Alert volume preference behave.
+
+At 16 frames, a sound played by `systemsoundserverd` could open a second direct I/O context on the physical output. Some of those starts caused a Core Audio safety violation and a paired aggregate timestamp jump. The same registered alert was clean when GlassEQ excluded the daemon's Core Audio process object from its tap. Repeated tests then produced direct system-alert I/O with no aggregate overloads or timestamp discontinuities.
+
+A later screenshot on the D10s advanced the input and output timestamp-jump counters together by one. The screenshot produced no notification sound, and a three-minute unified-log window contained no matching public Core Audio overload or safety-violation message. This still has the signature of one aggregate-timeline discontinuity rather than independent capture and playback faults, but its trigger remains unproven. It is a transient route event, separate from the steady safety offsets measured above.
+
+Excluding the daemon means alerts no longer pass through the profile preamp. That is unsafe with a large negative preamp because a listener may compensate downstream, making an unprocessed notification much louder than the music.
+
+macOS stores the user-facing Alert volume slider in the global `com.apple.sound.beep.volume` preference. A live experiment changed the value from `1.0` to `0.501187`, played the same alert, and observed `systemsoundserverd` use `user vol 0.501187` immediately. No daemon restart was required. The already-open System Settings pane also moved its Alert volume slider from 100 percent to about 31 percent. The slider uses a nonlinear perceptual mapping, while the preference and daemon log use the audio gain scalar. Restoring the preference to `1.0` updated both the next alert and the visible slider.
+
+The experimental build applied the active profile's negative preamp to that Alert volume while the combined aggregate was running:
+
+`adjusted alert volume = original alert volume * 10^(min(preamp dB, 0) / 20)`
+
+Stereo profiles used the more negative channel preamp. Positive preamp never raised the alert volume. The original value was restored on bypass, backend changes, normal stop, sleep, and termination.
+
+The adjustment had its own atomic restoration record. On launch, GlassEQ restored an interrupted session only when the current preference still matched a value GlassEQ wrote. While processing was active, GlassEQ checked the preference twice per second. A value other than the last compensated value had to remain stable for two checks before it became the user's new base volume, so GlassEQ did not fight an in-progress slider drag. GlassEQ then reapplied the current preamp from that base. Stopping restored the newest base rather than the value from before the manual change. If GlassEQ stopped before it observed a manual change, it left the different current value alone. A live owner process also prevented another GlassEQ process from taking over the same setting.
+
+App Sandbox blocked real changes to the global preference unless the signed app had the shared-preference read-write exception for both `.GlobalPreferences` and `kCFPreferencesAnyApplication`. Granting only `.GlobalPreferences` was deceptive: Core Foundation updated its process-local cache and read back the adjusted value, but synchronization returned `false` and the stored preference stayed unchanged. A sandboxed probe with both domains successfully applied and restored a different value. The experimental build therefore required the complete entitlement pair. The final two-tap implementation removes both the preference writer and those exceptions.
+
+This preference key is not a documented app-facing macOS API. The experimental implementation kept it isolated and verified every write by reading the value back. Removing it also removes that compatibility risk.
+
+## Two device-scoped taps remove the preference workaround
+
+The alert-volume experiment solved the immediate loudness mismatch, but it changed a global user preference and covered only sounds that honor `com.apple.sound.beep.volume`. The screenshot sound exposed that limitation.
+
+A read-only Core Audio process trace showed that both the Settings "Boop" alert and the screenshot sound come from `systemsoundserverd`. They do not share the same upstream volume behavior:
+
+- Boop responds to the macOS Alert volume slider.
+- The screenshot sound does not respond to that slider.
+- `Screen Capture.aif` is also intrinsically quieter than `Tink.aiff`: its measured peak was -13.89 dBFS rather than -8.77 dBFS, and its RMS level was -34.66 dBFS rather than -28.70 dBFS.
+
+One global preference therefore cannot match every system sound to GlassEQ's gain. The daemon itself is the useful boundary.
+
+GlassEQ now creates two private, muted, device-scoped, non-mixdown taps for the selected output stream:
+
+| Tap | Included audio | Processing |
+| --- | --- | --- |
+| Main tap | Every process except GlassEQ and `systemsoundserverd` | Profile preamp and filters |
+| System-sound tap | Only `systemsoundserverd` | Profile preamp only |
+
+Both taps belong to the same private aggregate and arrive in the same IOProc callback. GlassEQ processes the main samples, adds the preamp-adjusted system-sound samples, applies the existing output fade, and writes the result to the physical output. The mix needs no ring buffer, extra callback, or additional scheduling quantum.
+
+This keeps notifications out of the profile filters without allowing them to bypass the profile preamp. Muting the tap removes the daemon's dry system-sound output from the final mix, but it does not prevent `systemsoundserverd` from starting its own physical-output AudioUnit and I/O context. The source still has to render before Core Audio can supply samples to the tap.
+
+The release test passed audibly for both Boop and screenshots. The macOS Alert preference remained at its restored user value, `0.6535`, after GlassEQ launched. The listener also reported that alerts were no longer drowned out in a setup with macOS output and Apple Music both at 100 percent and volume controlled on the amplifier.
+
+The two-tap route did not eliminate every timestamp correction. A screenshot taken after several minutes without a system sound still produced a one-frame input jump and a matching one-frame output jump. Screenshots taken soon afterward did not.
+
+A focused Core Audio trace caught the cold event. `systemsoundserverd` started a fresh D10s I/O context when it began rendering the screenshot sound. Core Audio then reported `SafetyViolationOccurred` against GlassEQ with an I/O buffer size of 16 frames, `lateness: 14`, and a safety-violation time gap of 0.000375 seconds. At 48 kHz, that 0.375 ms gap is about 18 frames and slightly exceeds one 16-frame callback budget. A warm system sound 17 seconds later started the same context without an overload.
+
+This connects the paired one-frame correction to cold Core Audio graph startup, not accumulated clock drift. The tap removes the dry playback, but it cannot stop the source process from opening the physical-output graph it needs in order to render. The exact event produced a diagnostic correction; no audible crack was reported during that test.
+
+### Topology hardening
+
+The first implementation resolved the current Core Audio process object IDs when it built the taps. That leaves a daemon-restart risk because a new `systemsoundserverd` instance may receive a new process object.
+
+macOS 26 adds `CATapDescription.isProcessRestoreEnabled`. Both taps now enable it, allowing Core Audio to restore matching processes by bundle ID when they restart.
+
+A later cold launch exposed a related startup flaw. `systemsoundserverd` was running as a daemon but had not yet published a Core Audio process object, so resolving its transient object ID made the whole audio engine fail. macOS 26 also lets a tap description include or exclude `bundleIDs` directly. GlassEQ now names `systemsoundserverd` that way in both tap descriptions. The system-sound tap can therefore be created while the daemon is dormant, and Core Audio attaches the daemon when its audio process appears. GlassEQ still excludes its own live process object explicitly.
+
+GlassEQ also reads the aggregate composition back before starting I/O. It requires exactly the two expected tap UIDs and their requested drift settings. The returned UID order determines the input channel offsets. If HAL returns the taps in the opposite order, GlassEQ follows that order. If a tap is missing, duplicated, unknown, or has the wrong drift setting, startup fails rather than applying the wrong processing to either stream.
+
+A focused build disabled drift compensation only for the normally dormant system-sound tap while leaving the main tap unchanged. The same cold screenshot still produced one input jump and one output jump. Secondary-tap drift compensation is therefore not the cause of the re-anchor, and both taps retain high-quality drift compensation in the final configuration.
+
+The final mix has one remaining gain-stage risk. Music processed by the main path can already approach full scale before a system sound is added. GlassEQ uses the same smooth saturation curve as the EQ path for samples that overload during this addition and increments the saturated-sample counter. This prevents hard clipping, but repeated saturation can still make a loud notification over loud music sound compressed. It needs deliberate soak testing with hot profiles and positive preamp values.
+
+## Resulting hybrid architecture
+
+The normal-rate fast path uses this design:
+
+1. Find the default output and its preferred stereo pair.
+2. Select the native mono or stereo hardware stream containing that pair.
+3. Create a private muted main tap bound to the output UID and stream. Exclude GlassEQ itself and `systemsoundserverd`.
+4. Create a second private muted tap for only `systemsoundserverd`, bound to the same output UID and stream.
+5. Enable process restoration on both taps so Core Audio can follow daemon restarts by bundle ID.
+6. Create one private aggregate containing both taps and the physical output.
+7. Make the physical output the aggregate's main subdevice and retain high-quality drift compensation for both taps.
+8. Read the composition back, validate both tap UIDs and drift settings, and derive their input channel offsets from HAL's returned order.
+9. Create one IOProc for the aggregate.
+10. Disable every aggregate physical-input stream, enable both process-tap streams, and verify the readback.
+11. Apply the full profile to the main tap, apply only the active preamp to the system-sound tap, and mix them in the same callback.
+12. Recreate both taps and the aggregate when the selected output UID or stream changes.
+
+There is no application-owned audio queue, clock servo, resampler, or priming state on this path. GlassEQ requests 16 frames only from the private aggregate and does not tune the physical device.
+
+Bluetooth routes at 24 kHz or below start on the separate-clock fallback:
+
+1. Keep the muted process tap in a tap-only private aggregate.
+2. Capture at the tap's rate and feed a preallocated stereo ring buffer.
+3. Drive the physical output with a separate HAL callback at its device-owned rate and callback size.
+4. Use the occupancy servo and realtime PCM conversion to bridge the two clock domains.
+5. After the route settles, verify the physical clock slope and attempt promotion to the combined fast path.
+6. Return to compatibility mode for the rest of that output generation if validation or a later paired discontinuity fails.
+
+This retains the old complexity only as a transition and recovery path where the combined clock domain has been shown to fail audibly.
+
+## Soak-test results so far
+
+The release implementation has passed the edge cases exercised so far:
+
+- D10s and Scarlett Solo
+- Output-device switching
+- Bluetooth switching
+- Entering and leaving Teams headset mode without a relaunch
+- Sleep and wake
+- Notifications
+- Repeated start and stop
+- Verified 64-frame baseline runs on normal-rate routes
+- Clean 32-frame and 16-frame Scarlett listening runs, including 16 frames without physical-device buffer tuning
+- Clean 16-frame AirPods Pro playback with 0.667 ms tap-to-output scheduling
+- Clean AirPods Pro headset-mode playback through the automatic separate-clock fallback
+- No observed underruns or dropped input frames
+- No microphone indicator with the physical-input stream disabled
+- Roughly 1 to 2 percent CPU use in the release app
+- Audible Boop and screenshot tests through the dedicated system-sound tap
+- No change to the user's Alert volume preference after the two-tap build launched
+
+The verified Scarlett latency results are 4.500 ms at 64 frames, 3.167 ms at 32 frames, and 2.500 ms at 16 frames. Normal 48 kHz AirPods playback measured 0.667 ms to the Bluetooth output timestamp at 16 frames. The unsettled headset interval uses the slower bridge by design; its diagnostic figure is bridge occupancy, not a directly comparable tap-to-output timestamp measurement. A promoted steady headset route returns to the aggregate measurement.
+
+## Remaining constraints
+
+The architecture is much simpler, but it is not universal:
+
+- The fast path currently supports native mono and stereo hardware streams. A multichannel stream would require broader native-stream handling. Core Audio's tap mixdown is not an acceptable fallback because it restored 43.5 ms on the Scarlett.
+- A device-scoped tap captures only the selected device and stream. Audio explicitly routed to another device, including a distinct system-alert output, is outside GlassEQ's path.
+- Output switching requires rebuilding the muted tap after macOS reports the new route. No dry-audio leak has been observed, but handoff behavior remains part of soak testing.
+- Virtual devices, multi-output devices, and unusual stream layouts need explicit hardware testing. GlassEQ fails closed if it cannot isolate the tap from physical inputs.
+- The separate-clock headset fallback restores the ring buffer, servo, resampler, priming, and recovery machinery on that route. It also adds roughly 42.65 ms of buffered bridge time in the tested AirPods mode.
+- The current fallback policy is intentionally narrow: Bluetooth transport at 24 kHz or below. Other devices that exhibit the same combined-timeline failure will need evidence-based classification.
+- The dedicated system-sound path depends on macOS continuing to publish these sounds through `systemsoundserverd`. A future daemon split would need another classification rule.
+- A cold `systemsoundserverd` graph start can still cause one paired one-frame timestamp correction at a 16-frame buffer. The captured event was a Core Audio safety violation during physical-output I/O startup, not a drift-compensation failure. Warm sounds did not reproduce it.
+- System-sound handling is not yet equivalent in the separate-clock headset backend. That path still captures the full system mix through one global tap and applies the full profile.
+- Adding system sounds after the main DSP can exhaust output headroom. The smooth limiter prevents hard clipping, but the saturation counter must remain part of soak testing.
+- The second tap's effect on release CPU, safety offsets, and callback timing still needs a recorded before-and-after measurement. The initial listening test proves routing and gain behavior, not long-term timing stability.
+
+## Architecture decision
+
+The criticism of the original separate-clock design was legitimate. Its ring buffer, occupancy controller, servo, resampler, and recovery logic solve real clock-domain problems, but Core Audio can remove those problems when GlassEQ uses the right tap topology on a stable route.
+
+The first aggregate experiment did not prove that a combined aggregate was inherently slow. It proved that a global or mixed-down tap carries a large latency budget into the aggregate.
+
+For the normal-rate native mono and stereo routes tested here, the device-scoped combined aggregate is the preferred architecture. It is simpler than the reference design and reduces measured tap-to-output latency from 26.345 ms to 4.500 ms at 64 frames, 3.167 ms at 32 frames, and 2.500 ms at 16 frames on the Scarlett.
+
+The dedicated `systemsoundserverd` tap closes the largest behavioral gap in that architecture. System sounds now share the aggregate clock and profile preamp without passing through the profile filters or requiring GlassEQ to edit the global Alert volume preference.
+
+The 24 kHz AirPods headset transition is the counterexample. A combined aggregate created before HAL's timeline settles has periodic input and output timestamp jumps that remain audible even with clean application counters. The separate-clock design is slower but clean during that interval. Once the physical sample-time slope agrees with the advertised rate, the combined aggregate can take over again.
+
+The resulting decision is hybrid rather than ideological: use the single-clock aggregate wherever it behaves correctly, and retain the application-managed bridge for low-rate Bluetooth transition and recovery where it has demonstrated a concrete advantage. This preserves the latency and simplicity breakthrough for ordinary playback without accepting broken conferencing audio.
+
+## Adaptive callback-buffer policy
+
+The 16-frame result is real, but it leaves only 0.333 ms between callbacks at 48 kHz. That is smaller than some steady-state delays inside Core Audio. One captured cold system-sound start faulted a `coreaudiod` aggregate-context thread for 0.392 ms while GlassEQ's client I/O thread was waiting. A 32-frame period is 0.667 ms and a 64-frame period is 1.333 ms.
+
+A later run supplied stronger evidence that this is not limited to screenshots. Before a debugger was attached, the runtime probe ring contained 22 paired input/output discontinuity records. The final uncontaminated record advanced both sample timelines by 608 frames at 48 kHz, or 12.667 ms. Both sides delivered 16-frame callbacks, valid sample and host times, and a valid rate scalar of `1.0000057521651913`. Their host-interval errors were 12.664 ms. The same time window contained no public `coreaudiod` or `systemsoundserverd` overload, safety-violation, device-change, or route-change log. Records from sequence 23 onward were discarded because stopping the process in the debugger caused much larger artificial jumps.
+
+GlassEQ therefore treats 16 frames as an optimistic starting point rather than a promise. Automatic mode stores the smallest callback size that has proved reliable for each route fingerprint:
+
+`physical output UID + selected native output stream index + nominal sample rate`
+
+A new fingerprint starts at 16 frames. One qualifying interruption records evidence but does not change the route. A second interruption within five minutes advances that fingerprint from 16 to 32, or from 32 to 64. The evidence window and learned value are persisted, so relaunching cannot either erase one half of a real failure burst or make a single event permanent. Existing Automatic records written by the earlier one-shot policy reset to 16 because they do not contain enough evidence to satisfy the new rule; explicit fixed-size choices remain intact. Changing the native stream or sample rate creates a separate record because the same device can behave differently in another format or transport mode.
+
+The automatic policy does not learn from every diagnostic counter change. It requires all of the following:
+
+- The aggregate has been running for a two-second settling period.
+- No start, rebuild, output change, or sample-rate change is in progress.
+- The route UID, native stream, and nominal rate still match the fingerprint.
+- Both the input and output sample timelines jump in the same callback.
+- Both timelines had at least eight consecutive callbacks with valid timestamps, nominal sample-time progression, host-time slope within the callback tolerance, and a sane rate scalar before the jump.
+
+Once the safer aggregate has started successfully, GlassEQ posts a silent notification explaining that it increased this route's audio buffer. Opening the notification selects the Output pane. That pane exposes Automatic and fixed 16-, 32-, and 64-frame modes. A fixed choice disables learning for that route. Automatic also offers **Retry 16 frames**, which clears the learned rung for the current fingerprint without affecting other devices, streams, or rates.
+
+Automatic learning is reversible. A settled aggregate run counts as clean after five uninterrupted minutes without a qualifying discontinuity. Three clean runs lower the persisted value by one rung and rebuild the route at that size for revalidation. Any qualifying interruption resets the clean-run count. A route learned at 64 therefore retries 32 before 16, and any new failure burst moves it back up through the same two-event rule.
+
+Startup now includes a bounded topology warm-up. GlassEQ starts the aggregate muted, lets both tap inputs and the output IOProc run for 32 callbacks, and then fades processing in. The wait is capped at 100 ms so a disconnected route cannot stall startup indefinitely. This warms GlassEQ's own aggregate and callback storage, but it cannot force a dormant source such as `systemsoundserverd` to construct its separate physical-output graph. Arbitrary steady-state Core Audio stalls therefore remain possible, and the adaptive ladder is still required.
+
+This changes the product meaning of the buffer setting. Automatic means “the lowest latency this exact route has demonstrated reliably,” not “always 16 frames.” The user may override that conclusion for experiments. GlassEQ requires a short failure burst before moving up and periodically retries lower rungs after clean use, so neither one cold-path event nor one bad session becomes a permanent verdict.
+
+## Whole-bank transitions and the render watchdog
+
+The aggregate graph no longer needs a rebuild when the profile topology changes. GlassEQ prepares a complete processor bank away from the realtime callback, warms it with live input, and crossfades it into the active bank over 10 ms. Biquad banks receive 20 ms of live history. A convolution bank receives 16,383 frames so every tap of its impulse history is valid before the blend begins.
+
+This matters for more than cosmetic editing. Filter-count changes, channel-mode changes, bypass, and biquad-to-convolution changes can all replace the DSP bank without stopping Core Audio. The old bank continues producing output during warm-up. Only the newest pending edit survives, and retired banks are released outside the callback.
+
+The first bypass test found a real lifecycle bug. Applying a bypassed bank while Music was playing left the output silent until Apple Music stopped and GlassEQ was disabled and re-enabled. After correcting the transition state, the same operation recovered normally and repeated tests no longer lost output.
+
+A separate watchdog observes render progress without touching the callback. One three-second steady-state stall stops and rebuilds the engine once. A second stall within 60 seconds stops processing and restores direct system playback until the user retries. The manual fault-injection test reached the intended final state and reported that rendering had stalled again instead of entering a rebuild loop.
+
+The deadline recovery policy handles shorter bursts. Three missed callbacks within one second trigger remediation. Automatic mode follows its persisted route-specific ladder. A fixed buffer first rebuilds at the user's chosen size, then temporarily climbs through 32 and 64 frames if bursts recur within 60 seconds. It does not overwrite the fixed preference. Another burst at 64 stops processing. This cannot guarantee continuity during arbitrary scheduler stalls, but it can recover from the shorter poisoned states observed during ordinary use.
+
+## Programme-loudness-matched A/B comparison
+
+Ordinary EQ bypass is a poor listening comparison. It removes the filters and often removes the profile preamp too, so the louder branch tends to sound better before the frequency response gets a fair hearing.
+
+GlassEQ's A/B path renders two branches from the same input:
+
+| Branch | Preamp | Filters |
+| --- | --- | --- |
+| EQ | Active profile preamp | Active biquads or response curve |
+| Filters Off | Same linked or per-channel preamp | None |
+
+The comparison is transient render state. It does not mutate or persist the profile. For convolution profiles, Filters Off removes the response curve and switches the reference processor back to the parametric path, but keeps the preamp and keeps bypass disabled.
+
+Both branches run through BS.1770 K-weighting. The matcher stores thirty 100 ms energy segments, forms 400 ms gating blocks, and applies the same absolute and relative programme gate to both branches. Using a shared gate matters because independent gates could compare different passages of the song. The rolling history covers up to three seconds.
+
+GlassEQ attenuates only the louder branch. It never boosts the quieter one, which preserves the headroom already available in the profile. Gain changes settle over 500 ms, while switching between EQ and Filters Off uses the same 10 ms smoothstep blend as other bank transitions. Leaving comparison first returns to the EQ branch, restores any temporary matching attenuation, and then returns to the saved active profile.
+
+The first live attempt exposed a readiness bug: Matched never arrived even with music playing. After fixing publication of the realtime comparison snapshot, the match became ready, switching both ways worked, and returning to normal processing was clean. This confirmed the whole workflow with a real programme rather than only synthetic energy tests.
+
+## Minimum-phase FIR without added tap-to-output latency
+
+Response Curve profiles now compile frequency and gain points into a 16,384-tap minimum-phase impulse. The compiler uses log-frequency interpolation with linear dB gain, clamps below the first point and above the last point, constructs the even log-magnitude spectrum, performs the even-length cepstral lift, exponentiates the resulting complex log spectrum, and transforms it back into a causal impulse. The persisted source contains the curve points and a synthesis version, not the generated samples.
+
+The realtime processor is a hybrid convolver:
+
+- The first 512 taps run as a vectorized direct head and produce tap zero immediately.
+- The remaining 15,872 taps form 62 partitions of 256 frames.
+- Each partition uses a 512-point real transform.
+- Tail work is spread across sample-frame progress and has a 16-frame guard before the inverse transform is due.
+- All transform setups, storage, and Accelerate paths are allocated and prewarmed before the bank reaches the callback.
+
+The scheduler uses absolute sample frames rather than callback count. That distinction is necessary because a 480-frame render callback can cross more than one internal 256-frame boundary. Random and deliberately hostile chunk sequences are compared continuously with direct convolution, including seams around taps 510 through 514 and every partition boundary.
+
+Minimum phase does not make a 16,384-tap filter computationally cheap by itself. Partitioned convolution does. Minimum phase places useful impulse energy near time zero and avoids a linear-phase delay, while the direct head makes that first output available in the current callback. The tail is computed before its samples become due. The result adds DSP work but no fixed buffering and no tap-to-output scheduling term.
+
+The live D10s run confirmed that distinction. A Response Curve at 48 kHz with 32-frame aggregate callbacks still reported 3.17 ms tap-to-output, exactly the existing safety-offset and callback model. There was no convolution latency surcharge.
+
+The fixed tap count has a sample-rate trade-off:
+
+| Sample rate | Bin spacing | Impulse support |
+| ---: | ---: | ---: |
+| 48 kHz | 2.93 Hz | 341 ms |
+| 96 kHz | 5.86 Hz | 171 ms |
+| 192 kHz | 11.72 Hz | 85 ms |
+
+That is ample for smooth headphone correction but can become coarse for narrow low-frequency room correction at high sample rates. EqualizerAPO `GraphicEQ:` import is implemented and was exercised with a real Sennheiser HD 58X curve. Imported arbitrary impulse responses, starting with REW WAV exports, remain separate work because their supplied samples and phase are the source material and must be preserved.
+
+## Torture testing and the actual realtime limit
+
+A six-minute screen-recorded torture run drove the machine close to zero idle CPU. Slight crackles coincided with timestamp jumps. The same failure pattern occurred with a biquad profile and with convolution, which made it unlikely that the FIR engine itself was poisoning the route.
+
+The useful diagnostic split is:
+
+| Category | Meaning |
+| --- | --- |
+| Start starvation | The callback was already at least one full period late when GlassEQ entered it. |
+| Render overrun | The callback started in time, but GlassEQ's DSP itself consumed at least one full callback period. |
+| Paired discontinuity | HAL advanced both input and output timelines across a lost or skipped service interval. |
+
+The categories can overlap. A late callback may still complete in time relative to its delayed start, and one starvation event may or may not force HAL to rebase both timelines.
+
+The final 48 kHz D10s capture at 32 frames provided a clean example:
+
+| Diagnostic | Result |
+| --- | ---: |
+| Render deadline misses | 2 |
+| Start starvations | 2 |
+| Render overruns | 0 |
+| Paired discontinuities | 1 |
+| Captured / played frames | 3,181,984 / 3,181,984 |
+| Underrun / dropped / saturated samples | 0 / 0 / 0 |
+| Capture / output callback peak | 32 / 32 frames |
+| Callback start late, p99.99 / maximum | 116.00 / 10,237.08 us |
+| FIR direct head, p99.99 / maximum | 5.00 / 6.75 us |
+| FIR scheduled tail, p99.99 / maximum | 16.50 / 42.62 us |
+| Total render, p99.99 / maximum | 23.25 / 75.08 us |
+| Completion late, p99.99 / maximum | 0.25 / 9,645.50 us |
+| Tail completion | 0 frames minimum slack, 0 misses |
+| Input / output timestamp jumps | 1 / 1 |
+
+A 32-frame callback at 48 kHz has a 666.67 us period. GlassEQ's worst measured render took 75.08 us, while the worst callback started 10.24 ms late. Both deadline misses were start starvation, only one became a paired HAL discontinuity, there were no render overruns, and the partitioned tail never missed its own due frame. macOS did not schedule GlassEQ in time. The FIR scheduler did not accumulate debt.
+
+The longer torture run also produced operating-system absences on the order of 45 ms. No 16-, 32-, or 64-frame low-latency policy can hide that. Adding 128- or 256-frame rungs only to make an artificial CPU-apocalypse test look cleaner would add product complexity and latency during conditions where the rest of the machine was already visibly unusable.
+
+### Output repair after a paired discontinuity
+
+GlassEQ now remembers the last emitted sample for each channel. When both HAL timelines jump, it smooths from that sample into the resumed programme over 1.333 ms, scaled by sample rate. This de-clicker runs after the DSP, system-sound mix, and output fade. It adds no look-ahead or buffering.
+
+The repair made the crackle less sharp in the manual test, but the interruption remains audible because the source contains an actual gap. A 1.333 ms blend can smooth the reconnection edge. It cannot recreate 10 or 45 ms of missing audio. Hiding those gaps would require carrying a reservoir at least as large as the scheduler stall, which would give back the low-latency result the aggregate architecture was built to obtain.
+
+The current policy is therefore deliberate. Smooth the edge, classify the cause, recover through the buffer ladder when ordinary contention repeats, and stop safely when the operating system disappears for longer than a low-latency engine can cover.
+
+## Current working conclusions
+
+- A device-scoped, native-format, non-mixdown tap is the key to the low-latency aggregate. The first global-tap aggregate measured the wrong architecture.
+- The fixed tap-to-output cost is the physical device's input and output safety offsets. USB's 74-frame input value is a driver constant GlassEQ cannot remove through supported aggregate controls.
+- Sixteen-frame callbacks are real on the private aggregate, even when the physical device reports a much larger shared buffer. Automatic mode treats 16 as an experiment and learns 32 or 64 per device UID, native stream, and sample rate when steady-state evidence demands it.
+- A single aggregate is the normal backend. The separate-clock bridge remains useful for the unsettled part of low-rate Bluetooth headset transitions and for rollback, not as the permanent headset renderer.
+- System sounds need their own device-scoped tap so they keep the profile preamp without passing through the EQ filters. Cold `systemsoundserverd` graph startup can still provoke a HAL correction at 16 frames.
+- Whole-bank transitions let profile topology change without rebuilding Core Audio. The watchdog and deadline ladder cover stalled or poisoned render sessions without rebuilding the graph.
+- Programme-loudness A/B keeps the preamp, compares the same programme windows, and attenuates only the louder branch. It avoids the usual louder-is-better bypass bias.
+- The 16,384-tap minimum-phase response curve adds compute but no fixed tap-to-output latency. The head is immediate and the partitioned tail completes against frame deadlines.
+- Under severe contention, the measured failure was callback start starvation. Biquads and FIR failed in the same way, FIR render cost stayed far below one callback period, and the tail scheduler recorded no debt.
+- No application can make a low-latency stream continuous when macOS fails to schedule it for 10 to 45 ms. GlassEQ can soften the return and recover, but actually concealing the hole requires latency paid in advance.

--- a/Docs/AlphaTesting.md
+++ b/Docs/AlphaTesting.md
@@ -43,6 +43,9 @@ Run through this checklist with the exact downloaded build:
 - Toggle bypass and confirm audio still plays.
 - Change a 10-band or 31-band EQ setting and confirm the sound changes.
 - Import a small AutoEQ / EqualizerAPO profile if available.
+- Import an EqualizerAPO `GraphicEQ:` profile and confirm it opens as a Response Curve with editable frequency/gain points.
+- Preview and apply a Response Curve while music is playing. Confirm the old response remains uninterrupted during the roughly 341 ms history warm-up and the transition itself is click-free.
+- Start programme-loudness A/B from a Response Curve. Confirm Filters Off retains the profile preamp, matching eventually becomes ready, and returning to EQ is clean.
 - Switch the macOS default output device while audio is playing.
 - Test sleep/wake if practical.
 - Quit and reopen GlassEQ.
@@ -68,6 +71,8 @@ swift run GlassEQDiagnostics 2
 ```
 
 For installed-app testing, report the app status text and any visible callback metrics from the GlassEQ UI. If you can reproduce with the checkout diagnostic, include its full output in the bug report.
+
+For a CPU-contention torture test, reset metrics immediately before each run and use the same route, sample rate, buffer size, programme material, and external workload. Run one biquad profile and one Response Curve for long enough to collect well over 10,000 callbacks. Compare Callback Start Late first. If that distribution stays the same but FIR Head, FIR Tail, Total Render, or Completion Late grows, the convolution path is less tolerant of the poisoned deadline. If Callback Start Late itself grows under FIR, the extra DSP or cache footprint is affecting system scheduling. Tail Completion Slack and its miss count distinguish slow execution from an internal tail-scheduling failure.
 
 ## Known Alpha Issues
 

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -21,21 +21,25 @@ Bluetooth routes at 24 kHz or below initially use a separate-clock compatibility
 
 ## Real-Time Rules
 
-The audio render path must not allocate, lock, touch disk, log, parse text, mutate SwiftUI state, or use Combine. UI and import work build a complete candidate processor bank outside the callback. The callback warms that bank for 20 ms, then blends from the active bank with a sample-accurate 10 ms smoothstep ramp. This permits filter-count, mode, and channel-mode changes without rebuilding the Core Audio graph. Only the newest queued edit is retained, and retired banks are released outside the callback.
+The audio render path must not allocate, lock, touch disk, log, parse text, mutate SwiftUI state, or use Combine. UI and import work build and prewarm a complete candidate processor bank outside the callback. Biquad banks receive the normal 20 ms live-input warm-up. A new convolution bank receives 16,383 live frames so its complete impulse history is valid before the same sample-accurate 10 ms smoothstep blend begins. This permits filter-count, profile-type, and channel-mode changes without rebuilding the Core Audio graph or exposing a cold filter tail. Only the newest queued edit is retained, and retired banks are released outside the callback.
+
+Response Curve profiles compile log-frequency, linear-dB magnitude points into a 16,384-tap minimum-phase impulse. The compiler constructs the full even log-magnitude spectrum, performs the exact even-length real-cepstrum lift, and persists a synthesis version with the source points; generated samples are not stored. Rendering uses a 512-tap vectorized direct head and 62 vectorized 256-frame tail partitions with 512-point real FFTs. Tail work is scheduled against absolute sample-frame deadlines rather than callback count, so irregular and 480-frame callback sequences can cross internal block boundaries safely. Every Accelerate path and mutable buffer is exercised and detached before publication to the callback.
+
+The direct head produces tap zero immediately, while the partitioned tail is computed before the corresponding output frames become due. Response Curve processing therefore adds computation but no fixed buffering or tap-to-output latency. The fixed tap count provides 2.93 Hz bins and 341 ms support at 48 kHz, 5.86 Hz and 171 ms at 96 kHz, and 11.72 Hz and 85 ms at 192 kHz. The last case is an explicit bass-resolution limit for future room-correction work.
 
 A watchdog observes render progress outside the callback. One three-second steady-state stall stops the engine before rebuilding it once. Another stall within 60 seconds leaves GlassEQ stopped, restoring direct system audio until the user explicitly retries.
 
 The render callback also counts callbacks that arrive or finish at least one complete callback period late. After the route has settled, three misses within one second form a deadline burst. Automatic mode continues to use its persisted route-specific reliability policy. A fixed mode rebuilds once at the selected size, then temporarily climbs through 32 and 64 frames if bursts recur within 60 seconds. The fixed preference is never overwritten. The temporary rung lasts until the route session ends or the user retries the fixed size. Another burst at 64 frames stops processing.
 
-Programme-loudness A/B comparison is another transient render mode, not a profile mutation. The renderer runs the draft profile and a filters-off reference in parallel; the reference retains the same linked or per-channel preamp gains. Both branches pass through BS.1770 K-weighting and a shared three-second rolling gate so they are measured over the same programme passages. GlassEQ attenuates only the louder branch, smooths match changes over 500 ms, and crossfades A/B selection over 10 ms. Starting and stopping the comparison reuse the whole-bank warm-up and transition path, including a gain restoration before returning to the saved active profile. The measured gains, selected branch, and filters-off reference are never persisted.
+Programme-loudness A/B comparison is another transient render mode, not a profile mutation. The renderer runs the draft profile and a filters-off reference in parallel; the reference retains the same linked or per-channel preamp gains. “Filters off” removes either the biquad bank or the convolution curve. Both branches pass through BS.1770 K-weighting and a shared three-second rolling gate so they are measured over the same programme passages. GlassEQ attenuates only the louder branch, smooths match changes over 500 ms, and crossfades A/B selection over 10 ms. Starting and stopping the comparison reuse the whole-bank warm-up and transition path, including a gain restoration before returning to the saved active profile. The measured gains, selected branch, and filters-off reference are never persisted.
 
 ## Current Implementation Status
 
-This repository contains the SwiftPM project, DSP engine, importers, profile persistence, menu bar shell, the combined Core Audio tap/output fast path, and the transitional separate-clock Bluetooth headset backend. The Core Audio bridge is intentionally isolated under `GlassEQAudio` so device-format support and hardware QA can be hardened without disturbing UI/profile code.
+This repository contains the SwiftPM project, biquad and minimum-phase convolution DSP engines, EqualizerAPO ParametricEQ and GraphicEQ importers, profile persistence, menu bar shell, the combined Core Audio tap/output fast path, and the transitional separate-clock Bluetooth headset backend. The Core Audio bridge is intentionally isolated under `GlassEQAudio` so device-format support and hardware QA can be hardened without disturbing UI/profile code.
 
 ## Clocking And Routing
 
-On normal-rate routes, the selected physical output is the aggregate's main subdevice and therefore owns the render clock. The process tap captures the device stream containing the output's preferred stereo pair and is an aggregate subtap with high-quality Core Audio drift compensation enabled. The engine has one `AudioDeviceIOProcID`: each callback receives the tapped system mix, runs the biquad cascade, and writes directly to the physical output buffers. There is no application-level queue or asynchronous sample-rate converter on this path.
+On normal-rate routes, the selected physical output is the aggregate's main subdevice and therefore owns the render clock. The process tap captures the device stream containing the output's preferred stereo pair and is an aggregate subtap with high-quality Core Audio drift compensation enabled. The engine has one `AudioDeviceIOProcID`: each callback receives the tapped system mix, runs the active biquad or convolution bank, and writes directly to the physical output buffers. There is no application-level queue or asynchronous sample-rate converter on this path.
 
 GlassEQ measures tap-to-output latency as the host-time difference between the first tapped input frame acquired for an I/O cycle and the first rendered output frame scheduled for hardware. Diagnostics report the observed average and range. This does not include latency before the system tap or after the output reaches the hardware.
 
@@ -65,12 +69,25 @@ The command prints output device metadata and post-run callback metrics:
 - Input frames dropped because a callback exposed more input than output capacity.
 - Peak capture and output callback sizes.
 - Render callbacks that missed at least one complete callback period.
+- Callback-start lateness, total render time, and completion lateness at p99.99 and maximum. Start lateness compares callback entry with the previous callback's expected period. Completion lateness adds render time to that delay and reports the amount beyond the next period.
+- Convolution-only direct-head and scheduled-tail work at p99.99 and maximum.
+- The smallest sample-frame margin observed when a 256-frame tail job completed, plus any tail jobs that missed their internal due frame.
 - Average and range of tap-to-output latency from Core Audio's I/O timestamps.
 - Samples that reached the soft clipper.
+
+The p99.99 values come from fixed, callback-owned histograms. Normal timings use 0.25 microsecond buckets, timings above 64 microseconds use 4 microsecond buckets, and maxima remain exact. GlassEQ publishes one histogram roughly every 1,024 callbacks and staggers the five scans so the measurement work does not land in one callback. Resetting metrics changes a generation counter; it does not clear histogram storage on the realtime thread.
 
 The separate-clock fallback reports its additional bridge diagnostics instead: buffered frames, occupancy-derived bridge latency, clock correction, output timing gaps, sample-rate conversion, and reservoir target. Its bridge-latency number is not the same measurement as the combined path's timestamp-derived tap-to-output latency.
 
 The diagnostic follows the current macOS output device and does not switch outputs itself.
+
+The release DSP benchmark accepts an optional EqualizerAPO GraphicEQ file so the convolution path can be measured with a real response:
+
+```sh
+swift run -c release GlassEQDiagnostics dsp-benchmark /path/to/GraphicEQ.txt
+```
+
+It reports average, p99.9, p99.99, and maximum callback work for the 16,384-tap cases at 48, 96, and 192 kHz, plus dual-bank transition cost. It measures DSP execution only, not Core Audio latency.
 
 Diagnostics print full local device names, UIDs, and transport identifiers:
 
@@ -87,3 +104,4 @@ Profile data belongs to the main app sandbox and is migrated by the main app thr
 ## Backlog
 
 - Support preferred stereo pairs inside native output streams wider than two channels without enabling Core Audio tap mixdown. The first version should still process only the preferred pair, preserve the device-scoped native stream format, map the tapped channels and aggregate buffers explicitly, keep physical inputs disabled, and verify that the wider stream does not restore the 43.5 ms mixdown latency.
+- Import arbitrary impulse-response audio assets, starting with REW WAV exports, and preserve the phase and samples supplied by the user instead of running minimum-phase synthesis.

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,10 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "GlassEQCore"
+            name: "GlassEQCore",
+            linkerSettings: [
+                .linkedFramework("Accelerate")
+            ]
         ),
         .target(
             name: "GlassEQAudio",

--- a/Sources/GlassEQApp/GlassEQApp.swift
+++ b/Sources/GlassEQApp/GlassEQApp.swift
@@ -355,9 +355,12 @@ extension SettingsAudioMetricsDTO {
             playbackBufferObservations: metrics.playbackBufferObservations,
             inputTimestampDiscontinuities: metrics.inputTimestampDiscontinuities,
             outputTimestampDiscontinuities: metrics.outputTimestampDiscontinuities,
+            pairedTimestampDiscontinuities: metrics.pairedTimestampDiscontinuities,
             maximumCaptureCallbackFrames: metrics.maximumCaptureCallbackFrames,
             maximumPlaybackCallbackFrames: metrics.maximumPlaybackCallbackFrames,
             renderDeadlineMisses: metrics.renderDeadlineMisses,
+            callbackStartStarvations: metrics.callbackStartStarvations,
+            renderOverruns: metrics.renderOverruns,
             playbackTimestampDiscontinuities: metrics.playbackTimestampDiscontinuities,
             playbackBufferRenegotiations: metrics.playbackBufferRenegotiations,
             adaptivePlaybackRenderFailures: metrics.adaptivePlaybackRenderFailures,
@@ -370,7 +373,34 @@ extension SettingsAudioMetricsDTO {
             tapToOutputLatencyObservations: metrics.tapToOutputLatencyObservations,
             minimumTapToOutputLatencyNanoseconds: metrics.minimumTapToOutputLatencyNanoseconds,
             maximumTapToOutputLatencyNanoseconds: metrics.maximumTapToOutputLatencyNanoseconds,
-            averageTapToOutputLatencyNanoseconds: metrics.averageTapToOutputLatencyNanoseconds
+            averageTapToOutputLatencyNanoseconds: metrics.averageTapToOutputLatencyNanoseconds,
+            renderTiming: SettingsAudioRenderTimingDTO(
+                callbackStartLatenessObservations:
+                    metrics.renderTiming.callbackStartLatenessObservations,
+                callbackStartLatenessP9999Nanoseconds:
+                    metrics.renderTiming.callbackStartLatenessP9999Nanoseconds,
+                maximumCallbackStartLatenessNanoseconds:
+                    metrics.renderTiming.maximumCallbackStartLatenessNanoseconds,
+                directHeadObservations: metrics.renderTiming.directHeadObservations,
+                directHeadP9999Nanoseconds: metrics.renderTiming.directHeadP9999Nanoseconds,
+                maximumDirectHeadNanoseconds: metrics.renderTiming.maximumDirectHeadNanoseconds,
+                tailWorkObservations: metrics.renderTiming.tailWorkObservations,
+                tailWorkP9999Nanoseconds: metrics.renderTiming.tailWorkP9999Nanoseconds,
+                maximumTailWorkNanoseconds: metrics.renderTiming.maximumTailWorkNanoseconds,
+                totalRenderObservations: metrics.renderTiming.totalRenderObservations,
+                totalRenderP9999Nanoseconds: metrics.renderTiming.totalRenderP9999Nanoseconds,
+                maximumTotalRenderNanoseconds: metrics.renderTiming.maximumTotalRenderNanoseconds,
+                completionLatenessObservations:
+                    metrics.renderTiming.completionLatenessObservations,
+                completionLatenessP9999Nanoseconds:
+                    metrics.renderTiming.completionLatenessP9999Nanoseconds,
+                maximumCompletionLatenessNanoseconds:
+                    metrics.renderTiming.maximumCompletionLatenessNanoseconds,
+                tailCompletionObservations: metrics.renderTiming.tailCompletionObservations,
+                minimumTailCompletionSlackFrames:
+                    metrics.renderTiming.minimumTailCompletionSlackFrames,
+                tailDeadlineMisses: metrics.renderTiming.tailDeadlineMisses
+            )
         )
     }
 }
@@ -1164,6 +1194,14 @@ final class GlassEQAppModel {
         }
     }
 
+    func createConvolutionProfile() {
+        do {
+            try createProfile(kind: .convolution)
+        } catch {
+            reportProfileActionFailure(error)
+        }
+    }
+
     func duplicateSelectedProfile() {
         do {
             try duplicateProfile(id: selectedProfileID)
@@ -1466,6 +1504,12 @@ final class GlassEQAppModel {
                 EQFilter(kind: .peak, frequency: 1_000, gainDB: 0, q: 1)
             ]
             try addProfile(profile, name: localized("New Parametric"), status: localized("Created New Parametric"))
+        case .convolution:
+            try addProfile(
+                .flatConvolution,
+                name: localized("New Response Curve"),
+                status: localized("Created New Response Curve")
+            )
         }
     }
 

--- a/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
+++ b/Sources/GlassEQAudio/SeparateClockAudioBackend.swift
@@ -307,16 +307,14 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         private let playbackChannelPair = Atomic<UInt64>(SeparateClockAudioBackend.encodedPlaybackChannelPair(left: 0, right: 1))
 
         init(
-            profile: EQProfile,
-            sampleRate: Double,
-            channelCount: Int,
+            renderConfiguration: EQRenderConfiguration,
             ringCapacityFrames: Int,
             scratchFrames: Int,
             captureCallbackFrames: Int,
             playbackPrimeFrames: Int
         ) {
-            self.channelCount = max(channelCount, 1)
-            self.sampleRate = sampleRate
+            self.channelCount = max(renderConfiguration.configuration.channelCount, 1)
+            self.sampleRate = renderConfiguration.configuration.sampleRate
             self.configuredCaptureCallbackFrames = max(captureCallbackFrames, 1)
             self.ringBuffer = RealtimeAudioRingBuffer(
                 channelCount: self.channelCount,
@@ -336,25 +334,21 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             self.adaptivePlaybackTargetFrames = Atomic(max(playbackPrimeFrames, 1))
             self.maxCallbackFrames = SeparateClockAudioBackend.maximumSupportedCallbackFrames
             self.playbackRateServo = PlaybackRateServo(
-                sampleRate: sampleRate,
+                sampleRate: self.sampleRate,
                 targetFrames: playbackPrimeFrames
             )
             self.playbackResampler = HermitePlaybackResampler(channelCount: self.channelCount)
             self.playbackSampleRatePlan = PlaybackSampleRatePlan(
-                inputSampleRate: sampleRate,
-                outputSampleRate: sampleRate
+                inputSampleRate: self.sampleRate,
+                outputSampleRate: self.sampleRate
             )
             self.dspTransition = RealtimeEQTransition(
                 activeProcessor: EQProcessor(
-                    renderConfiguration: EQRenderConfiguration(
-                        profile: profile,
-                        sampleRate: sampleRate,
-                        channelCount: self.channelCount
-                    )
+                    renderConfiguration: renderConfiguration
                 ),
                 maximumFrameCount: scratchFrames,
                 channelCount: self.channelCount,
-                sampleRate: sampleRate
+                sampleRate: self.sampleRate
             )
         }
 
@@ -1751,8 +1745,38 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
 
     @discardableResult
     public func updateDSP(profile: EQProfile) -> Bool {
-        control.withLock { state in
-            updateDSPLocked(&state, profile: profile)
+        guard let preparation = control.withLock({ state -> (AudioRuntime, EQProfile, UInt64, Double)? in
+            guard let runtime = state.runtime,
+                  let activeProfile = state.activeProfile else {
+                return nil
+            }
+            let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+                sampleRate: state.activeOutput?.nominalSampleRate ?? runtime.sampleRate
+            )
+            return (runtime, activeProfile, state.profileRevision, maximumUsableFrequency)
+        }) else {
+            return false
+        }
+        let (runtime, activeProfile, profileRevision, maximumUsableFrequency) = preparation
+        guard let preparedConfig = try? EQRenderConfiguration.prepare(
+            profile: profile,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ) else {
+            return false
+        }
+        return control.withLock { state in
+            guard state.runtime === runtime,
+                  state.activeProfile == activeProfile,
+                  state.profileRevision == profileRevision else {
+                return false
+            }
+            return updateDSPLocked(
+                &state,
+                profile: profile,
+                preparedConfig: preparedConfig
+            )
         }
     }
 
@@ -1761,27 +1785,37 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         guard !profile.isBypassed else {
             return false
         }
-        return control.withLock { state in
+        guard let preparation = control.withLock({ state -> (AudioRuntime, UInt64, Double)? in
             guard let runtime = state.runtime else {
-                return false
+                return nil
             }
             let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
                 sampleRate: state.activeOutput?.nominalSampleRate ?? runtime.sampleRate
             )
-            let equalizedConfig = EQRenderConfiguration(
-                profile: profile,
-                sampleRate: runtime.sampleRate,
-                channelCount: runtime.channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
-            )
-            let referenceConfig = EQRenderConfiguration(
-                profile: profile.programmeComparisonReference,
-                sampleRate: runtime.sampleRate,
-                channelCount: runtime.channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
-            )
-            guard equalizedConfig.isNumericallySafe,
-                  referenceConfig.isNumericallySafe else {
+            return (runtime, state.profileRevision, maximumUsableFrequency)
+        }) else {
+            return false
+        }
+        let (runtime, profileRevision, maximumUsableFrequency) = preparation
+        guard let equalizedConfig = try? EQRenderConfiguration.prepare(
+            profile: profile,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ),
+        let referenceConfig = try? EQRenderConfiguration.prepare(
+            profile: profile.programmeComparisonReference,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ),
+        equalizedConfig.isNumericallySafe,
+        referenceConfig.isNumericallySafe else {
+            return false
+        }
+        return control.withLock { state in
+            guard state.runtime === runtime,
+                  state.profileRevision == profileRevision else {
                 return false
             }
             runtime.setProgrammeComparisonSelection(.equalized)
@@ -1810,6 +1844,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
     private func updateDSPLocked(
         _ state: inout ControlState,
         profile: EQProfile,
+        preparedConfig: EQRenderConfiguration? = nil,
         incrementsProfileRevision: Bool = true
     ) -> Bool {
         guard let runtime = state.runtime,
@@ -1820,22 +1855,22 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             sampleRate: state.activeOutput?.nominalSampleRate ?? runtime.sampleRate
         )
 
-        guard Self.canHotSwapDSP(
-            from: activeProfile,
-            to: profile,
-            sampleRate: runtime.sampleRate,
-            channelCount: runtime.channelCount,
-            maximumUsableFrequency: maximumUsableFrequency
-        ) else {
-            return false
-        }
-
-        let preparedConfig = EQRenderConfiguration(
+        guard let preparedConfig = preparedConfig ?? (try? EQRenderConfiguration.prepare(
             profile: profile,
             sampleRate: runtime.sampleRate,
             channelCount: runtime.channelCount,
             maximumUsableFrequency: maximumUsableFrequency
-        )
+        )),
+        Self.canHotSwapDSP(
+            from: activeProfile,
+            to: profile,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency,
+            preparedConfiguration: preparedConfig
+        ) else {
+            return false
+        }
         runtime.setProgrammeComparisonSelection(.equalized)
         runtime.drainDSPConfigBoxes()
         runtime.publishPendingDSPConfig(preparedConfig)
@@ -1851,14 +1886,18 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
         to nextProfile: EQProfile,
         sampleRate: Double,
         channelCount: Int,
-        maximumUsableFrequency: Double? = nil
+        maximumUsableFrequency: Double? = nil,
+        preparedConfiguration: EQRenderConfiguration? = nil
     ) -> Bool {
-        EQRenderConfiguration(
+        if let preparedConfiguration {
+            return preparedConfiguration.isNumericallySafe
+        }
+        return (try? EQRenderConfiguration.prepare(
             profile: nextProfile,
             sampleRate: sampleRate,
             channelCount: channelCount,
             maximumUsableFrequency: maximumUsableFrequency
-        ).isNumericallySafe
+        ))?.isNumericallySafe == true
     }
 
     public func muteOutputForTransition() {
@@ -2044,10 +2083,13 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
             reportedFrames: reportedCaptureCallbackFrames
         )
 
-        let runtime = AudioRuntime(
+        let renderConfiguration = try EQRenderConfiguration.prepare(
             profile: profile,
             sampleRate: tapSampleRate,
-            channelCount: tapChannelCount,
+            channelCount: tapChannelCount
+        )
+        let runtime = AudioRuntime(
+            renderConfiguration: renderConfiguration,
             ringCapacityFrames: ringCapacityFrames,
             scratchFrames: scratchFrames,
             captureCallbackFrames: captureCallbackFrames,
@@ -2200,7 +2242,7 @@ public final class SeparateClockAudioBackend: @unchecked Sendable {
                 captureCallbackFrames: runtime.maximumKnownCaptureCallbackFrames()
             )
             runtime.drainDSPConfigBoxes()
-            runtime.publishPendingDSPConfig(EQRenderConfiguration(
+            runtime.publishPendingDSPConfig(try EQRenderConfiguration.prepare(
                 profile: effectiveProfile,
                 sampleRate: runtime.sampleRate,
                 channelCount: runtime.channelCount,

--- a/Sources/GlassEQAudio/SystemTapAudioEngine.swift
+++ b/Sources/GlassEQAudio/SystemTapAudioEngine.swift
@@ -16,6 +16,67 @@ public enum HeadsetAggregatePromotionResult: Equatable, Sendable {
     case promoted(AudioOutputDevice)
 }
 
+public struct AudioRenderTimingMetrics: Equatable, Sendable {
+    public var callbackStartLatenessObservations: UInt64
+    public var callbackStartLatenessP9999Nanoseconds: UInt64
+    public var maximumCallbackStartLatenessNanoseconds: UInt64
+    public var directHeadObservations: UInt64
+    public var directHeadP9999Nanoseconds: UInt64
+    public var maximumDirectHeadNanoseconds: UInt64
+    public var tailWorkObservations: UInt64
+    public var tailWorkP9999Nanoseconds: UInt64
+    public var maximumTailWorkNanoseconds: UInt64
+    public var totalRenderObservations: UInt64
+    public var totalRenderP9999Nanoseconds: UInt64
+    public var maximumTotalRenderNanoseconds: UInt64
+    public var completionLatenessObservations: UInt64
+    public var completionLatenessP9999Nanoseconds: UInt64
+    public var maximumCompletionLatenessNanoseconds: UInt64
+    public var tailCompletionObservations: UInt64
+    public var minimumTailCompletionSlackFrames: Int
+    public var tailDeadlineMisses: UInt64
+
+    public init(
+        callbackStartLatenessObservations: UInt64 = 0,
+        callbackStartLatenessP9999Nanoseconds: UInt64 = 0,
+        maximumCallbackStartLatenessNanoseconds: UInt64 = 0,
+        directHeadObservations: UInt64 = 0,
+        directHeadP9999Nanoseconds: UInt64 = 0,
+        maximumDirectHeadNanoseconds: UInt64 = 0,
+        tailWorkObservations: UInt64 = 0,
+        tailWorkP9999Nanoseconds: UInt64 = 0,
+        maximumTailWorkNanoseconds: UInt64 = 0,
+        totalRenderObservations: UInt64 = 0,
+        totalRenderP9999Nanoseconds: UInt64 = 0,
+        maximumTotalRenderNanoseconds: UInt64 = 0,
+        completionLatenessObservations: UInt64 = 0,
+        completionLatenessP9999Nanoseconds: UInt64 = 0,
+        maximumCompletionLatenessNanoseconds: UInt64 = 0,
+        tailCompletionObservations: UInt64 = 0,
+        minimumTailCompletionSlackFrames: Int = 0,
+        tailDeadlineMisses: UInt64 = 0
+    ) {
+        self.callbackStartLatenessObservations = callbackStartLatenessObservations
+        self.callbackStartLatenessP9999Nanoseconds = callbackStartLatenessP9999Nanoseconds
+        self.maximumCallbackStartLatenessNanoseconds = maximumCallbackStartLatenessNanoseconds
+        self.directHeadObservations = directHeadObservations
+        self.directHeadP9999Nanoseconds = directHeadP9999Nanoseconds
+        self.maximumDirectHeadNanoseconds = maximumDirectHeadNanoseconds
+        self.tailWorkObservations = tailWorkObservations
+        self.tailWorkP9999Nanoseconds = tailWorkP9999Nanoseconds
+        self.maximumTailWorkNanoseconds = maximumTailWorkNanoseconds
+        self.totalRenderObservations = totalRenderObservations
+        self.totalRenderP9999Nanoseconds = totalRenderP9999Nanoseconds
+        self.maximumTotalRenderNanoseconds = maximumTotalRenderNanoseconds
+        self.completionLatenessObservations = completionLatenessObservations
+        self.completionLatenessP9999Nanoseconds = completionLatenessP9999Nanoseconds
+        self.maximumCompletionLatenessNanoseconds = maximumCompletionLatenessNanoseconds
+        self.tailCompletionObservations = tailCompletionObservations
+        self.minimumTailCompletionSlackFrames = minimumTailCompletionSlackFrames
+        self.tailDeadlineMisses = tailDeadlineMisses
+    }
+}
+
 public struct AggregateAudioRouteFingerprint: Codable, Equatable, Hashable, Sendable {
     public var outputDeviceUID: String
     public var nativeOutputStreamIndex: Int
@@ -67,6 +128,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var maximumCaptureCallbackFrames: Int
     public var maximumPlaybackCallbackFrames: Int
     public var renderDeadlineMisses: UInt64
+    public var callbackStartStarvations: UInt64
+    public var renderOverruns: UInt64
     public var playbackTimestampDiscontinuities: UInt64
     public var playbackBufferRenegotiations: UInt64
     public var adaptivePlaybackRenderFailures: UInt64
@@ -87,6 +150,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
     public var minimumOutputLeadNanoseconds: UInt64
     public var maximumOutputLeadNanoseconds: UInt64
     public var averageOutputLeadNanoseconds: Double
+    public var renderTiming: AudioRenderTimingMetrics
 
     public init(
         capturedFrames: UInt64 = 0,
@@ -117,6 +181,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         maximumCaptureCallbackFrames: Int = 0,
         maximumPlaybackCallbackFrames: Int = 0,
         renderDeadlineMisses: UInt64 = 0,
+        callbackStartStarvations: UInt64 = 0,
+        renderOverruns: UInt64 = 0,
         playbackTimestampDiscontinuities: UInt64 = 0,
         playbackBufferRenegotiations: UInt64 = 0,
         adaptivePlaybackRenderFailures: UInt64 = 0,
@@ -136,7 +202,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         averageInputAgeNanoseconds: Double = 0,
         minimumOutputLeadNanoseconds: UInt64 = 0,
         maximumOutputLeadNanoseconds: UInt64 = 0,
-        averageOutputLeadNanoseconds: Double = 0
+        averageOutputLeadNanoseconds: Double = 0,
+        renderTiming: AudioRenderTimingMetrics = AudioRenderTimingMetrics()
     ) {
         self.capturedFrames = capturedFrames
         self.playedFrames = playedFrames
@@ -166,6 +233,8 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.maximumCaptureCallbackFrames = maximumCaptureCallbackFrames
         self.maximumPlaybackCallbackFrames = maximumPlaybackCallbackFrames
         self.renderDeadlineMisses = renderDeadlineMisses
+        self.callbackStartStarvations = callbackStartStarvations
+        self.renderOverruns = renderOverruns
         self.playbackTimestampDiscontinuities = playbackTimestampDiscontinuities
         self.playbackBufferRenegotiations = playbackBufferRenegotiations
         self.adaptivePlaybackRenderFailures = adaptivePlaybackRenderFailures
@@ -186,6 +255,7 @@ public struct AudioEngineMetrics: Equatable, Sendable {
         self.minimumOutputLeadNanoseconds = minimumOutputLeadNanoseconds
         self.maximumOutputLeadNanoseconds = maximumOutputLeadNanoseconds
         self.averageOutputLeadNanoseconds = averageOutputLeadNanoseconds
+        self.renderTiming = renderTiming
     }
 }
 
@@ -401,6 +471,217 @@ struct RealtimeOutputFade: Sendable {
     }
 }
 
+struct RealtimeOutputDeclicker: Sendable {
+    static let durationSeconds = 64.0 / 48_000.0
+
+    private let correctionFrameCount: Int
+    private var lastSamples: [Float]
+    private var correctionAnchors: [Float]
+    private var hasLastSamples = false
+    private var correctionPending = false
+    private var completedCorrectionFrames = 0
+    private var remainingCorrectionFrames = 0
+
+    init(
+        sampleRate: Double,
+        channelCount: Int,
+        durationSeconds: Double = Self.durationSeconds
+    ) {
+        let validSampleRate = sampleRate.isFinite && sampleRate > 0 ? sampleRate : 48_000
+        let validDuration = durationSeconds.isFinite && durationSeconds > 0
+            ? durationSeconds
+            : Self.durationSeconds
+        self.correctionFrameCount = max(
+            Int((validSampleRate * validDuration).rounded()),
+            2
+        )
+        let channels = max(channelCount, 1)
+        self.lastSamples = Array(repeating: 0, count: channels)
+        self.correctionAnchors = Array(repeating: 0, count: channels)
+    }
+
+    mutating func markDiscontinuity() {
+        correctionPending = true
+    }
+
+    mutating func apply(
+        to samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) {
+        guard channelCount == lastSamples.count else {
+            return
+        }
+        let availableFrames = min(max(frameCount, 0), samples.count / channelCount)
+        guard availableFrames > 0 else {
+            return
+        }
+
+        if correctionPending {
+            correctionPending = false
+            if hasLastSamples {
+                for channel in 0..<channelCount {
+                    correctionAnchors[channel] = lastSamples[channel]
+                }
+                completedCorrectionFrames = 0
+                remainingCorrectionFrames = correctionFrameCount
+            }
+        }
+
+        let framesToCorrect = min(availableFrames, remainingCorrectionFrames)
+        if framesToCorrect > 0 {
+            var sampleIndex = 0
+            for _ in 0..<framesToCorrect {
+                let progress = Float(completedCorrectionFrames)
+                    / Float(correctionFrameCount - 1)
+                let smoothedProgress = progress * progress * (3 - 2 * progress)
+                for channel in 0..<channelCount {
+                    let anchor = correctionAnchors[channel]
+                    samples[sampleIndex + channel] = anchor
+                        + (samples[sampleIndex + channel] - anchor) * smoothedProgress
+                }
+                completedCorrectionFrames += 1
+                remainingCorrectionFrames -= 1
+                sampleIndex += channelCount
+            }
+        }
+
+        let lastFrameIndex = (availableFrames - 1) * channelCount
+        for channel in 0..<channelCount {
+            lastSamples[channel] = samples[lastFrameIndex + channel]
+        }
+        hasLastSamples = true
+    }
+}
+
+struct ExtremeDurationSnapshot {
+    var observations: UInt64
+    var p9999Nanoseconds: UInt64
+    var maximumNanoseconds: UInt64
+}
+
+final class RealtimeExtremeDurationTracker: @unchecked Sendable {
+    private static let fineBucketCount = 256
+    private static let fineBucketWidthNanoseconds: UInt64 = 250
+    private static let coarseBucketCount = 256
+    private static let coarseBucketWidthNanoseconds: UInt64 = 4_000
+    private static let overflowBucket = fineBucketCount + coarseBucketCount
+    private static let bucketCount = overflowBucket + 1
+    private static let publishInterval: UInt64 = 1_024
+
+    private let requestedGeneration = Atomic<UInt64>(0)
+    private let publishedObservations = Atomic<UInt64>(0)
+    private let publishedP9999Nanoseconds = Atomic<UInt64>(0)
+    private let publishedMaximumNanoseconds = Atomic<UInt64>(0)
+    private var localGeneration: UInt64 = 0
+    private var bucketGenerations = [UInt64](repeating: .max, count: bucketCount)
+    private var bucketCounts = [UInt64](repeating: 0, count: bucketCount)
+    private var observations: UInt64 = 0
+    private var maximumNanoseconds: UInt64 = 0
+    private let publishPhase: UInt64
+
+    init(publishPhase: UInt64 = 0) {
+        self.publishPhase = publishPhase % Self.publishInterval
+    }
+
+    func record(_ nanoseconds: UInt64) {
+        adoptRequestedGeneration()
+        let bucket = Self.bucketIndex(for: nanoseconds)
+        if bucketGenerations[bucket] != localGeneration {
+            bucketGenerations[bucket] = localGeneration
+            bucketCounts[bucket] = 0
+        }
+        bucketCounts[bucket] &+= 1
+        observations &+= 1
+        if nanoseconds > maximumNanoseconds {
+            maximumNanoseconds = nanoseconds
+            publishedMaximumNanoseconds.store(nanoseconds, ordering: .relaxed)
+        }
+        if observations == 1
+            || (observations &+ publishPhase).isMultiple(of: Self.publishInterval) {
+            publish()
+        }
+    }
+
+    func reset() {
+        requestedGeneration.wrappingAdd(1, ordering: .releasing)
+        publishedObservations.store(0, ordering: .relaxed)
+        publishedP9999Nanoseconds.store(0, ordering: .relaxed)
+        publishedMaximumNanoseconds.store(0, ordering: .relaxed)
+    }
+
+    func snapshot() -> ExtremeDurationSnapshot {
+        ExtremeDurationSnapshot(
+            observations: publishedObservations.load(ordering: .relaxed),
+            p9999Nanoseconds: publishedP9999Nanoseconds.load(ordering: .relaxed),
+            maximumNanoseconds: publishedMaximumNanoseconds.load(ordering: .relaxed)
+        )
+    }
+
+    private func adoptRequestedGeneration() {
+        let requested = requestedGeneration.load(ordering: .acquiring)
+        guard requested != localGeneration else {
+            return
+        }
+        localGeneration = requested
+        observations = 0
+        maximumNanoseconds = 0
+    }
+
+    private func publish() {
+        let rank = max(
+            UInt64(ceil(Double(observations) * 0.9999)),
+            1
+        )
+        var cumulative: UInt64 = 0
+        var percentile = maximumNanoseconds
+        for bucket in 0..<Self.bucketCount
+        where bucketGenerations[bucket] == localGeneration {
+            cumulative &+= bucketCounts[bucket]
+            if cumulative >= rank {
+                percentile = min(
+                    Self.bucketUpperBound(
+                        bucket,
+                        maximumNanoseconds: maximumNanoseconds
+                    ),
+                    maximumNanoseconds
+                )
+                break
+            }
+        }
+        publishedMaximumNanoseconds.store(maximumNanoseconds, ordering: .relaxed)
+        publishedP9999Nanoseconds.store(percentile, ordering: .relaxed)
+        publishedObservations.store(observations, ordering: .releasing)
+    }
+
+    private static func bucketIndex(for nanoseconds: UInt64) -> Int {
+        let fineLimit = UInt64(fineBucketCount) * fineBucketWidthNanoseconds
+        if nanoseconds < fineLimit {
+            return Int(nanoseconds / fineBucketWidthNanoseconds)
+        }
+        let coarseOffset = nanoseconds - fineLimit
+        let coarseBucket = Int(coarseOffset / coarseBucketWidthNanoseconds)
+        return coarseBucket < coarseBucketCount
+            ? fineBucketCount + coarseBucket
+            : overflowBucket
+    }
+
+    private static func bucketUpperBound(
+        _ bucket: Int,
+        maximumNanoseconds: UInt64
+    ) -> UInt64 {
+        if bucket < fineBucketCount {
+            return UInt64(bucket + 1) * fineBucketWidthNanoseconds
+        }
+        if bucket < overflowBucket {
+            let fineLimit = UInt64(fineBucketCount) * fineBucketWidthNanoseconds
+            return fineLimit
+                + UInt64(bucket - fineBucketCount + 1) * coarseBucketWidthNanoseconds
+        }
+        return maximumNanoseconds
+    }
+}
+
 public final class SystemTapAudioEngine: @unchecked Sendable {
     private static let preferredAggregateBufferFrameSize: UInt32 = 16
     private static let maximumSupportedCallbackFrames = 8192
@@ -532,6 +813,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private var dspTransition: RealtimeEQTransition
         private var activeSystemSoundPreampGains: (left: Float, right: Float)
         private var outputFade: RealtimeOutputFade
+        private var outputDeclicker: RealtimeOutputDeclicker
         private var scratchSamples: [Float]
         private var inputTimestampState = TimestampContinuityState()
         private var outputTimestampState = TimestampContinuityState()
@@ -567,8 +849,18 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         private let maxCaptureCallbackFrames = Atomic<Int>(0)
         private let maxPlaybackCallbackFrames = Atomic<Int>(0)
         private let renderDeadlineMisses = Atomic<UInt64>(0)
+        private let callbackStartStarvations = Atomic<UInt64>(0)
+        private let renderOverruns = Atomic<UInt64>(0)
         private var previousRenderStartNanoseconds: UInt64?
         private var previousRenderFrameCount = 0
+        private let callbackStartLateness = RealtimeExtremeDurationTracker(publishPhase: 0)
+        private let directHeadDuration = RealtimeExtremeDurationTracker(publishPhase: 205)
+        private let tailWorkDuration = RealtimeExtremeDurationTracker(publishPhase: 410)
+        private let totalRenderDuration = RealtimeExtremeDurationTracker(publishPhase: 615)
+        private let completionLateness = RealtimeExtremeDurationTracker(publishPhase: 820)
+        private let tailCompletionObservations = Atomic<UInt64>(0)
+        private let minimumTailCompletionSlackFrames = Atomic<Int>(Int.max)
+        private let tailDeadlineMisses = Atomic<UInt64>(0)
         private let tapToOutputLatencyObservations = Atomic<UInt64>(0)
         private let minTapToOutputLatencyNanoseconds = Atomic<UInt64>(.max)
         private let maxTapToOutputLatencyNanoseconds = Atomic<UInt64>(0)
@@ -599,36 +891,30 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         )
 
         init(
-            profile: EQProfile,
-            sampleRate: Double,
-            channelCount: Int,
+            renderConfiguration: EQRenderConfiguration,
             inputChannelOffset: Int,
             systemSoundInputChannelOffset: Int,
             maxCallbackFrames: Int
         ) {
-            self.channelCount = max(channelCount, 1)
-            self.sampleRate = sampleRate
+            self.channelCount = max(renderConfiguration.configuration.channelCount, 1)
+            self.sampleRate = renderConfiguration.configuration.sampleRate
             self.inputChannelOffset = max(inputChannelOffset, 0)
             self.systemSoundInputChannelOffset = max(systemSoundInputChannelOffset, 0)
             self.maxCallbackFrames = maxCallbackFrames
-            self.outputFade = RealtimeOutputFade(sampleRate: sampleRate)
+            self.outputFade = RealtimeOutputFade(sampleRate: self.sampleRate)
+            self.outputDeclicker = RealtimeOutputDeclicker(
+                sampleRate: self.sampleRate,
+                channelCount: self.channelCount
+            )
             self.scratchSamples = Array(
                 repeating: 0,
                 count: maxCallbackFrames * self.channelCount
-            )
-            let renderConfiguration = EQRenderConfiguration(
-                profile: profile,
-                sampleRate: sampleRate,
-                channelCount: self.channelCount,
-                maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
-                    sampleRate: sampleRate
-                )
             )
             self.dspTransition = RealtimeEQTransition(
                 activeProcessor: EQProcessor(renderConfiguration: renderConfiguration),
                 maximumFrameCount: maxCallbackFrames,
                 channelCount: self.channelCount,
-                sampleRate: sampleRate
+                sampleRate: self.sampleRate
             )
             self.activeSystemSoundPreampGains = SystemTapAudioEngine.systemSoundPreampGains(
                 for: renderConfiguration
@@ -680,28 +966,98 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             let inputFrameCount = min(mainInputFrameCount, systemSoundFrameCount)
 
             let renderStartNanoseconds = AudioConvertHostTimeToNanos(callbackHostTime)
-            let entryDeadlineMisses = previousRenderStartNanoseconds.map {
+            let previousRenderStart = previousRenderStartNanoseconds
+            let expectedEntryIntervalNanoseconds = previousRenderStart.map { _ in
+                SystemTapAudioEngine.renderPeriodNanoseconds(
+                    frameCount: previousRenderFrameCount,
+                    sampleRate: sampleRate
+                )
+            } ?? 0
+            let entryElapsedNanoseconds = previousRenderStart.map {
+                renderStartNanoseconds >= $0 ? renderStartNanoseconds - $0 : 0
+            } ?? 0
+            let callbackStartLatenessNanoseconds = entryElapsedNanoseconds
+                > expectedEntryIntervalNanoseconds
+                ? entryElapsedNanoseconds - expectedEntryIntervalNanoseconds
+                : 0
+            if previousRenderStart != nil {
+                callbackStartLateness.record(callbackStartLatenessNanoseconds)
+            }
+            let entryDeadlineMisses = previousRenderStart.map { _ in
                 SystemTapAudioEngine.missedRenderDeadlines(
-                    elapsedNanoseconds: renderStartNanoseconds >= $0
-                        ? renderStartNanoseconds - $0
-                        : 0,
+                    elapsedNanoseconds: entryElapsedNanoseconds,
                     frameCount: previousRenderFrameCount,
                     sampleRate: sampleRate
                 )
             } ?? 0
             previousRenderStartNanoseconds = renderStartNanoseconds
             previousRenderFrameCount = outputFrameCount
+            var renderWorkTiming = EQRenderWorkTiming()
             defer {
                 let renderEndNanoseconds = AudioConvertHostTimeToNanos(
                     AudioGetCurrentHostTime()
                 )
+                let totalRenderNanoseconds = renderEndNanoseconds >= renderStartNanoseconds
+                    ? renderEndNanoseconds - renderStartNanoseconds
+                    : 0
+                totalRenderDuration.record(totalRenderNanoseconds)
+                if previousRenderStart != nil {
+                    let currentPeriodNanoseconds = SystemTapAudioEngine.renderPeriodNanoseconds(
+                        frameCount: outputFrameCount,
+                        sampleRate: sampleRate
+                    )
+                    let completionElapsed = callbackStartLatenessNanoseconds
+                        .addingReportingOverflow(totalRenderNanoseconds)
+                    let completionElapsedNanoseconds = completionElapsed.overflow
+                        ? UInt64.max
+                        : completionElapsed.partialValue
+                    completionLateness.record(
+                        completionElapsedNanoseconds > currentPeriodNanoseconds
+                            ? completionElapsedNanoseconds - currentPeriodNanoseconds
+                            : 0
+                    )
+                }
+                if renderWorkTiming.directHeadHostTicks > 0 {
+                    directHeadDuration.record(
+                        AudioConvertHostTimeToNanos(renderWorkTiming.directHeadHostTicks)
+                    )
+                }
+                if renderWorkTiming.tailScheduledWorkHostTicks > 0 {
+                    tailWorkDuration.record(
+                        AudioConvertHostTimeToNanos(renderWorkTiming.tailScheduledWorkHostTicks)
+                    )
+                }
+                if renderWorkTiming.tailCompletionObservations > 0 {
+                    tailCompletionObservations.wrappingAdd(
+                        renderWorkTiming.tailCompletionObservations,
+                        ordering: .relaxed
+                    )
+                    updateMinimum(
+                        minimumTailCompletionSlackFrames,
+                        renderWorkTiming.minimumTailCompletionSlackFrames
+                    )
+                }
+                if renderWorkTiming.tailDeadlineMisses > 0 {
+                    tailDeadlineMisses.wrappingAdd(
+                        renderWorkTiming.tailDeadlineMisses,
+                        ordering: .relaxed
+                    )
+                }
                 let executionDeadlineMisses = SystemTapAudioEngine.missedRenderDeadlines(
-                    elapsedNanoseconds: renderEndNanoseconds >= renderStartNanoseconds
-                        ? renderEndNanoseconds - renderStartNanoseconds
-                        : 0,
+                    elapsedNanoseconds: totalRenderNanoseconds,
                     frameCount: outputFrameCount,
                     sampleRate: sampleRate
                 )
+                if entryDeadlineMisses > 0 {
+                    callbackStartStarvations.wrappingAdd(1, ordering: .relaxed)
+                }
+                if SystemTapAudioEngine.renderOverranPeriod(
+                    elapsedNanoseconds: totalRenderNanoseconds,
+                    frameCount: outputFrameCount,
+                    sampleRate: sampleRate
+                ) {
+                    renderOverruns.wrappingAdd(1, ordering: .relaxed)
+                }
                 let missedDeadlines = max(entryDeadlineMisses, executionDeadlineMisses)
                 if missedDeadlines > 0 {
                     renderDeadlineMisses.wrappingAdd(
@@ -771,6 +1127,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                     frameCount: frameCount,
                     channelCount: channelCount
                 )
+                renderWorkTiming = transitionResult.workTiming
                 if transitionResult.programmeComparison.isActive
                     || programmeComparisonActive.load(ordering: .relaxed) {
                     publishProgrammeComparisonSnapshot(
@@ -803,6 +1160,11 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 }
 
                 outputFade.apply(
+                    to: samples,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+                outputDeclicker.apply(
                     to: samples,
                     frameCount: frameCount,
                     channelCount: channelCount
@@ -904,6 +1266,16 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             maxCaptureCallbackFrames.store(0, ordering: .relaxed)
             maxPlaybackCallbackFrames.store(0, ordering: .relaxed)
             renderDeadlineMisses.store(0, ordering: .relaxed)
+            callbackStartStarvations.store(0, ordering: .relaxed)
+            renderOverruns.store(0, ordering: .relaxed)
+            callbackStartLateness.reset()
+            directHeadDuration.reset()
+            tailWorkDuration.reset()
+            totalRenderDuration.reset()
+            completionLateness.reset()
+            tailCompletionObservations.store(0, ordering: .relaxed)
+            minimumTailCompletionSlackFrames.store(Int.max, ordering: .relaxed)
+            tailDeadlineMisses.store(0, ordering: .relaxed)
             tapToOutputLatencyObservations.store(0, ordering: .relaxed)
             minTapToOutputLatencyNanoseconds.store(.max, ordering: .relaxed)
             maxTapToOutputLatencyNanoseconds.store(0, ordering: .relaxed)
@@ -935,6 +1307,13 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             let totalJumpInterval = totalTimestampJumpIntervalNanoseconds.load(
                 ordering: .relaxed
             )
+            let callbackStart = callbackStartLateness.snapshot()
+            let directHead = directHeadDuration.snapshot()
+            let tailWork = tailWorkDuration.snapshot()
+            let totalRender = totalRenderDuration.snapshot()
+            let completion = completionLateness.snapshot()
+            let tailCompletions = tailCompletionObservations.load(ordering: .relaxed)
+            let minimumTailSlack = minimumTailCompletionSlackFrames.load(ordering: .relaxed)
             return AudioEngineMetrics(
                 capturedFrames: capturedFrames.load(ordering: .relaxed),
                 playedFrames: playedFrames.load(ordering: .relaxed),
@@ -975,6 +1354,8 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 maximumCaptureCallbackFrames: maxCaptureCallbackFrames.load(ordering: .relaxed),
                 maximumPlaybackCallbackFrames: maxPlaybackCallbackFrames.load(ordering: .relaxed),
                 renderDeadlineMisses: renderDeadlineMisses.load(ordering: .relaxed),
+                callbackStartStarvations: callbackStartStarvations.load(ordering: .relaxed),
+                renderOverruns: renderOverruns.load(ordering: .relaxed),
                 tapToOutputLatencyObservations: latencyObservations,
                 minimumTapToOutputLatencyNanoseconds: latencyObservations == 0 || minimumLatency == .max
                     ? 0
@@ -999,7 +1380,30 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 maximumOutputLeadNanoseconds: maxOutputLeadNanoseconds.load(ordering: .relaxed),
                 averageOutputLeadNanoseconds: timingObservations == 0
                     ? 0
-                    : Double(totalOutputLead) / Double(timingObservations)
+                    : Double(totalOutputLead) / Double(timingObservations),
+                renderTiming: AudioRenderTimingMetrics(
+                    callbackStartLatenessObservations: callbackStart.observations,
+                    callbackStartLatenessP9999Nanoseconds: callbackStart.p9999Nanoseconds,
+                    maximumCallbackStartLatenessNanoseconds: callbackStart.maximumNanoseconds,
+                    directHeadObservations: directHead.observations,
+                    directHeadP9999Nanoseconds: directHead.p9999Nanoseconds,
+                    maximumDirectHeadNanoseconds: directHead.maximumNanoseconds,
+                    tailWorkObservations: tailWork.observations,
+                    tailWorkP9999Nanoseconds: tailWork.p9999Nanoseconds,
+                    maximumTailWorkNanoseconds: tailWork.maximumNanoseconds,
+                    totalRenderObservations: totalRender.observations,
+                    totalRenderP9999Nanoseconds: totalRender.p9999Nanoseconds,
+                    maximumTotalRenderNanoseconds: totalRender.maximumNanoseconds,
+                    completionLatenessObservations: completion.observations,
+                    completionLatenessP9999Nanoseconds: completion.p9999Nanoseconds,
+                    maximumCompletionLatenessNanoseconds: completion.maximumNanoseconds,
+                    tailCompletionObservations: tailCompletions,
+                    minimumTailCompletionSlackFrames:
+                        tailCompletions == 0 || minimumTailSlack == Int.max
+                            ? 0
+                            : minimumTailSlack,
+                    tailDeadlineMisses: tailDeadlineMisses.load(ordering: .relaxed)
+                )
             )
         }
 
@@ -1303,6 +1707,7 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 )
             }
             if inputJump != nil, outputJump != nil {
+                outputDeclicker.markDiscontinuity()
                 recordPairedTimestampJump(inputTime: inputTime, outputTime: outputTime)
                 if inputJump?.precededByStableSlope == true,
                    outputJump?.precededByStableSlope == true {
@@ -1598,6 +2003,24 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
             updateMaximum(maxOutputLeadNanoseconds, timing.outputLead)
             totalOutputLeadNanoseconds.wrappingAdd(timing.outputLead, ordering: .relaxed)
             callbackTimingObservations.wrappingAdd(1, ordering: .relaxed)
+        }
+
+        private func updateMinimum(
+            _ counter: borrowing Atomic<Int>,
+            _ value: Int
+        ) {
+            var current = counter.load(ordering: .relaxed)
+            while value < current {
+                let result = counter.compareExchange(
+                    expected: current,
+                    desired: value,
+                    ordering: .relaxed
+                )
+                if result.exchanged {
+                    return
+                }
+                current = result.original
+            }
         }
 
         private func updateMinimum(
@@ -2039,10 +2462,16 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
                 )
             }
 
-            let preparedRuntime = AudioRuntime(
+            let renderConfiguration = try EQRenderConfiguration.prepare(
                 profile: profile,
                 sampleRate: aggregate.nominalSampleRate,
                 channelCount: mainTapChannelCount,
+                maximumUsableFrequency: EQRouteFrequencyPolicy.maximumUsableFrequency(
+                    sampleRate: aggregate.nominalSampleRate
+                )
+            )
+            let preparedRuntime = AudioRuntime(
+                renderConfiguration: renderConfiguration,
                 inputChannelOffset: tapInputChannelOffsets.main,
                 systemSoundInputChannelOffset: tapInputChannelOffsets.systemSounds,
                 maxCallbackFrames: Self.maximumSupportedCallbackFrames
@@ -2190,33 +2619,45 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         if activeBackend.withLock({ $0 }) == .separateClock {
             return separateClockBackend.updateDSP(profile: profile)
         }
-        return control.withLock { state in
+        guard let preparation = control.withLock({ state -> (AudioRuntime, EQProfile, Double)? in
             guard let runtime = state.runtime,
                   let activeProfile = state.activeProfile else {
-                return false
+                return nil
             }
             let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
                 sampleRate: runtime.sampleRate
             )
+            return (runtime, activeProfile, maximumUsableFrequency)
+        }) else {
+            return false
+        }
+        let (runtime, activeProfile, maximumUsableFrequency) = preparation
+        guard let preparedConfig = try? EQRenderConfiguration.prepare(
+            profile: profile,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ), preparedConfig.isNumericallySafe else {
+            return false
+        }
+        return control.withLock { state in
+            guard state.runtime === runtime,
+                  state.activeProfile == activeProfile else {
+                return false
+            }
             guard Self.canHotSwapDSP(
                 from: activeProfile,
                 to: profile,
                 sampleRate: runtime.sampleRate,
                 channelCount: runtime.channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
+                maximumUsableFrequency: maximumUsableFrequency,
+                preparedConfiguration: preparedConfig
             ) else {
                 return false
             }
             runtime.setProgrammeComparisonSelection(.equalized)
             runtime.drainDSPConfigBoxes()
-            runtime.publishPendingDSPConfig(
-                EQRenderConfiguration(
-                    profile: profile,
-                    sampleRate: runtime.sampleRate,
-                    channelCount: runtime.channelCount,
-                    maximumUsableFrequency: maximumUsableFrequency
-                )
-            )
+            runtime.publishPendingDSPConfig(preparedConfig)
             state.activeProfile = profile
             return true
         }
@@ -2230,27 +2671,38 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         if activeBackend.withLock({ $0 }) == .separateClock {
             return separateClockBackend.beginProgrammeComparison(profile: profile)
         }
-        return control.withLock { state in
-            guard let runtime = state.runtime else {
-                return false
+        guard let preparation = control.withLock({ state -> (AudioRuntime, EQProfile)? in
+            guard let runtime = state.runtime,
+                  let activeProfile = state.activeProfile else {
+                return nil
             }
-            let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
-                sampleRate: runtime.sampleRate
-            )
-            let equalizedConfig = EQRenderConfiguration(
-                profile: profile,
-                sampleRate: runtime.sampleRate,
-                channelCount: runtime.channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
-            )
-            let referenceConfig = EQRenderConfiguration(
-                profile: profile.programmeComparisonReference,
-                sampleRate: runtime.sampleRate,
-                channelCount: runtime.channelCount,
-                maximumUsableFrequency: maximumUsableFrequency
-            )
-            guard equalizedConfig.isNumericallySafe,
-                  referenceConfig.isNumericallySafe else {
+            return (runtime, activeProfile)
+        }) else {
+            return false
+        }
+        let (runtime, activeProfile) = preparation
+        let maximumUsableFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+            sampleRate: runtime.sampleRate
+        )
+        guard let equalizedConfig = try? EQRenderConfiguration.prepare(
+            profile: profile,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ),
+        let referenceConfig = try? EQRenderConfiguration.prepare(
+            profile: profile.programmeComparisonReference,
+            sampleRate: runtime.sampleRate,
+            channelCount: runtime.channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ),
+        equalizedConfig.isNumericallySafe,
+        referenceConfig.isNumericallySafe else {
+            return false
+        }
+        return control.withLock { state in
+            guard state.runtime === runtime,
+                  state.activeProfile == activeProfile else {
                 return false
             }
             runtime.setProgrammeComparisonSelection(.equalized)
@@ -3033,14 +3485,18 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         to nextProfile: EQProfile,
         sampleRate: Double,
         channelCount: Int,
-        maximumUsableFrequency: Double? = nil
+        maximumUsableFrequency: Double? = nil,
+        preparedConfiguration: EQRenderConfiguration? = nil
     ) -> Bool {
-        EQRenderConfiguration(
+        if let preparedConfiguration {
+            return preparedConfiguration.isNumericallySafe
+        }
+        return (try? EQRenderConfiguration.prepare(
             profile: nextProfile,
             sampleRate: sampleRate,
             channelCount: channelCount,
             maximumUsableFrequency: maximumUsableFrequency
-        ).isNumericallySafe
+        ))?.isNumericallySafe == true
     }
 
     static func supportedRuntimeChannelCount(
@@ -3543,16 +3999,41 @@ public final class SystemTapAudioEngine: @unchecked Sendable {
         frameCount: Int,
         sampleRate: Double
     ) -> UInt64 {
+        let expectedNanoseconds = renderPeriodNanoseconds(
+            frameCount: frameCount,
+            sampleRate: sampleRate
+        )
+        guard expectedNanoseconds > 0 else {
+            return 0
+        }
+        let elapsedPeriods = elapsedNanoseconds / expectedNanoseconds
+        return elapsedPeriods >= 2 ? elapsedPeriods - 1 : 0
+    }
+
+    static func renderOverranPeriod(
+        elapsedNanoseconds: UInt64,
+        frameCount: Int,
+        sampleRate: Double
+    ) -> Bool {
+        let expectedNanoseconds = renderPeriodNanoseconds(
+            frameCount: frameCount,
+            sampleRate: sampleRate
+        )
+        return expectedNanoseconds > 0 && elapsedNanoseconds > expectedNanoseconds
+    }
+
+    static func renderPeriodNanoseconds(
+        frameCount: Int,
+        sampleRate: Double
+    ) -> UInt64 {
         guard frameCount > 0,
               sampleRate.isFinite,
               sampleRate > 0 else {
             return 0
         }
-        let expectedNanoseconds = UInt64(
+        return UInt64(
             max((Double(frameCount) * 1_000_000_000 / sampleRate).rounded(), 1)
         )
-        let elapsedPeriods = elapsedNanoseconds / expectedNanoseconds
-        return elapsedPeriods >= 2 ? elapsedPeriods - 1 : 0
     }
 
     static func preferredBufferFrameSize(for _: AudioOutputDevice) -> UInt32 {

--- a/Sources/GlassEQCore/Biquad.swift
+++ b/Sources/GlassEQCore/Biquad.swift
@@ -267,6 +267,62 @@ public enum FrequencyResponse {
             .max() ?? preampDB
     }
 
+    public static func points(
+        for source: EQConvolutionSource?,
+        preampDB: Double,
+        sampleRate: Double = 48_000,
+        count: Int = 96
+    ) -> [FrequencyResponsePoint] {
+        let lower = log10(20.0)
+        let upperFrequency = max(
+            20,
+            EQRouteFrequencyPolicy.maximumUsableFrequency(sampleRate: sampleRate)
+        )
+        let upper = log10(upperFrequency)
+        let curve = magnitudePoints(from: source)
+        return (0..<max(count, 2)).map { index in
+            let fraction = Double(index) / Double(max(count - 1, 1))
+            let frequency = pow(10, lower + (upper - lower) * fraction)
+            return FrequencyResponsePoint(
+                frequency: frequency,
+                magnitudeDB: preampDB + MinimumPhaseFIRCompiler.interpolatedGainDB(
+                    frequency: frequency,
+                    points: curve
+                )
+            )
+        }
+    }
+
+    public static func peakMagnitudeDB(
+        for source: EQConvolutionSource?,
+        preampDB: Double,
+        sampleRate: Double = 48_000
+    ) -> Double {
+        let maximumFrequency = EQRouteFrequencyPolicy.maximumUsableFrequency(
+            sampleRate: sampleRate
+        )
+        let curve = magnitudePoints(from: source)
+        let relevantGains = curve.lazy
+            .filter { $0.frequency <= maximumFrequency }
+            .map(\.gainDB)
+        let boundaryGain = MinimumPhaseFIRCompiler.interpolatedGainDB(
+            frequency: maximumFrequency,
+            points: curve
+        )
+        return preampDB + max(relevantGains.max() ?? 0, boundaryGain)
+    }
+
+    private static func magnitudePoints(
+        from source: EQConvolutionSource?
+    ) -> [EQMagnitudePoint] {
+        switch source {
+        case .magnitudeCurve(let curve):
+            return curve.points.sorted { $0.frequency < $1.frequency }
+        case nil:
+            return []
+        }
+    }
+
     private static func enabledCoefficients(filters: [EQFilter], sampleRate: Double) -> [BiquadCoefficients] {
         Array(
             filters.lazy
@@ -319,11 +375,29 @@ public enum EQProfileAnalysis {
         let peaks: [Double]
         switch profile.channelMode {
         case .linked:
-            peaks = [FrequencyResponse.peakMagnitudeDB(for: profile.filters, preampDB: profile.preampDB, sampleRate: sampleRate)]
+            peaks = [peakMagnitudeDB(
+                mode: profile.mode,
+                filters: profile.filters,
+                source: profile.convolution,
+                preampDB: profile.preampDB,
+                sampleRate: sampleRate
+            )]
         case .stereo:
             peaks = [
-                FrequencyResponse.peakMagnitudeDB(for: profile.leftFilters, preampDB: profile.leftPreampDB, sampleRate: sampleRate),
-                FrequencyResponse.peakMagnitudeDB(for: profile.rightFilters, preampDB: profile.rightPreampDB, sampleRate: sampleRate)
+                peakMagnitudeDB(
+                    mode: profile.mode,
+                    filters: profile.leftFilters,
+                    source: profile.leftConvolution,
+                    preampDB: profile.leftPreampDB,
+                    sampleRate: sampleRate
+                ),
+                peakMagnitudeDB(
+                    mode: profile.mode,
+                    filters: profile.rightFilters,
+                    source: profile.rightConvolution,
+                    preampDB: profile.rightPreampDB,
+                    sampleRate: sampleRate
+                )
             ]
         }
         let peak = peaks.max() ?? 0
@@ -336,5 +410,26 @@ public enum EQProfileAnalysis {
         case .stereo:
             return min(profile.leftPreampDB, profile.rightPreampDB)
         }
+    }
+
+    private static func peakMagnitudeDB(
+        mode: EQMode,
+        filters: [EQFilter],
+        source: EQConvolutionSource?,
+        preampDB: Double,
+        sampleRate: Double
+    ) -> Double {
+        if mode == .convolution {
+            return FrequencyResponse.peakMagnitudeDB(
+                for: source,
+                preampDB: preampDB,
+                sampleRate: sampleRate
+            )
+        }
+        return FrequencyResponse.peakMagnitudeDB(
+            for: filters,
+            preampDB: preampDB,
+            sampleRate: sampleRate
+        )
     }
 }

--- a/Sources/GlassEQCore/EQModels.swift
+++ b/Sources/GlassEQCore/EQModels.swift
@@ -4,6 +4,7 @@ public enum EQMode: String, Codable, Sendable, CaseIterable {
     case parametric
     case graphic10
     case graphic31
+    case convolution
 }
 
 public enum EQChannelMode: String, Codable, Sendable, CaseIterable {
@@ -44,6 +45,69 @@ public struct EQFilter: Codable, Equatable, Identifiable, Sendable {
     }
 }
 
+public struct EQMagnitudePoint: Codable, Equatable, Identifiable, Sendable {
+    public var id: UUID
+    public var frequency: Double
+    public var gainDB: Double
+
+    public init(
+        id: UUID = UUID(),
+        frequency: Double,
+        gainDB: Double
+    ) {
+        self.id = id
+        self.frequency = frequency
+        self.gainDB = gainDB
+    }
+}
+
+public struct MagnitudeCurveSource: Codable, Equatable, Sendable {
+    public var synthesisVersion: UInt16
+    public var points: [EQMagnitudePoint]
+
+    public init(
+        synthesisVersion: UInt16 = MinimumPhaseFIRCompiler.synthesisVersion,
+        points: [EQMagnitudePoint]
+    ) {
+        self.synthesisVersion = synthesisVersion
+        self.points = points
+    }
+}
+
+public enum EQConvolutionSource: Equatable, Sendable {
+    case magnitudeCurve(MagnitudeCurveSource)
+}
+
+extension EQConvolutionSource: Codable {
+    private enum SourceType: String, Codable {
+        case magnitudeCurve
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case magnitudeCurve
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(SourceType.self, forKey: .type) {
+        case .magnitudeCurve:
+            self = .magnitudeCurve(
+                try container.decode(MagnitudeCurveSource.self, forKey: .magnitudeCurve)
+            )
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .magnitudeCurve(let source):
+            try container.encode(SourceType.magnitudeCurve, forKey: .type)
+            try container.encode(source, forKey: .magnitudeCurve)
+        }
+    }
+}
+
 public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
     public var id: UUID
     public var name: String
@@ -55,6 +119,9 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
     public var leftFilters: [EQFilter]
     public var rightPreampDB: Double
     public var rightFilters: [EQFilter]
+    public var convolution: EQConvolutionSource?
+    public var leftConvolution: EQConvolutionSource?
+    public var rightConvolution: EQConvolutionSource?
     public var isBypassed: Bool
 
     public init(
@@ -68,6 +135,9 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
         leftFilters: [EQFilter]? = nil,
         rightPreampDB: Double? = nil,
         rightFilters: [EQFilter]? = nil,
+        convolution: EQConvolutionSource? = nil,
+        leftConvolution: EQConvolutionSource? = nil,
+        rightConvolution: EQConvolutionSource? = nil,
         isBypassed: Bool = false
     ) {
         self.id = id
@@ -80,6 +150,9 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
         self.leftFilters = leftFilters ?? filters
         self.rightPreampDB = rightPreampDB ?? preampDB
         self.rightFilters = rightFilters ?? filters
+        self.convolution = convolution
+        self.leftConvolution = leftConvolution ?? convolution
+        self.rightConvolution = rightConvolution ?? convolution
         self.isBypassed = isBypassed
     }
 
@@ -94,6 +167,9 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
         case leftFilters
         case rightPreampDB
         case rightFilters
+        case convolution
+        case leftConvolution
+        case rightConvolution
         case isBypassed
     }
 
@@ -109,6 +185,11 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
         leftFilters = try container.decodeIfPresent([EQFilter].self, forKey: .leftFilters) ?? filters
         rightPreampDB = try container.decodeIfPresent(Double.self, forKey: .rightPreampDB) ?? preampDB
         rightFilters = try container.decodeIfPresent([EQFilter].self, forKey: .rightFilters) ?? filters
+        convolution = try container.decodeIfPresent(EQConvolutionSource.self, forKey: .convolution)
+        leftConvolution = try container.decodeIfPresent(EQConvolutionSource.self, forKey: .leftConvolution)
+            ?? convolution
+        rightConvolution = try container.decodeIfPresent(EQConvolutionSource.self, forKey: .rightConvolution)
+            ?? convolution
         isBypassed = try container.decodeIfPresent(Bool.self, forKey: .isBypassed) ?? false
     }
 
@@ -124,6 +205,9 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
         try container.encode(leftFilters, forKey: .leftFilters)
         try container.encode(rightPreampDB, forKey: .rightPreampDB)
         try container.encode(rightFilters, forKey: .rightFilters)
+        try container.encodeIfPresent(convolution, forKey: .convolution)
+        try container.encodeIfPresent(leftConvolution, forKey: .leftConvolution)
+        try container.encodeIfPresent(rightConvolution, forKey: .rightConvolution)
         try container.encode(isBypassed, forKey: .isBypassed)
     }
 
@@ -147,6 +231,16 @@ public struct EQProfile: Codable, Equatable, Identifiable, Sendable {
         filters: GraphicEQBands.thirtyOneBand.map {
             EQFilter(kind: .peak, frequency: $0, gainDB: 0, q: GraphicEQBands.graphicQ)
         }
+    )
+
+    public static let flatConvolution = EQProfile(
+        name: "Flat Response Curve",
+        mode: .convolution,
+        filters: [],
+        convolution: .magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: 0),
+            EQMagnitudePoint(frequency: 20_000, gainDB: 0)
+        ]))
     )
 }
 

--- a/Sources/GlassEQCore/EQModels.swift
+++ b/Sources/GlassEQCore/EQModels.swift
@@ -308,7 +308,8 @@ public struct ProfileStoreRepairSummary: Equatable, Sendable {
 }
 
 public struct ProfileStore: Codable, Equatable, Sendable {
-    public static let currentSchemaVersion = 1
+    static let initialSchemaVersion = 1
+    public static let currentSchemaVersion = 2
     public static let defaultProfiles: [EQProfile] = [.flatGraphic31, .flatGraphic10, .flatParametric]
 
     public var schemaVersion: Int
@@ -337,7 +338,7 @@ public struct ProfileStore: Codable, Equatable, Sendable {
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? Self.currentSchemaVersion
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? Self.initialSchemaVersion
         profiles = try container.decode([EQProfile].self, forKey: .profiles)
         outputMappings = try container.decode([OutputDeviceProfileMapping].self, forKey: .outputMappings)
         fallbackProfileID = try container.decode(UUID.self, forKey: .fallbackProfileID)

--- a/Sources/GlassEQCore/EQProcessor.swift
+++ b/Sources/GlassEQCore/EQProcessor.swift
@@ -30,6 +30,8 @@ public struct EQConfiguration: Equatable, Sendable {
     public var preampLinearGain: Float
     public var coefficients: [BiquadCoefficients]
     public var channelConfigurations: [EQChannelConfiguration]
+    public var convolutionSources: [EQConvolutionSource?]
+    public var usesConvolution: Bool
     public var isBypassed: Bool
 
     public init(
@@ -59,6 +61,11 @@ public struct EQConfiguration: Equatable, Sendable {
             channelCount: self.channelCount,
             linkedConfiguration: linkedConfiguration
         )
+        self.convolutionSources = Self.makeConvolutionSources(
+            profile: profile,
+            channelCount: self.channelCount
+        )
+        self.usesConvolution = profile.mode == .convolution
         self.isBypassed = profile.isBypassed
     }
 
@@ -97,14 +104,38 @@ public struct EQConfiguration: Equatable, Sendable {
             }
         }
     }
+
+    private static func makeConvolutionSources(
+        profile: EQProfile,
+        channelCount: Int
+    ) -> [EQConvolutionSource?] {
+        guard profile.mode == .convolution else {
+            return Array(repeating: nil, count: channelCount)
+        }
+        guard profile.channelMode == .stereo else {
+            return Array(repeating: profile.convolution, count: channelCount)
+        }
+        return (0..<channelCount).map { channel in
+            switch channel {
+            case 0:
+                profile.leftConvolution
+            case 1:
+                profile.rightConvolution
+            default:
+                profile.convolution
+            }
+        }
+    }
 }
 
-public struct EQRenderConfiguration: Equatable, Sendable {
+public struct EQRenderConfiguration: Sendable {
     public var configuration: EQConfiguration
     var coefficients: [RenderBiquadCoefficients]
     var channelStarts: [Int]
     var channelFilterCounts: [Int]
     var preampLinearGains: [Float]
+    var convolvers: [RealtimeHybridConvolver?]
+    private var preparationSucceeded: Bool
 
     public init(
         profile: EQProfile,
@@ -121,26 +152,100 @@ public struct EQRenderConfiguration: Equatable, Sendable {
     }
 
     public init(configuration: EQConfiguration) {
+        do {
+            try self.init(preparing: configuration)
+        } catch {
+            self.init(unprepared: configuration)
+        }
+    }
+
+    public static func prepare(
+        profile: EQProfile,
+        sampleRate: Double,
+        channelCount: Int,
+        maximumUsableFrequency: Double? = nil
+    ) throws -> EQRenderConfiguration {
+        try EQRenderConfiguration(preparing: EQConfiguration(
+            profile: profile,
+            sampleRate: sampleRate,
+            channelCount: channelCount,
+            maximumUsableFrequency: maximumUsableFrequency
+        ))
+    }
+
+    private init(preparing configuration: EQConfiguration) throws {
         self.configuration = configuration
         let renderLayout = EQProcessor.makeRenderLayout(configuration: configuration)
         self.coefficients = renderLayout.coefficients
         self.channelStarts = renderLayout.channelStarts
         self.channelFilterCounts = renderLayout.channelFilterCounts
         self.preampLinearGains = renderLayout.preampLinearGains
+        self.convolvers = try Self.makeConvolvers(configuration: configuration)
+        self.preparationSucceeded = true
+    }
+
+    private init(unprepared configuration: EQConfiguration) {
+        self.configuration = configuration
+        let renderLayout = EQProcessor.makeRenderLayout(configuration: configuration)
+        self.coefficients = renderLayout.coefficients
+        self.channelStarts = renderLayout.channelStarts
+        self.channelFilterCounts = renderLayout.channelFilterCounts
+        self.preampLinearGains = renderLayout.preampLinearGains
+        self.convolvers = Array(repeating: nil, count: configuration.channelCount)
+        self.preparationSucceeded = !configuration.usesConvolution
     }
 
     public func hasRealtimeCompatibleTopology(with other: EQRenderConfiguration) -> Bool {
         configuration.sampleRate == other.configuration.sampleRate
             && configuration.channelCount == other.configuration.channelCount
+            && configuration.usesConvolution == other.configuration.usesConvolution
             && channelFilterCounts == other.channelFilterCounts
     }
 
     public var isNumericallySafe: Bool {
-        configuration.sampleRate.isFinite
+        preparationSucceeded
+            && configuration.sampleRate.isFinite
             && configuration.sampleRate > 0
             && configuration.channelCount > 0
             && preampLinearGains.allSatisfy { $0.isFinite && $0 >= 0 }
             && coefficients.allSatisfy(Self.isNumericallySafe)
+            && (!configuration.usesConvolution
+                || convolvers.count == configuration.channelCount
+                    && convolvers.allSatisfy { $0 != nil })
+    }
+
+    private static func makeConvolvers(
+        configuration: EQConfiguration
+    ) throws -> [RealtimeHybridConvolver?] {
+        guard configuration.usesConvolution else {
+            return Array(repeating: nil, count: configuration.channelCount)
+        }
+
+        var preparedSources: [(source: EQConvolutionSource, kernel: PreparedConvolutionKernel)] = []
+        return try configuration.convolutionSources.map { source in
+            guard let source else {
+                throw MinimumPhaseFIRCompilerError.insufficientPoints
+            }
+            let kernel: PreparedConvolutionKernel
+            if let prepared = preparedSources.first(where: { $0.source == source }) {
+                kernel = prepared.kernel
+            } else {
+                switch source {
+                case .magnitudeCurve(let curve):
+                    guard curve.synthesisVersion == MinimumPhaseFIRCompiler.synthesisVersion else {
+                        throw MinimumPhaseFIRCompilerError.invalidPoint
+                    }
+                    kernel = try PreparedConvolutionKernel(
+                        impulseResponse: MinimumPhaseFIRCompiler.compile(
+                            points: curve.points,
+                            sampleRate: configuration.sampleRate
+                        )
+                    )
+                }
+                preparedSources.append((source, kernel))
+            }
+            return try RealtimeHybridConvolver(kernel: kernel)
+        }
     }
 
     private static func isNumericallySafe(_ coefficients: RenderBiquadCoefficients) -> Bool {
@@ -172,11 +277,55 @@ public struct EQRenderConfiguration: Equatable, Sendable {
     }
 }
 
+public struct EQRenderWorkTiming: Equatable, Sendable {
+    public var directHeadHostTicks: UInt64
+    public var tailScheduledWorkHostTicks: UInt64
+    public var tailCompletionObservations: UInt64
+    public var minimumTailCompletionSlackFrames: Int
+    public var tailDeadlineMisses: UInt64
+
+    public init(
+        directHeadHostTicks: UInt64 = 0,
+        tailScheduledWorkHostTicks: UInt64 = 0,
+        tailCompletionObservations: UInt64 = 0,
+        minimumTailCompletionSlackFrames: Int = 0,
+        tailDeadlineMisses: UInt64 = 0
+    ) {
+        self.directHeadHostTicks = directHeadHostTicks
+        self.tailScheduledWorkHostTicks = tailScheduledWorkHostTicks
+        self.tailCompletionObservations = tailCompletionObservations
+        self.minimumTailCompletionSlackFrames = minimumTailCompletionSlackFrames
+        self.tailDeadlineMisses = tailDeadlineMisses
+    }
+
+    mutating func merge(_ other: EQRenderWorkTiming) {
+        directHeadHostTicks &+= other.directHeadHostTicks
+        tailScheduledWorkHostTicks &+= other.tailScheduledWorkHostTicks
+        tailDeadlineMisses &+= other.tailDeadlineMisses
+        if other.tailCompletionObservations > 0 {
+            if tailCompletionObservations == 0 {
+                minimumTailCompletionSlackFrames = other.minimumTailCompletionSlackFrames
+            } else {
+                minimumTailCompletionSlackFrames = min(
+                    minimumTailCompletionSlackFrames,
+                    other.minimumTailCompletionSlackFrames
+                )
+            }
+            tailCompletionObservations &+= other.tailCompletionObservations
+        }
+    }
+}
+
 struct EQLinearRenderDiagnostics: Equatable, Sendable {
     var nonFiniteSamples: UInt64
+    var workTiming: EQRenderWorkTiming
 
-    init(nonFiniteSamples: UInt64 = 0) {
+    init(
+        nonFiniteSamples: UInt64 = 0,
+        workTiming: EQRenderWorkTiming = EQRenderWorkTiming()
+    ) {
         self.nonFiniteSamples = nonFiniteSamples
+        self.workTiming = workTiming
     }
 }
 
@@ -187,6 +336,13 @@ public struct EQProcessor: Sendable {
     private var channelStarts: [Int]
     private var channelFilterCounts: [Int]
     private var preampLinearGains: [Float]
+    private var convolvers: [RealtimeHybridConvolver?]
+
+    public var requiredWarmupFrames: Int {
+        configuration.usesConvolution && !configuration.isBypassed
+            ? PreparedConvolutionKernel.tapCount - 1
+            : 0
+    }
 
     public init(configuration: EQConfiguration) {
         self.init(renderConfiguration: EQRenderConfiguration(configuration: configuration))
@@ -199,6 +355,8 @@ public struct EQProcessor: Sendable {
         self.channelStarts = renderConfiguration.channelStarts
         self.channelFilterCounts = renderConfiguration.channelFilterCounts
         self.preampLinearGains = renderConfiguration.preampLinearGains
+        self.convolvers = renderConfiguration.convolvers
+        resetConvolversForExclusiveRenderOwnership()
     }
 
     public mutating func update(configuration: EQConfiguration) {
@@ -216,6 +374,8 @@ public struct EQProcessor: Sendable {
         channelStarts = renderConfiguration.channelStarts
         channelFilterCounts = renderConfiguration.channelFilterCounts
         preampLinearGains = renderConfiguration.preampLinearGains
+        convolvers = renderConfiguration.convolvers
+        resetConvolversForExclusiveRenderOwnership()
 
         if needsStateReset {
             states = Array(repeating: BiquadState(), count: renderConfiguration.coefficients.count)
@@ -236,6 +396,12 @@ public struct EQProcessor: Sendable {
 
         for index in nextCoefficients.indices where previousCoefficients[index] != nextCoefficients[index] {
             states[index] = BiquadState()
+        }
+    }
+
+    private mutating func resetConvolversForExclusiveRenderOwnership() {
+        for index in convolvers.indices {
+            convolvers[index]?.reset()
         }
     }
 
@@ -271,6 +437,19 @@ public struct EQProcessor: Sendable {
         let availableFrames = min(frameCount, samples.count / sourceChannelCount)
         guard availableFrames > 0 else {
             return 0
+        }
+
+        if configuration.usesConvolution {
+            let diagnostics = processConvolutionInterleavedLinearly(
+                samples,
+                frameCount: availableFrames,
+                channelCount: sourceChannelCount
+            )
+            return diagnostics.nonFiniteSamples &+ Self.protectInterleavedWithDiagnostics(
+                samples,
+                frameCount: availableFrames,
+                channelCount: sourceChannelCount
+            )
         }
 
         if sourceChannelCount == 2, channelStarts.count >= 2 {
@@ -331,6 +510,14 @@ public struct EQProcessor: Sendable {
             )
         }
 
+        if configuration.usesConvolution {
+            return processConvolutionInterleavedLinearly(
+                samples,
+                frameCount: availableFrames,
+                channelCount: sourceChannelCount
+            )
+        }
+
         return withRenderBuffers { stateBuffer, coefficientBuffer, channelStartBuffer, channelFilterCountBuffer, preampLinearGainBuffer in
             var diagnostics = EQLinearRenderDiagnostics()
             let channels = min(sourceChannelCount, channelStartBuffer.count)
@@ -380,6 +567,18 @@ public struct EQProcessor: Sendable {
             return
         }
 
+        if configuration.usesConvolution {
+            for channelIndex in channels.indices {
+                for sampleIndex in channels[channelIndex].indices {
+                    channels[channelIndex][sampleIndex] = processSample(
+                        channels[channelIndex][sampleIndex],
+                        channel: channelIndex
+                    )
+                }
+            }
+            return
+        }
+
         withRenderBuffers { stateBuffer, coefficientBuffer, channelStartBuffer, channelFilterCountBuffer, preampLinearGainBuffer in
             for channelIndex in channels.indices {
                 guard channelIndex < channelStartBuffer.count else {
@@ -411,6 +610,20 @@ public struct EQProcessor: Sendable {
 
         guard channel >= 0, channel < channelStarts.count else {
             return (input, false)
+        }
+        if configuration.usesConvolution {
+            guard channel < convolvers.count,
+                  convolvers[channel] != nil else {
+                return (0, true)
+            }
+            let processed = convolvers[channel]!.processSample(
+                input * preampLinearGains[channel]
+            )
+            let protected = Self.saturate(processed.sample)
+            return (
+                protected.sample,
+                processed.encounteredNonFinite || protected.saturated
+            )
         }
         return withRenderBuffers { stateBuffer, coefficientBuffer, channelStartBuffer, channelFilterCountBuffer, preampLinearGainBuffer in
             Self.processSampleWithDiagnosticsUnchecked(
@@ -451,6 +664,36 @@ public struct EQProcessor: Sendable {
                 }
             }
         }
+    }
+
+    private mutating func processConvolutionInterleavedLinearly(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> EQLinearRenderDiagnostics {
+        var diagnostics = EQLinearRenderDiagnostics()
+        let channels = min(channelCount, convolvers.count)
+        for channel in 0..<channels {
+            guard convolvers[channel] != nil else {
+                diagnostics.nonFiniteSamples += UInt64(frameCount)
+                var sampleIndex = channel
+                for _ in 0..<frameCount {
+                    samples[sampleIndex] = 0
+                    sampleIndex += channelCount
+                }
+                continue
+            }
+            let channelDiagnostics = convolvers[channel]!.processInterleavedChannel(
+                samples,
+                frameCount: frameCount,
+                channel: channel,
+                channelCount: channelCount,
+                preampLinearGain: preampLinearGains[channel]
+            )
+            diagnostics.nonFiniteSamples &+= channelDiagnostics.nonFiniteSamples
+            diagnostics.workTiming.merge(channelDiagnostics.workTiming)
+        }
+        return diagnostics
     }
 
     private static func processStereoInterleaved(

--- a/Sources/GlassEQCore/HybridConvolver.swift
+++ b/Sources/GlassEQCore/HybridConvolver.swift
@@ -1,0 +1,584 @@
+import Accelerate
+import Darwin
+import Foundation
+
+enum HybridConvolverError: Error, Equatable, Sendable {
+    case invalidImpulseResponse
+    case transformSetupFailed
+}
+
+struct PreparedConvolutionKernel: @unchecked Sendable {
+    static let tapCount = 16_384
+    static let directTapCount = 512
+    static let tailPartitionFrames = 256
+    static let transformFrames = tailPartitionFrames * 2
+    static let packedBinCount = transformFrames / 2
+    static let tailPartitionCount = (tapCount - directTapCount) / tailPartitionFrames
+
+    let directCoefficientsReversed: [Float]
+    let tailSpectrumReal: [Float]
+    let tailSpectrumImaginary: [Float]
+
+    init(impulseResponse: [Float]) throws {
+        guard !impulseResponse.isEmpty,
+              impulseResponse.count <= Self.tapCount,
+              impulseResponse.allSatisfy(\.isFinite) else {
+            throw HybridConvolverError.invalidImpulseResponse
+        }
+
+        var padded = [Float](repeating: 0, count: Self.tapCount)
+        padded.replaceSubrange(0..<impulseResponse.count, with: impulseResponse)
+        self.directCoefficientsReversed = Array(
+            padded[0..<Self.directTapCount].reversed()
+        )
+
+        let setup = try RealFloatDFTSetup()
+        var spectrumReal = [Float](
+            repeating: 0,
+            count: Self.tailPartitionCount * Self.packedBinCount
+        )
+        var spectrumImaginary = spectrumReal
+        var inputEven = [Float](repeating: 0, count: Self.packedBinCount)
+        var inputOdd = inputEven
+        var outputReal = inputEven
+        var outputImaginary = inputEven
+
+        for partition in 0..<Self.tailPartitionCount {
+            clear(&inputEven)
+            clear(&inputOdd)
+            let sourceStart = Self.directTapCount + partition * Self.tailPartitionFrames
+            for pair in 0..<(Self.tailPartitionFrames / 2) {
+                inputEven[pair] = padded[sourceStart + pair * 2]
+                inputOdd[pair] = padded[sourceStart + pair * 2 + 1]
+            }
+            setup.forward(
+                even: &inputEven,
+                odd: &inputOdd,
+                outputReal: &outputReal,
+                outputImaginary: &outputImaginary
+            )
+            let destinationStart = partition * Self.packedBinCount
+            for bin in 0..<Self.packedBinCount {
+                spectrumReal[destinationStart + bin] = outputReal[bin] * 0.5
+                spectrumImaginary[destinationStart + bin] = outputImaginary[bin] * 0.5
+            }
+        }
+
+        self.tailSpectrumReal = spectrumReal
+        self.tailSpectrumImaginary = spectrumImaginary
+    }
+}
+
+struct RealtimeHybridConvolver: @unchecked Sendable {
+    private static let outputRingFrames = 1_024
+    private static let outputRingMask = outputRingFrames - 1
+    private static let inverseGuardFrames = 16
+    private static let partitionWorkFrames = PreparedConvolutionKernel.tailPartitionFrames
+        - inverseGuardFrames
+
+    private let kernel: PreparedConvolutionKernel
+    private let transform: RealFloatDFTSetup
+    private var directHistory = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.directTapCount * 2
+    )
+    private var directWriteIndex = 0
+    private var tailInputBlock = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.tailPartitionFrames
+    )
+    private var tailInputCount = 0
+    private var fftInputEven = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var fftInputOdd = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var fftOutputReal = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var fftOutputImaginary = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var inputSpectrumReal = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.tailPartitionCount
+            * PreparedConvolutionKernel.packedBinCount
+    )
+    private var inputSpectrumImaginary = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.tailPartitionCount
+            * PreparedConvolutionKernel.packedBinCount
+    )
+    private var inputSpectrumWriteIndex = -1
+    private var accumulatorReal = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var accumulatorImaginary = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var inverseOutputEven = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var inverseOutputOdd = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.packedBinCount
+    )
+    private var tailOverlap = [Float](
+        repeating: 0,
+        count: PreparedConvolutionKernel.tailPartitionFrames
+    )
+    private var tailOutputRing = [Float](
+        repeating: 0,
+        count: Self.outputRingFrames
+    )
+    private var jobActive = false
+    private var jobInputSpectrumIndex = 0
+    private var jobNextPartition = 0
+    private var jobWorkNumerator = 0
+    private var jobDueFrame: Int64 = 0
+    private var absoluteFrame: Int64 = 0
+
+    init(kernel: PreparedConvolutionKernel, prewarm: Bool = true) throws {
+        self.kernel = kernel
+        self.transform = try RealFloatDFTSetup()
+        if prewarm {
+            prewarmAndReset()
+        }
+    }
+
+    mutating func processSample(_ rawInput: Float) -> (
+        sample: Float,
+        encounteredNonFinite: Bool
+    ) {
+        let encounteredNonFinite = !rawInput.isFinite
+        let input = encounteredNonFinite ? 0 : rawInput
+        let outputRingIndex = Int(absoluteFrame) & Self.outputRingMask
+        let tailOutput = tailOutputRing[outputRingIndex]
+        tailOutputRing[outputRingIndex] = 0
+
+        directHistory[directWriteIndex] = input
+        directHistory[directWriteIndex + PreparedConvolutionKernel.directTapCount] = input
+        let historyStart = directWriteIndex + 1
+        var directOutput: Float = 0
+        kernel.directCoefficientsReversed.withUnsafeBufferPointer { coefficients in
+            directHistory.withUnsafeBufferPointer { history in
+                vDSP_dotpr(
+                    coefficients.baseAddress!,
+                    1,
+                    history.baseAddress! + historyStart,
+                    1,
+                    &directOutput,
+                    vDSP_Length(PreparedConvolutionKernel.directTapCount)
+                )
+            }
+        }
+        directWriteIndex = (directWriteIndex + 1)
+            & (PreparedConvolutionKernel.directTapCount - 1)
+
+        tailInputBlock[tailInputCount] = input
+        tailInputCount += 1
+        let completedInputBlock = tailInputCount
+            == PreparedConvolutionKernel.tailPartitionFrames
+
+        advanceTailJobByOneFrame()
+        absoluteFrame += 1
+        if completedInputBlock {
+            beginTailJob()
+        }
+
+        let output = directOutput + tailOutput
+        return (output.isFinite ? output : 0, encounteredNonFinite || !output.isFinite)
+    }
+
+    mutating func processInterleavedChannel(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channel: Int,
+        channelCount: Int,
+        preampLinearGain: Float
+    ) -> EQLinearRenderDiagnostics {
+        guard channel >= 0,
+              channel < channelCount,
+              frameCount > 0 else {
+            return EQLinearRenderDiagnostics()
+        }
+
+        var diagnostics = EQLinearRenderDiagnostics()
+        var renderedFrames = 0
+        while renderedFrames < frameCount {
+            let segmentFrames = min(
+                frameCount - renderedFrames,
+                PreparedConvolutionKernel.tailPartitionFrames - tailInputCount
+            )
+
+            let tailAdvanceStart = mach_absolute_time()
+            let tailAdvance = advanceTailJob(frameCount: segmentFrames)
+            let directHeadStart = mach_absolute_time()
+            if tailAdvance.didWork {
+                diagnostics.workTiming.tailScheduledWorkHostTicks &+=
+                    directHeadStart &- tailAdvanceStart
+            }
+            diagnostics.workTiming.mergeTailCompletion(tailAdvance.completion)
+
+            var sampleIndex = channel + renderedFrames * channelCount
+            for _ in 0..<segmentFrames {
+                let rawInput = samples[sampleIndex] * preampLinearGain
+                let encounteredNonFinite = !rawInput.isFinite
+                let input = encounteredNonFinite ? 0 : rawInput
+                let outputRingIndex = Int(absoluteFrame) & Self.outputRingMask
+                let tailOutput = tailOutputRing[outputRingIndex]
+                tailOutputRing[outputRingIndex] = 0
+
+                directHistory[directWriteIndex] = input
+                directHistory[directWriteIndex + PreparedConvolutionKernel.directTapCount] = input
+                let historyStart = directWriteIndex + 1
+                var directOutput: Float = 0
+                kernel.directCoefficientsReversed.withUnsafeBufferPointer { coefficients in
+                    directHistory.withUnsafeBufferPointer { history in
+                        vDSP_dotpr(
+                            coefficients.baseAddress!,
+                            1,
+                            history.baseAddress! + historyStart,
+                            1,
+                            &directOutput,
+                            vDSP_Length(PreparedConvolutionKernel.directTapCount)
+                        )
+                    }
+                }
+                directWriteIndex = (directWriteIndex + 1)
+                    & (PreparedConvolutionKernel.directTapCount - 1)
+
+                tailInputBlock[tailInputCount] = input
+                tailInputCount += 1
+                absoluteFrame += 1
+
+                let output = directOutput + tailOutput
+                samples[sampleIndex] = output.isFinite ? output : 0
+                if encounteredNonFinite || !output.isFinite {
+                    diagnostics.nonFiniteSamples += 1
+                }
+                sampleIndex += channelCount
+            }
+            let directHeadEnd = mach_absolute_time()
+            diagnostics.workTiming.directHeadHostTicks &+= directHeadEnd &- directHeadStart
+
+            if tailInputCount == PreparedConvolutionKernel.tailPartitionFrames {
+                let tailBeginStart = mach_absolute_time()
+                beginTailJob()
+                diagnostics.workTiming.tailScheduledWorkHostTicks &+=
+                    mach_absolute_time() &- tailBeginStart
+            }
+            renderedFrames += segmentFrames
+        }
+        return diagnostics
+    }
+
+    mutating func reset() {
+        clear(&directHistory)
+        directWriteIndex = 0
+        clear(&tailInputBlock)
+        tailInputCount = 0
+        clear(&fftInputEven)
+        clear(&fftInputOdd)
+        clear(&fftOutputReal)
+        clear(&fftOutputImaginary)
+        clear(&inputSpectrumReal)
+        clear(&inputSpectrumImaginary)
+        inputSpectrumWriteIndex = -1
+        clear(&accumulatorReal)
+        clear(&accumulatorImaginary)
+        clear(&inverseOutputEven)
+        clear(&inverseOutputOdd)
+        clear(&tailOverlap)
+        clear(&tailOutputRing)
+        jobActive = false
+        jobInputSpectrumIndex = 0
+        jobNextPartition = 0
+        jobWorkNumerator = 0
+        jobDueFrame = 0
+        absoluteFrame = 0
+    }
+
+    private mutating func prewarmAndReset() {
+        for _ in 0..<(PreparedConvolutionKernel.tailPartitionFrames * 3) {
+            _ = processSample(0)
+        }
+        reset()
+    }
+
+    private mutating func advanceTailJobByOneFrame() {
+        _ = advanceTailJob(frameCount: 1)
+    }
+
+    private mutating func advanceTailJob(
+        frameCount: Int
+    ) -> TailAdvanceResult {
+        guard jobActive else {
+            return TailAdvanceResult()
+        }
+
+        jobWorkNumerator += PreparedConvolutionKernel.tailPartitionCount * frameCount
+        var didWork = false
+        while jobWorkNumerator >= Self.partitionWorkFrames,
+              jobNextPartition < PreparedConvolutionKernel.tailPartitionCount {
+            jobWorkNumerator -= Self.partitionWorkFrames
+            accumulateTailPartition(jobNextPartition)
+            jobNextPartition += 1
+            didWork = true
+        }
+
+        if jobNextPartition == PreparedConvolutionKernel.tailPartitionCount {
+            finishTailJob()
+            let completionFrame = absoluteFrame + Int64(frameCount)
+            let slackFrames = jobDueFrame - completionFrame
+            return TailAdvanceResult(
+                didWork: true,
+                completion: TailCompletion(
+                    slackFrames: max(Int(slackFrames), 0),
+                    missedDeadline: slackFrames < 0
+                )
+            )
+        }
+        return TailAdvanceResult(didWork: didWork)
+    }
+
+    private mutating func beginTailJob() {
+        precondition(!jobActive)
+        for pair in 0..<(PreparedConvolutionKernel.tailPartitionFrames / 2) {
+            fftInputEven[pair] = tailInputBlock[pair * 2]
+            fftInputOdd[pair] = tailInputBlock[pair * 2 + 1]
+        }
+        let zeroPairStart = PreparedConvolutionKernel.tailPartitionFrames / 2
+        for pair in zeroPairStart..<PreparedConvolutionKernel.packedBinCount {
+            fftInputEven[pair] = 0
+            fftInputOdd[pair] = 0
+        }
+        tailInputCount = 0
+
+        transform.forward(
+            even: &fftInputEven,
+            odd: &fftInputOdd,
+            outputReal: &fftOutputReal,
+            outputImaginary: &fftOutputImaginary
+        )
+        inputSpectrumWriteIndex = (inputSpectrumWriteIndex + 1)
+            % PreparedConvolutionKernel.tailPartitionCount
+        let destinationStart = inputSpectrumWriteIndex
+            * PreparedConvolutionKernel.packedBinCount
+        for bin in 0..<PreparedConvolutionKernel.packedBinCount {
+            inputSpectrumReal[destinationStart + bin] = fftOutputReal[bin] * 0.5
+            inputSpectrumImaginary[destinationStart + bin] = fftOutputImaginary[bin] * 0.5
+        }
+
+        clear(&accumulatorReal)
+        clear(&accumulatorImaginary)
+        jobActive = true
+        jobInputSpectrumIndex = inputSpectrumWriteIndex
+        jobNextPartition = 0
+        jobWorkNumerator = 0
+        jobDueFrame = absoluteFrame + Int64(PreparedConvolutionKernel.tailPartitionFrames)
+    }
+
+    private mutating func accumulateTailPartition(_ partition: Int) {
+        let spectrumIndex = (
+            jobInputSpectrumIndex
+                - partition
+                + PreparedConvolutionKernel.tailPartitionCount
+        ) % PreparedConvolutionKernel.tailPartitionCount
+        let inputStart = spectrumIndex * PreparedConvolutionKernel.packedBinCount
+        let kernelStart = partition * PreparedConvolutionKernel.packedBinCount
+
+        accumulatorReal[0] += inputSpectrumReal[inputStart]
+            * kernel.tailSpectrumReal[kernelStart]
+        accumulatorImaginary[0] += inputSpectrumImaginary[inputStart]
+            * kernel.tailSpectrumImaginary[kernelStart]
+        inputSpectrumReal.withUnsafeMutableBufferPointer { inputReal in
+            inputSpectrumImaginary.withUnsafeMutableBufferPointer { inputImaginary in
+                kernel.tailSpectrumReal.withUnsafeBufferPointer { kernelReal in
+                    kernel.tailSpectrumImaginary.withUnsafeBufferPointer { kernelImaginary in
+                        accumulatorReal.withUnsafeMutableBufferPointer { accumulatorReal in
+                            accumulatorImaginary.withUnsafeMutableBufferPointer { accumulatorImaginary in
+                                var input = DSPSplitComplex(
+                                    realp: inputReal.baseAddress! + inputStart + 1,
+                                    imagp: inputImaginary.baseAddress! + inputStart + 1
+                                )
+                                var coefficients = DSPSplitComplex(
+                                    realp: .init(mutating: kernelReal.baseAddress! + kernelStart + 1),
+                                    imagp: .init(mutating: kernelImaginary.baseAddress! + kernelStart + 1)
+                                )
+                                var accumulator = DSPSplitComplex(
+                                    realp: accumulatorReal.baseAddress! + 1,
+                                    imagp: accumulatorImaginary.baseAddress! + 1
+                                )
+                                vDSP_zvma(
+                                    &input,
+                                    1,
+                                    &coefficients,
+                                    1,
+                                    &accumulator,
+                                    1,
+                                    &accumulator,
+                                    1,
+                                    vDSP_Length(PreparedConvolutionKernel.packedBinCount - 1)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private mutating func finishTailJob() {
+        transform.inverse(
+            real: &accumulatorReal,
+            imaginary: &accumulatorImaginary,
+            outputEven: &inverseOutputEven,
+            outputOdd: &inverseOutputOdd
+        )
+        let scale = 1 / Float(PreparedConvolutionKernel.transformFrames)
+        for frame in 0..<PreparedConvolutionKernel.tailPartitionFrames {
+            let firstHalfSample = unpackedInverseSample(frame) * scale
+            let secondHalfSample = unpackedInverseSample(
+                frame + PreparedConvolutionKernel.tailPartitionFrames
+            ) * scale
+            let outputIndex = Int(jobDueFrame + Int64(frame)) & Self.outputRingMask
+            tailOutputRing[outputIndex] = firstHalfSample + tailOverlap[frame]
+            tailOverlap[frame] = secondHalfSample
+        }
+        jobActive = false
+        jobWorkNumerator = 0
+    }
+
+    private func unpackedInverseSample(_ frame: Int) -> Float {
+        let pair = frame / 2
+        return frame.isMultiple(of: 2)
+            ? inverseOutputEven[pair]
+            : inverseOutputOdd[pair]
+    }
+}
+
+private struct TailAdvanceResult {
+    var didWork = false
+    var completion: TailCompletion?
+}
+
+private struct TailCompletion {
+    var slackFrames: Int
+    var missedDeadline: Bool
+}
+
+private extension EQRenderWorkTiming {
+    mutating func mergeTailCompletion(_ completion: TailCompletion?) {
+        guard let completion else {
+            return
+        }
+        if tailCompletionObservations == 0 {
+            minimumTailCompletionSlackFrames = completion.slackFrames
+        } else {
+            minimumTailCompletionSlackFrames = min(
+                minimumTailCompletionSlackFrames,
+                completion.slackFrames
+            )
+        }
+        tailCompletionObservations &+= 1
+        if completion.missedDeadline {
+            tailDeadlineMisses &+= 1
+        }
+    }
+}
+
+private final class RealFloatDFTSetup: @unchecked Sendable {
+    private let forwardSetup: vDSP_DFT_Setup
+    private let inverseSetup: vDSP_DFT_Setup
+
+    init() throws {
+        let length = vDSP_Length(PreparedConvolutionKernel.transformFrames)
+        guard let forwardSetup = vDSP_DFT_zrop_CreateSetup(nil, length, .FORWARD) else {
+            throw HybridConvolverError.transformSetupFailed
+        }
+        guard let inverseSetup = vDSP_DFT_zrop_CreateSetup(
+            forwardSetup,
+            length,
+            .INVERSE
+        ) else {
+            vDSP_DFT_DestroySetup(forwardSetup)
+            throw HybridConvolverError.transformSetupFailed
+        }
+        self.forwardSetup = forwardSetup
+        self.inverseSetup = inverseSetup
+    }
+
+    deinit {
+        vDSP_DFT_DestroySetup(forwardSetup)
+        vDSP_DFT_DestroySetup(inverseSetup)
+    }
+
+    func forward(
+        even: inout [Float],
+        odd: inout [Float],
+        outputReal: inout [Float],
+        outputImaginary: inout [Float]
+    ) {
+        execute(
+            setup: forwardSetup,
+            inputReal: &even,
+            inputImaginary: &odd,
+            outputReal: &outputReal,
+            outputImaginary: &outputImaginary
+        )
+    }
+
+    func inverse(
+        real: inout [Float],
+        imaginary: inout [Float],
+        outputEven: inout [Float],
+        outputOdd: inout [Float]
+    ) {
+        execute(
+            setup: inverseSetup,
+            inputReal: &real,
+            inputImaginary: &imaginary,
+            outputReal: &outputEven,
+            outputImaginary: &outputOdd
+        )
+    }
+
+    private func execute(
+        setup: vDSP_DFT_Setup,
+        inputReal: inout [Float],
+        inputImaginary: inout [Float],
+        outputReal: inout [Float],
+        outputImaginary: inout [Float]
+    ) {
+        inputReal.withUnsafeBufferPointer { inputRealBuffer in
+            inputImaginary.withUnsafeBufferPointer { inputImaginaryBuffer in
+                outputReal.withUnsafeMutableBufferPointer { outputRealBuffer in
+                    outputImaginary.withUnsafeMutableBufferPointer { outputImaginaryBuffer in
+                        vDSP_DFT_Execute(
+                            setup,
+                            inputRealBuffer.baseAddress!,
+                            inputImaginaryBuffer.baseAddress!,
+                            outputRealBuffer.baseAddress!,
+                            outputImaginaryBuffer.baseAddress!
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private func clear(_ values: inout [Float]) {
+    for index in values.indices {
+        values[index] = 0
+    }
+}

--- a/Sources/GlassEQCore/MinimumPhaseFIRCompiler.swift
+++ b/Sources/GlassEQCore/MinimumPhaseFIRCompiler.swift
@@ -1,0 +1,239 @@
+import Accelerate
+import Foundation
+
+public enum MinimumPhaseFIRCompilerError: Error, Equatable, Sendable {
+    case invalidSampleRate
+    case insufficientPoints
+    case invalidPoint
+    case duplicateFrequency(Double)
+    case transformSetupFailed
+    case nonFiniteImpulseResponse
+}
+
+public enum MinimumPhaseFIRCompiler {
+    public static let synthesisVersion: UInt16 = 1
+    public static let tapCount = 16_384
+
+    public static func compile(
+        points: [EQMagnitudePoint],
+        sampleRate: Double
+    ) throws -> [Float] {
+        guard sampleRate.isFinite, sampleRate > 0 else {
+            throw MinimumPhaseFIRCompilerError.invalidSampleRate
+        }
+
+        let sortedPoints = try validatedPoints(points)
+        let transform = try ComplexDoubleDFT(length: tapCount)
+        let halfCount = tapCount / 2
+        let nyquist = sampleRate / 2
+        var logMagnitudeReal = [Double](repeating: 0, count: tapCount)
+        var logMagnitudeImaginary = [Double](repeating: 0, count: tapCount)
+
+        for bin in 0...halfCount {
+            let frequency = Double(bin) * nyquist / Double(halfCount)
+            let gainDB = interpolatedGainDB(
+                frequency: frequency,
+                points: sortedPoints
+            )
+            let logAmplitude = gainDB * log(10) / 20
+            logMagnitudeReal[bin] = logAmplitude
+            if bin > 0, bin < halfCount {
+                logMagnitudeReal[tapCount - bin] = logAmplitude
+            }
+        }
+
+        var cepstrumReal = [Double](repeating: 0, count: tapCount)
+        var cepstrumImaginary = [Double](repeating: 0, count: tapCount)
+        transform.inverse(
+            real: &logMagnitudeReal,
+            imaginary: &logMagnitudeImaginary,
+            outputReal: &cepstrumReal,
+            outputImaginary: &cepstrumImaginary
+        )
+        let inverseScale = 1 / Double(tapCount)
+        cepstrumReal[0] *= inverseScale
+        for index in 1..<halfCount {
+            cepstrumReal[index] *= 2 * inverseScale
+        }
+        cepstrumReal[halfCount] *= inverseScale
+        for index in (halfCount + 1)..<tapCount {
+            cepstrumReal[index] = 0
+        }
+        for index in cepstrumImaginary.indices {
+            cepstrumImaginary[index] = 0
+        }
+
+        var minimumPhaseLogReal = [Double](repeating: 0, count: tapCount)
+        var minimumPhaseLogImaginary = [Double](repeating: 0, count: tapCount)
+        transform.forward(
+            real: &cepstrumReal,
+            imaginary: &cepstrumImaginary,
+            outputReal: &minimumPhaseLogReal,
+            outputImaginary: &minimumPhaseLogImaginary
+        )
+
+        for index in 0..<tapCount {
+            let amplitude = exp(minimumPhaseLogReal[index])
+            let phase = minimumPhaseLogImaginary[index]
+            minimumPhaseLogReal[index] = amplitude * cos(phase)
+            minimumPhaseLogImaginary[index] = amplitude * sin(phase)
+        }
+
+        var impulseReal = [Double](repeating: 0, count: tapCount)
+        var impulseImaginary = [Double](repeating: 0, count: tapCount)
+        transform.inverse(
+            real: &minimumPhaseLogReal,
+            imaginary: &minimumPhaseLogImaginary,
+            outputReal: &impulseReal,
+            outputImaginary: &impulseImaginary
+        )
+
+        var impulse = [Float](repeating: 0, count: tapCount)
+        for index in 0..<tapCount {
+            let value = impulseReal[index] * inverseScale
+            guard value.isFinite else {
+                throw MinimumPhaseFIRCompilerError.nonFiniteImpulseResponse
+            }
+            impulse[index] = Float(value)
+        }
+        return impulse
+    }
+
+    public static func interpolatedGainDB(
+        frequency: Double,
+        points: [EQMagnitudePoint]
+    ) -> Double {
+        guard let first = points.first else {
+            return 0
+        }
+        guard frequency > first.frequency else {
+            return first.gainDB
+        }
+        guard let last = points.last, frequency < last.frequency else {
+            return points.last?.gainDB ?? first.gainDB
+        }
+
+        var lowerIndex = 0
+        var upperIndex = points.count - 1
+        while lowerIndex + 1 < upperIndex {
+            let middle = (lowerIndex + upperIndex) / 2
+            if points[middle].frequency <= frequency {
+                lowerIndex = middle
+            } else {
+                upperIndex = middle
+            }
+        }
+
+        let lower = points[lowerIndex]
+        let upper = points[upperIndex]
+        let lowerLog = log(lower.frequency)
+        let upperLog = log(upper.frequency)
+        let fraction = (log(frequency) - lowerLog) / (upperLog - lowerLog)
+        return lower.gainDB + (upper.gainDB - lower.gainDB) * fraction
+    }
+
+    private static func validatedPoints(
+        _ points: [EQMagnitudePoint]
+    ) throws -> [EQMagnitudePoint] {
+        guard points.count >= 2 else {
+            throw MinimumPhaseFIRCompilerError.insufficientPoints
+        }
+        guard points.allSatisfy({
+            $0.frequency.isFinite
+                && $0.frequency > 0
+                && $0.gainDB.isFinite
+        }) else {
+            throw MinimumPhaseFIRCompilerError.invalidPoint
+        }
+
+        let sorted = points.sorted { $0.frequency < $1.frequency }
+        for index in 1..<sorted.count where sorted[index].frequency == sorted[index - 1].frequency {
+            throw MinimumPhaseFIRCompilerError.duplicateFrequency(sorted[index].frequency)
+        }
+        return sorted
+    }
+}
+
+private final class ComplexDoubleDFT {
+    private let forwardSetup: vDSP_DFT_SetupD
+    private let inverseSetup: vDSP_DFT_SetupD
+
+    init(length: Int) throws {
+        guard let forwardSetup = vDSP_DFT_zop_CreateSetupD(
+            nil,
+            vDSP_Length(length),
+            .FORWARD
+        ) else {
+            throw MinimumPhaseFIRCompilerError.transformSetupFailed
+        }
+        guard let inverseSetup = vDSP_DFT_zop_CreateSetupD(
+            forwardSetup,
+            vDSP_Length(length),
+            .INVERSE
+        ) else {
+            vDSP_DFT_DestroySetupD(forwardSetup)
+            throw MinimumPhaseFIRCompilerError.transformSetupFailed
+        }
+        self.forwardSetup = forwardSetup
+        self.inverseSetup = inverseSetup
+    }
+
+    deinit {
+        vDSP_DFT_DestroySetupD(forwardSetup)
+        vDSP_DFT_DestroySetupD(inverseSetup)
+    }
+
+    func forward(
+        real: inout [Double],
+        imaginary: inout [Double],
+        outputReal: inout [Double],
+        outputImaginary: inout [Double]
+    ) {
+        execute(
+            setup: forwardSetup,
+            real: &real,
+            imaginary: &imaginary,
+            outputReal: &outputReal,
+            outputImaginary: &outputImaginary
+        )
+    }
+
+    func inverse(
+        real: inout [Double],
+        imaginary: inout [Double],
+        outputReal: inout [Double],
+        outputImaginary: inout [Double]
+    ) {
+        execute(
+            setup: inverseSetup,
+            real: &real,
+            imaginary: &imaginary,
+            outputReal: &outputReal,
+            outputImaginary: &outputImaginary
+        )
+    }
+
+    private func execute(
+        setup: vDSP_DFT_SetupD,
+        real: inout [Double],
+        imaginary: inout [Double],
+        outputReal: inout [Double],
+        outputImaginary: inout [Double]
+    ) {
+        real.withUnsafeBufferPointer { realBuffer in
+            imaginary.withUnsafeBufferPointer { imaginaryBuffer in
+                outputReal.withUnsafeMutableBufferPointer { outputRealBuffer in
+                    outputImaginary.withUnsafeMutableBufferPointer { outputImaginaryBuffer in
+                        vDSP_DFT_ExecuteD(
+                            setup,
+                            realBuffer.baseAddress!,
+                            imaginaryBuffer.baseAddress!,
+                            outputRealBuffer.baseAddress!,
+                            outputImaginaryBuffer.baseAddress!
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/GlassEQCore/ProfileImporters.swift
+++ b/Sources/GlassEQCore/ProfileImporters.swift
@@ -47,6 +47,7 @@ public struct ProfileImportLimits: Equatable, Sendable {
 
 public enum ProfileImportError: Error, Equatable, Sendable, LocalizedError {
     case noSupportedFilters
+    case mixedEqualizerAPOFormats(graphicEQLine: Int, filterLine: Int)
     case inputTooLarge(byteCount: Int, maximum: Int)
     case tooManyLines(lineCount: Int, maximum: Int)
     case invalidNumber(line: Int, field: String, value: String)
@@ -61,6 +62,8 @@ public enum ProfileImportError: Error, Equatable, Sendable, LocalizedError {
         switch self {
         case .noSupportedFilters:
             return "No supported filters were found in the imported profile."
+        case let .mixedEqualizerAPOFormats(graphicEQLine, filterLine):
+            return "Line \(graphicEQLine) contains GraphicEQ, but line \(filterLine) contains a Filter directive. Import one EqualizerAPO format at a time."
         case let .inputTooLarge(byteCount, maximum):
             return "Imported profile is \(byteCount) UTF-8 bytes, which exceeds the \(maximum)-byte limit."
         case let .tooManyLines(lineCount, maximum):
@@ -101,12 +104,34 @@ public enum EQProfileTextImporter {
     ) throws -> EQProfile {
         try validateInput(text, limits: limits)
 
-        if text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
-            .contains(where: {
-                $0.trimmingCharacters(in: .whitespacesAndNewlines)
-                    .lowercased()
-                    .hasPrefix("graphiceq")
-            }) {
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        var graphicEQLine: Int?
+        var filterLine: Int?
+        for (offset, rawLine) in lines.enumerated() {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty, !line.hasPrefix("#") else {
+                continue
+            }
+            if line.lowercased().hasPrefix("graphiceq") {
+                graphicEQLine = graphicEQLine ?? offset + 1
+            }
+            let firstToken = line
+                .replacingOccurrences(of: ":", with: " ")
+                .split(whereSeparator: \.isWhitespace)
+                .first
+            if firstToken?.lowercased() == "filter" {
+                filterLine = filterLine ?? offset + 1
+            }
+        }
+
+        if let graphicEQLine, let filterLine {
+            throw ProfileImportError.mixedEqualizerAPOFormats(
+                graphicEQLine: graphicEQLine,
+                filterLine: filterLine
+            )
+        }
+
+        if graphicEQLine != nil {
             return try importGraphicEQ(
                 text,
                 profileName: profileName,

--- a/Sources/GlassEQCore/ProfileImporters.swift
+++ b/Sources/GlassEQCore/ProfileImporters.swift
@@ -5,6 +5,7 @@ public struct ProfileImportLimits: Equatable, Sendable {
     public var maxLineCount: Int
     public var maxFiltersPerChannel: Int
     public var maxTotalFilters: Int
+    public var maxMagnitudePoints: Int
     public var frequencyRange: ClosedRange<Double>
     public var gainRange: ClosedRange<Double>
     public var preampRange: ClosedRange<Double>
@@ -18,12 +19,14 @@ public struct ProfileImportLimits: Equatable, Sendable {
         frequencyRange: ClosedRange<Double>,
         gainRange: ClosedRange<Double>,
         preampRange: ClosedRange<Double>,
-        qRange: ClosedRange<Double>
+        qRange: ClosedRange<Double>,
+        maxMagnitudePoints: Int = 2_048
     ) {
         self.maxUTF8Bytes = maxUTF8Bytes
         self.maxLineCount = maxLineCount
         self.maxFiltersPerChannel = maxFiltersPerChannel
         self.maxTotalFilters = maxTotalFilters
+        self.maxMagnitudePoints = maxMagnitudePoints
         self.frequencyRange = frequencyRange
         self.gainRange = gainRange
         self.preampRange = preampRange
@@ -51,6 +54,8 @@ public enum ProfileImportError: Error, Equatable, Sendable, LocalizedError {
     case valueOutOfRange(line: Int, field: String, value: Double, range: ClosedRange<Double>)
     case tooManyFilters(line: Int, channel: String, count: Int, maximum: Int)
     case tooManyTotalFilters(line: Int, count: Int, maximum: Int)
+    case tooManyMagnitudePoints(line: Int, count: Int, maximum: Int)
+    case duplicateMagnitudeFrequency(line: Int, frequency: Double)
 
     public var errorDescription: String? {
         switch self {
@@ -70,6 +75,10 @@ public enum ProfileImportError: Error, Equatable, Sendable, LocalizedError {
             return "Line \(line) adds filter \(count) to \(channel), which exceeds the \(maximum)-filter channel limit."
         case let .tooManyTotalFilters(line, count, maximum):
             return "Line \(line) adds filter \(count), which exceeds the \(maximum)-filter total limit."
+        case let .tooManyMagnitudePoints(line, count, maximum):
+            return "Line \(line) contains \(count) magnitude points, which exceeds the \(maximum)-point limit."
+        case let .duplicateMagnitudeFrequency(line, frequency):
+            return "Line \(line) contains duplicate frequency \(format(frequency))."
         }
     }
 
@@ -91,6 +100,19 @@ public enum EQProfileTextImporter {
         limits: ProfileImportLimits = .default
     ) throws -> EQProfile {
         try validateInput(text, limits: limits)
+
+        if text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            .contains(where: {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                    .hasPrefix("graphiceq")
+            }) {
+            return try importGraphicEQ(
+                text,
+                profileName: profileName,
+                limits: limits
+            )
+        }
 
         var filters: [EQFilter] = []
         var leftFilters: [EQFilter] = []
@@ -217,6 +239,179 @@ public enum EQProfileTextImporter {
         }
 
         return EQProfile(name: profileName, mode: inferredMode(filters: filters), preampDB: preampDB, filters: filters)
+    }
+
+    private static func importGraphicEQ(
+        _ text: String,
+        profileName: String,
+        limits: ProfileImportLimits
+    ) throws -> EQProfile {
+        var preampDB = 0.0
+        var points: [EQMagnitudePoint] = []
+        var frequencies = Set<Double>()
+        var leftPreampDB: Double?
+        var leftPoints: [EQMagnitudePoint] = []
+        var leftFrequencies = Set<Double>()
+        var rightPreampDB: Double?
+        var rightPoints: [EQMagnitudePoint] = []
+        var rightFrequencies = Set<Double>()
+        var currentChannel = ImportChannel.linked
+
+        for (offset, rawLine) in text.split(
+            omittingEmptySubsequences: false,
+            whereSeparator: \.isNewline
+        ).enumerated() {
+            let lineNumber = offset + 1
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty, !line.hasPrefix("#") else {
+                continue
+            }
+
+            let tokens = line
+                .replacingOccurrences(of: ":", with: " ")
+                .split(whereSeparator: \.isWhitespace)
+                .map(String.init)
+
+            if tokens.first?.caseInsensitiveCompare("Channel") == .orderedSame,
+               let channel = tokens.dropFirst().first {
+                switch channel.uppercased() {
+                case "L", "LEFT":
+                    currentChannel = .left
+                case "R", "RIGHT":
+                    currentChannel = .right
+                default:
+                    currentChannel = .linked
+                }
+                continue
+            }
+
+            if line.lowercased().hasPrefix("preamp") {
+                guard let value = try requiredValue(
+                    after: "Preamp",
+                    in: tokens,
+                    field: "preamp",
+                    line: lineNumber
+                ) else {
+                    throw ProfileImportError.missingNumber(
+                        line: lineNumber,
+                        field: "preamp"
+                    )
+                }
+                try validate(
+                    value,
+                    in: limits.preampRange,
+                    field: "preamp",
+                    line: lineNumber
+                )
+                switch currentChannel {
+                case .linked:
+                    preampDB = value
+                case .left:
+                    leftPreampDB = value
+                case .right:
+                    rightPreampDB = value
+                }
+                continue
+            }
+
+            guard line.lowercased().hasPrefix("graphiceq"),
+                  let colon = line.firstIndex(of: ":") else {
+                continue
+            }
+            let declarations = line[line.index(after: colon)...].split(separator: ";")
+            for declaration in declarations {
+                let tokens = declaration.split(whereSeparator: \.isWhitespace).map(String.init)
+                guard tokens.count == 2 else {
+                    throw ProfileImportError.missingNumber(
+                        line: lineNumber,
+                        field: "GraphicEQ frequency/gain pair"
+                    )
+                }
+                let frequency = try parseNumber(tokens[0], field: "frequency", line: lineNumber)
+                let gain = try parseNumber(tokens[1], field: "gain", line: lineNumber)
+                try validate(
+                    frequency,
+                    in: limits.frequencyRange,
+                    field: "frequency",
+                    line: lineNumber
+                )
+                try validate(gain, in: limits.gainRange, field: "gain", line: lineNumber)
+                let point = EQMagnitudePoint(frequency: frequency, gainDB: gain)
+                switch currentChannel {
+                case .linked:
+                    try appendMagnitudePoint(
+                        point,
+                        to: &points,
+                        frequencies: &frequencies,
+                        line: lineNumber,
+                        limits: limits
+                    )
+                case .left:
+                    try appendMagnitudePoint(
+                        point,
+                        to: &leftPoints,
+                        frequencies: &leftFrequencies,
+                        line: lineNumber,
+                        limits: limits
+                    )
+                case .right:
+                    try appendMagnitudePoint(
+                        point,
+                        to: &rightPoints,
+                        frequencies: &rightFrequencies,
+                        line: lineNumber,
+                        limits: limits
+                    )
+                }
+            }
+        }
+
+        let hasStereoData = !leftPoints.isEmpty
+            || !rightPoints.isEmpty
+            || leftPreampDB != nil
+            || rightPreampDB != nil
+        if hasStereoData {
+            let resolvedLeft = leftPoints.isEmpty ? points : leftPoints
+            let resolvedRight = rightPoints.isEmpty ? points : rightPoints
+            guard resolvedLeft.count >= 2, resolvedRight.count >= 2 else {
+                throw ProfileImportError.noSupportedFilters
+            }
+            let linkedSource = points.count >= 2
+                ? EQConvolutionSource.magnitudeCurve(MagnitudeCurveSource(
+                    points: points.sorted { $0.frequency < $1.frequency }
+                ))
+                : nil
+            return EQProfile(
+                name: profileName,
+                mode: .convolution,
+                channelMode: .stereo,
+                preampDB: preampDB,
+                filters: [],
+                leftPreampDB: leftPreampDB ?? preampDB,
+                leftFilters: [],
+                rightPreampDB: rightPreampDB ?? preampDB,
+                rightFilters: [],
+                convolution: linkedSource,
+                leftConvolution: .magnitudeCurve(MagnitudeCurveSource(
+                    points: resolvedLeft.sorted { $0.frequency < $1.frequency }
+                )),
+                rightConvolution: .magnitudeCurve(MagnitudeCurveSource(
+                    points: resolvedRight.sorted { $0.frequency < $1.frequency }
+                ))
+            )
+        }
+
+        guard points.count >= 2 else {
+            throw ProfileImportError.noSupportedFilters
+        }
+        points.sort { $0.frequency < $1.frequency }
+        return EQProfile(
+            name: profileName,
+            mode: .convolution,
+            preampDB: preampDB,
+            filters: [],
+            convolution: .magnitudeCurve(MagnitudeCurveSource(points: points))
+        )
     }
 
     public static func importREW(
@@ -464,6 +659,30 @@ public enum EQProfileTextImporter {
         filters.append(filter)
     }
 
+    private static func appendMagnitudePoint(
+        _ point: EQMagnitudePoint,
+        to points: inout [EQMagnitudePoint],
+        frequencies: inout Set<Double>,
+        line: Int,
+        limits: ProfileImportLimits
+    ) throws {
+        guard frequencies.insert(point.frequency).inserted else {
+            throw ProfileImportError.duplicateMagnitudeFrequency(
+                line: line,
+                frequency: point.frequency
+            )
+        }
+        let pointCount = points.count + 1
+        guard pointCount <= limits.maxMagnitudePoints else {
+            throw ProfileImportError.tooManyMagnitudePoints(
+                line: line,
+                count: pointCount,
+                maximum: limits.maxMagnitudePoints
+            )
+        }
+        points.append(point)
+    }
+
     private static func totalFilterCount(
         filters: [EQFilter],
         leftFilters: [EQFilter],
@@ -512,6 +731,9 @@ public enum EQProfileTextImporter {
 
 public enum EQProfileTextExporter {
     public static func exportEqualizerAPO(_ profile: EQProfile) -> String {
+        if profile.mode == .convolution {
+            return exportGraphicEQ(profile)
+        }
         var lines: [String] = []
 
         switch profile.channelMode {
@@ -535,6 +757,52 @@ public enum EQProfileTextExporter {
         }
 
         return lines.joined(separator: "\n")
+    }
+
+    private static func exportGraphicEQ(_ profile: EQProfile) -> String {
+        var lines = [String(format: "Preamp: %.2f dB", profile.preampDB)]
+        switch profile.channelMode {
+        case .linked:
+            if let line = graphicEQLine(profile.convolution) {
+                lines.append(line)
+            }
+        case .stereo:
+            lines.append("")
+            lines.append("Channel: L")
+            if profile.leftPreampDB != profile.preampDB {
+                lines.append(String(format: "Preamp: %.2f dB", profile.leftPreampDB))
+            }
+            if let line = graphicEQLine(profile.leftConvolution) {
+                lines.append(line)
+            }
+            lines.append("")
+            lines.append("Channel: R")
+            if profile.rightPreampDB != profile.preampDB {
+                lines.append(String(format: "Preamp: %.2f dB", profile.rightPreampDB))
+            }
+            if let line = graphicEQLine(profile.rightConvolution) {
+                lines.append(line)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func graphicEQLine(_ source: EQConvolutionSource?) -> String? {
+        guard case .magnitudeCurve(let curve) = source else {
+            return nil
+        }
+        let declarations = curve.points
+            .sorted { $0.frequency < $1.frequency }
+            .map {
+                String(
+                    format: "%.8g %.8g",
+                    locale: Locale(identifier: "en_US_POSIX"),
+                    $0.frequency,
+                    $0.gainDB
+                )
+            }
+            .joined(separator: "; ")
+        return "GraphicEQ: \(declarations)"
     }
 
     private static func filterLines(_ filters: [EQFilter]) -> [String] {

--- a/Sources/GlassEQCore/ProfileImporters.swift
+++ b/Sources/GlassEQCore/ProfileImporters.swift
@@ -115,11 +115,11 @@ public enum EQProfileTextImporter {
             if line.lowercased().hasPrefix("graphiceq") {
                 graphicEQLine = graphicEQLine ?? offset + 1
             }
-            let firstToken = line
+            let tokens = line
                 .replacingOccurrences(of: ":", with: " ")
                 .split(whereSeparator: \.isWhitespace)
-                .first
-            if firstToken?.lowercased() == "filter" {
+            if tokens.first?.lowercased() == "filter",
+               !tokens.contains(where: { $0.lowercased() == "off" }) {
                 filterLine = filterLine ?? offset + 1
             }
         }

--- a/Sources/GlassEQCore/ProfilePersistence.swift
+++ b/Sources/GlassEQCore/ProfilePersistence.swift
@@ -36,6 +36,11 @@ public enum ProfileStoreValidationError: Error, Equatable, Sendable, LocalizedEr
     case tooManyStereoFilters(profileID: UUID, count: Int, maximum: Int)
     case tooManyStereoActiveFilters(profileID: UUID, count: Int, maximum: Int)
     case invalidGraphicBandCount(profileID: UUID, channel: String, count: Int, expected: Int)
+    case missingConvolutionSource(profileID: UUID, channel: String)
+    case unexpectedConvolutionSource(profileID: UUID, channel: String)
+    case invalidMagnitudePointCount(profileID: UUID, channel: String, count: Int, allowed: ClosedRange<Int>)
+    case unsupportedSynthesisVersion(profileID: UUID, version: UInt16)
+    case duplicateMagnitudeFrequency(profileID: UUID, channel: String, frequency: Double)
 
     public var errorDescription: String? {
         switch self {
@@ -69,6 +74,16 @@ public enum ProfileStoreValidationError: Error, Equatable, Sendable, LocalizedEr
             return "Profile store contains \(count) active stereo filters, which exceeds the \(maximum)-filter stereo limit."
         case let .invalidGraphicBandCount(_, channel, count, expected):
             return "Graphic profile contains \(count) active \(channel) bands; expected \(expected)."
+        case let .missingConvolutionSource(_, channel):
+            return "Convolution profile is missing its \(channel) source."
+        case let .unexpectedConvolutionSource(_, channel):
+            return "Non-convolution profile contains an unexpected \(channel) convolution source."
+        case let .invalidMagnitudePointCount(_, channel, count, allowed):
+            return "Convolution profile contains \(count) \(channel) magnitude points; expected \(allowed.lowerBound)...\(allowed.upperBound)."
+        case let .unsupportedSynthesisVersion(_, version):
+            return "Convolution profile uses unsupported synthesis version \(version)."
+        case let .duplicateMagnitudeFrequency(_, channel, frequency):
+            return "Convolution profile contains duplicate \(channel) frequency \(format(frequency))."
         }
     }
 
@@ -87,6 +102,7 @@ public enum ProfilePersistence {
     public static let maxStereoFilters = 256
     public static let maxActiveFiltersPerChannel = maxFiltersPerChannel
     public static let maxStereoActiveFilters = maxStereoFilters
+    public static let magnitudePointCountRange = 2...2_048
     public static let frequencyRange: ClosedRange<Double> = 1...24_000
     public static let gainRange: ClosedRange<Double> = -120...120
     public static let preampRange: ClosedRange<Double> = -120...120
@@ -435,6 +451,8 @@ public enum ProfilePersistence {
                 )
             }
         }
+
+        try validateConvolutionSources(profile)
     }
 
     private static func validateFilters(
@@ -502,6 +520,98 @@ public enum ProfilePersistence {
         }
     }
 
+    private static func validateConvolutionSources(_ profile: EQProfile) throws {
+        switch (profile.mode, profile.channelMode) {
+        case (.convolution, .linked):
+            guard let source = profile.convolution else {
+                throw ProfileStoreValidationError.missingConvolutionSource(
+                    profileID: profile.id,
+                    channel: "linked"
+                )
+            }
+            try validateConvolutionSource(source, channel: "linked", profileID: profile.id)
+            if let left = profile.leftConvolution {
+                try validateConvolutionSource(left, channel: "left", profileID: profile.id)
+            }
+            if let right = profile.rightConvolution {
+                try validateConvolutionSource(right, channel: "right", profileID: profile.id)
+            }
+        case (.convolution, .stereo):
+            guard let left = profile.leftConvolution else {
+                throw ProfileStoreValidationError.missingConvolutionSource(
+                    profileID: profile.id,
+                    channel: "left"
+                )
+            }
+            guard let right = profile.rightConvolution else {
+                throw ProfileStoreValidationError.missingConvolutionSource(
+                    profileID: profile.id,
+                    channel: "right"
+                )
+            }
+            try validateConvolutionSource(left, channel: "left", profileID: profile.id)
+            try validateConvolutionSource(right, channel: "right", profileID: profile.id)
+            if let linked = profile.convolution {
+                try validateConvolutionSource(linked, channel: "linked", profileID: profile.id)
+            }
+        case (_, _):
+            guard profile.convolution == nil,
+                  profile.leftConvolution == nil,
+                  profile.rightConvolution == nil else {
+                throw ProfileStoreValidationError.unexpectedConvolutionSource(
+                    profileID: profile.id,
+                    channel: "profile"
+                )
+            }
+        }
+    }
+
+    private static func validateConvolutionSource(
+        _ source: EQConvolutionSource,
+        channel: String,
+        profileID: UUID
+    ) throws {
+        switch source {
+        case .magnitudeCurve(let curve):
+            guard curve.synthesisVersion == MinimumPhaseFIRCompiler.synthesisVersion else {
+                throw ProfileStoreValidationError.unsupportedSynthesisVersion(
+                    profileID: profileID,
+                    version: curve.synthesisVersion
+                )
+            }
+            guard magnitudePointCountRange.contains(curve.points.count) else {
+                throw ProfileStoreValidationError.invalidMagnitudePointCount(
+                    profileID: profileID,
+                    channel: channel,
+                    count: curve.points.count,
+                    allowed: magnitudePointCountRange
+                )
+            }
+            var frequencies = Set<Double>()
+            for point in curve.points {
+                try validate(
+                    point.frequency,
+                    in: frequencyRange,
+                    field: "\(channel) magnitude frequency",
+                    profileID: profileID
+                )
+                try validate(
+                    point.gainDB,
+                    in: gainRange,
+                    field: "\(channel) magnitude gain",
+                    profileID: profileID
+                )
+                guard frequencies.insert(point.frequency).inserted else {
+                    throw ProfileStoreValidationError.duplicateMagnitudeFrequency(
+                        profileID: profileID,
+                        channel: channel,
+                        frequency: point.frequency
+                    )
+                }
+            }
+        }
+    }
+
     private static func graphicBandCount(for mode: EQMode) -> Int? {
         switch mode {
         case .parametric:
@@ -510,6 +620,8 @@ public enum ProfilePersistence {
             return 10
         case .graphic31:
             return 31
+        case .convolution:
+            return nil
         }
     }
 

--- a/Sources/GlassEQCore/ProfilePersistence.swift
+++ b/Sources/GlassEQCore/ProfilePersistence.swift
@@ -219,35 +219,9 @@ public enum ProfilePersistence {
             return recoverInvalidStore(at: url, timestamp: timestamp)
         }
 
+        let decodedStore: ProfileStore
         do {
-            var store = try decodeRaw(data)
-            if store.schemaVersion > ProfileStore.currentSchemaVersion {
-                return ProfileStoreLoadResult(
-                    store: defaultStore(),
-                    status: .unsupportedSchemaVersion(
-                        version: store.schemaVersion,
-                        maximumSupported: ProfileStore.currentSchemaVersion
-                    )
-                )
-            }
-            let repairSummary = store.repairReferences()
-            do {
-                try validate(store)
-            } catch {
-                return repairInvalidDecodedStore(
-                    store,
-                    initialRepairSummary: repairSummary,
-                    at: url,
-                    timestamp: timestamp
-                )
-            }
-
-            if repairSummary.didRepair {
-                try save(store, to: url)
-                return ProfileStoreLoadResult(store: store, status: .repairedReferences(repairSummary))
-            }
-
-            return ProfileStoreLoadResult(store: store, status: .loaded)
+            decodedStore = try decodeRaw(data)
         } catch {
             if let repairable = try? decodeRepairableStore(data) {
                 if repairable.store.schemaVersion > ProfileStore.currentSchemaVersion {
@@ -270,6 +244,58 @@ public enum ProfilePersistence {
             }
             return recoverInvalidStore(at: url, timestamp: timestamp)
         }
+
+        var store = decodedStore
+        if store.schemaVersion > ProfileStore.currentSchemaVersion {
+            return ProfileStoreLoadResult(
+                store: defaultStore(),
+                status: .unsupportedSchemaVersion(
+                    version: store.schemaVersion,
+                    maximumSupported: ProfileStore.currentSchemaVersion
+                )
+            )
+        }
+        let repairSummary = store.repairReferences()
+        do {
+            try validate(store)
+        } catch {
+            return repairInvalidDecodedStore(
+                store,
+                initialRepairSummary: repairSummary,
+                at: url,
+                timestamp: timestamp
+            )
+        }
+
+        if repairSummary.didRepair {
+            var committedStore = store
+            committedStore.schemaVersion = ProfileStore.currentSchemaVersion
+            do {
+                try save(committedStore, to: url)
+                return ProfileStoreLoadResult(
+                    store: committedStore,
+                    status: .repairedReferences(repairSummary)
+                )
+            } catch {
+                return ProfileStoreLoadResult(
+                    store: store,
+                    status: .repairedReferences(repairSummary)
+                )
+            }
+        }
+
+        if store.schemaVersion < ProfileStore.currentSchemaVersion {
+            var migratedStore = store
+            migratedStore.schemaVersion = ProfileStore.currentSchemaVersion
+            do {
+                try save(migratedStore, to: url)
+                return ProfileStoreLoadResult(store: migratedStore, status: .loaded)
+            } catch {
+                return ProfileStoreLoadResult(store: store, status: .loaded)
+            }
+        }
+
+        return ProfileStoreLoadResult(store: store, status: .loaded)
     }
 
     public static func invalidStoreBackupURL(for storeURL: URL, timestamp: Date = Date()) -> URL {
@@ -320,7 +346,9 @@ public enum ProfilePersistence {
 
     private static func encodeForCommit(_ store: ProfileStore) throws -> Data {
         try validate(store)
-        let data = try encode(store)
+        var committedStore = store
+        committedStore.schemaVersion = ProfileStore.currentSchemaVersion
+        let data = try encode(committedStore)
         try validateStoreSize(byteCount: data.count)
         return data
     }
@@ -339,7 +367,7 @@ public enum ProfilePersistence {
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
-                ?? ProfileStore.currentSchemaVersion
+                ?? ProfileStore.initialSchemaVersion
             outputMappings = try container.decode([OutputDeviceProfileMapping].self, forKey: .outputMappings)
             fallbackProfileID = try container.decode(UUID.self, forKey: .fallbackProfileID)
         }

--- a/Sources/GlassEQCore/ProgrammeLoudnessMatcher.swift
+++ b/Sources/GlassEQCore/ProgrammeLoudnessMatcher.swift
@@ -6,6 +6,12 @@ public extension EQProfile {
         reference.filters = []
         reference.leftFilters = []
         reference.rightFilters = []
+        reference.convolution = nil
+        reference.leftConvolution = nil
+        reference.rightConvolution = nil
+        if reference.mode == .convolution {
+            reference.mode = .parametric
+        }
         reference.isBypassed = false
         return reference
     }

--- a/Sources/GlassEQCore/RealtimeEQTransition.swift
+++ b/Sources/GlassEQCore/RealtimeEQTransition.swift
@@ -228,6 +228,11 @@ public struct RealtimeEQTransition: Sendable {
         frameCount: Int,
         channelCount: Int
     ) -> EQTransitionRenderResult {
+        guard !activeProcessor.configuration.isBypassed else {
+            return EQTransitionRenderResult(
+                programmeComparison: programmeComparisonSnapshot
+            )
+        }
         guard activeProcessor.configuration.usesConvolution else {
             let saturated = activeProcessor.processInterleavedWithDiagnostics(
                 samples,

--- a/Sources/GlassEQCore/RealtimeEQTransition.swift
+++ b/Sources/GlassEQCore/RealtimeEQTransition.swift
@@ -6,6 +6,7 @@ public struct EQTransitionRenderResult: Sendable {
     public var blendStartFrame: Int?
     public var blendFrameCount: Int
     public var programmeComparison: EQProgrammeComparisonSnapshot
+    public var workTiming: EQRenderWorkTiming
 
     public init(
         saturatedSamples: UInt64 = 0,
@@ -14,7 +15,8 @@ public struct EQTransitionRenderResult: Sendable {
         secondRetiredProcessor: EQProcessor? = nil,
         blendStartFrame: Int? = nil,
         blendFrameCount: Int = 0,
-        programmeComparison: EQProgrammeComparisonSnapshot = EQProgrammeComparisonSnapshot()
+        programmeComparison: EQProgrammeComparisonSnapshot = EQProgrammeComparisonSnapshot(),
+        workTiming: EQRenderWorkTiming = EQRenderWorkTiming()
     ) {
         self.saturatedSamples = saturatedSamples
         self.completedTransition = completedTransition
@@ -23,6 +25,7 @@ public struct EQTransitionRenderResult: Sendable {
         self.blendStartFrame = blendStartFrame
         self.blendFrameCount = blendFrameCount
         self.programmeComparison = programmeComparison
+        self.workTiming = workTiming
     }
 
     @inline(__always)
@@ -191,14 +194,10 @@ public struct RealtimeEQTransition: Sendable {
         }
         guard channels == self.channelCount,
               availableFrames * channels <= alternateSamples.count else {
-            let saturated = activeProcessor.processInterleavedWithDiagnostics(
+            return processActiveProcessor(
                 samples,
                 frameCount: availableFrames,
                 channelCount: channels
-            )
-            return EQTransitionRenderResult(
-                saturatedSamples: saturated,
-                programmeComparison: programmeComparisonSnapshot
             )
         }
 
@@ -217,14 +216,40 @@ public struct RealtimeEQTransition: Sendable {
             )
         }
 
-        let saturated = activeProcessor.processInterleavedWithDiagnostics(
+        return processActiveProcessor(
             samples,
             frameCount: availableFrames,
             channelCount: channels
         )
+    }
+
+    private mutating func processActiveProcessor(
+        _ samples: UnsafeMutableBufferPointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) -> EQTransitionRenderResult {
+        guard activeProcessor.configuration.usesConvolution else {
+            let saturated = activeProcessor.processInterleavedWithDiagnostics(
+                samples,
+                frameCount: frameCount,
+                channelCount: channelCount
+            )
+            return EQTransitionRenderResult(
+                saturatedSamples: saturated,
+                programmeComparison: programmeComparisonSnapshot
+            )
+        }
+
+        let diagnostics = activeProcessor.processInterleavedLinearlyWithDiagnostics(
+            samples,
+            frameCount: frameCount,
+            channelCount: channelCount
+        )
         return EQTransitionRenderResult(
-            saturatedSamples: saturated,
-            programmeComparison: programmeComparisonSnapshot
+            saturatedSamples: diagnostics.nonFiniteSamples
+                &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount),
+            programmeComparison: programmeComparisonSnapshot,
+            workTiming: diagnostics.workTiming
         )
     }
 
@@ -251,13 +276,16 @@ public struct RealtimeEQTransition: Sendable {
                 frameCount: frameCount,
                 channelCount: channelCount
             )
+            var workTiming = activeDiagnostics.workTiming
+            workTiming.merge(incomingDiagnostics.workTiming)
 
             if warmupFramesRemaining > 0 {
                 warmupFramesRemaining = max(warmupFramesRemaining - frameCount, 0)
                 return EQTransitionRenderResult(
                     saturatedSamples: activeDiagnostics.nonFiniteSamples
                         &+ incomingDiagnostics.nonFiniteSamples
-                        &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
+                        &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount),
+                    workTiming: workTiming
                 )
             }
 
@@ -286,7 +314,8 @@ public struct RealtimeEQTransition: Sendable {
                 return EQTransitionRenderResult(
                     saturatedSamples: saturated,
                     blendStartFrame: renderedBlendStartFrame,
-                    blendFrameCount: blendFrameCount
+                    blendFrameCount: blendFrameCount,
+                    workTiming: workTiming
                 )
             }
 
@@ -315,7 +344,8 @@ public struct RealtimeEQTransition: Sendable {
                 retiredProcessor: retiredProcessor,
                 secondRetiredProcessor: secondRetiredProcessor,
                 blendStartFrame: renderedBlendStartFrame,
-                blendFrameCount: blendFrameCount
+                blendFrameCount: blendFrameCount,
+                workTiming: workTiming
             )
         }
         result.programmeComparison = programmeComparisonSnapshot
@@ -355,6 +385,8 @@ public struct RealtimeEQTransition: Sendable {
                     frameCount: frameCount,
                     channelCount: channelCount
                 )
+            var workTiming = equalizedDiagnostics.workTiming
+            workTiming.merge(filtersOffDiagnostics.workTiming)
 
             if comparisonWarmupFramesRemaining > 0 {
                 comparisonWarmupFramesRemaining = max(
@@ -367,7 +399,8 @@ public struct RealtimeEQTransition: Sendable {
                 return EQTransitionRenderResult(
                     saturatedSamples: equalizedDiagnostics.nonFiniteSamples
                         &+ filtersOffDiagnostics.nonFiniteSamples
-                        &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
+                        &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount),
+                    workTiming: workTiming
                 )
             }
 
@@ -424,7 +457,8 @@ public struct RealtimeEQTransition: Sendable {
             return EQTransitionRenderResult(
                 saturatedSamples: equalizedDiagnostics.nonFiniteSamples
                     &+ filtersOffDiagnostics.nonFiniteSamples
-                    &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount)
+                    &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount),
+                workTiming: workTiming
             )
         }
         if shouldFinishComparison {
@@ -469,7 +503,8 @@ public struct RealtimeEQTransition: Sendable {
         return EQTransitionRenderResult(
             saturatedSamples: diagnostics.nonFiniteSamples
                 &+ Self.protect(samples, frameCount: frameCount, channelCount: channelCount),
-            programmeComparison: programmeComparisonSnapshot
+            programmeComparison: programmeComparisonSnapshot,
+            workTiming: diagnostics.workTiming
         )
     }
 
@@ -488,7 +523,10 @@ public struct RealtimeEQTransition: Sendable {
     }
 
     private mutating func beginStandardTransition() {
-        warmupFramesRemaining = warmupFrameCount
+        warmupFramesRemaining = max(
+            warmupFrameCount,
+            incomingProcessor?.requiredWarmupFrames ?? 0
+        )
         blendedFrames = 0
     }
 

--- a/Sources/GlassEQDiagnostics/main.swift
+++ b/Sources/GlassEQDiagnostics/main.swift
@@ -5,7 +5,7 @@ import GlassEQCore
 
 let arguments = Array(CommandLine.arguments.dropFirst().drop { $0 == "--" })
 if arguments.first == "dsp-benchmark" || arguments.first == "--dsp-benchmark" {
-    runDSPBenchmark()
+    runDSPBenchmark(curvePath: arguments.dropFirst().first)
     exit(0)
 }
 
@@ -354,6 +354,43 @@ private func printMetrics(_ metrics: AudioEngineMetrics, sampleRate: Double) {
     print("Max capture callback frames: \(metrics.maximumCaptureCallbackFrames)")
     print("Max playback callback frames: \(metrics.maximumPlaybackCallbackFrames)")
     print("Render deadline misses: \(metrics.renderDeadlineMisses)")
+    print("Start starvations: \(metrics.callbackStartStarvations)")
+    print("Render overruns: \(metrics.renderOverruns)")
+    printExtremeDuration(
+        "Callback start late",
+        observations: metrics.renderTiming.callbackStartLatenessObservations,
+        p9999Nanoseconds: metrics.renderTiming.callbackStartLatenessP9999Nanoseconds,
+        maximumNanoseconds: metrics.renderTiming.maximumCallbackStartLatenessNanoseconds
+    )
+    if metrics.renderTiming.directHeadObservations > 0 {
+        printExtremeDuration(
+            "FIR head",
+            observations: metrics.renderTiming.directHeadObservations,
+            p9999Nanoseconds: metrics.renderTiming.directHeadP9999Nanoseconds,
+            maximumNanoseconds: metrics.renderTiming.maximumDirectHeadNanoseconds
+        )
+        printExtremeDuration(
+            "FIR tail",
+            observations: metrics.renderTiming.tailWorkObservations,
+            p9999Nanoseconds: metrics.renderTiming.tailWorkP9999Nanoseconds,
+            maximumNanoseconds: metrics.renderTiming.maximumTailWorkNanoseconds
+        )
+        print(
+            "Tail completion slack: \(metrics.renderTiming.minimumTailCompletionSlackFrames) frames minimum, \(metrics.renderTiming.tailDeadlineMisses) misses"
+        )
+    }
+    printExtremeDuration(
+        "Total render",
+        observations: metrics.renderTiming.totalRenderObservations,
+        p9999Nanoseconds: metrics.renderTiming.totalRenderP9999Nanoseconds,
+        maximumNanoseconds: metrics.renderTiming.maximumTotalRenderNanoseconds
+    )
+    printExtremeDuration(
+        "Completion late",
+        observations: metrics.renderTiming.completionLatenessObservations,
+        p9999Nanoseconds: metrics.renderTiming.completionLatenessP9999Nanoseconds,
+        maximumNanoseconds: metrics.renderTiming.maximumCompletionLatenessNanoseconds
+    )
     if metrics.tapToOutputLatencyObservations > 0 {
         print(String(
             format: "Tap-to-output latency: %.3f ms average, %.3f to %.3f ms",
@@ -383,6 +420,24 @@ private func printMetrics(_ metrics: AudioEngineMetrics, sampleRate: Double) {
         print("Input age: unavailable")
         print("Output lead: unavailable")
     }
+}
+
+private func printExtremeDuration(
+    _ label: String,
+    observations: UInt64,
+    p9999Nanoseconds: UInt64,
+    maximumNanoseconds: UInt64
+) {
+    guard observations > 0 else {
+        print("\(label): unavailable")
+        return
+    }
+    print(String(
+        format: "\(label): %.3f us p99.99, %.3f us maximum over %llu published callbacks",
+        Double(p9999Nanoseconds) / 1_000,
+        Double(maximumNanoseconds) / 1_000,
+        observations
+    ))
 }
 
 private func printTimestampProbeRecords(_ records: [AudioTimestampProbeRecord]) {
@@ -420,9 +475,33 @@ private struct DSPBenchmarkCase {
     var sampleRate: Double
     var channelCount: Int
     var frameCount: Int
+
+    var usesConvolution: Bool {
+        profile.mode == .convolution
+    }
 }
 
-private func runDSPBenchmark() {
+private func runDSPBenchmark(curvePath: String?) {
+    let convolutionProfile: EQProfile
+    if let curvePath {
+        do {
+            let text = try String(contentsOfFile: curvePath, encoding: .utf8)
+            convolutionProfile = try EQProfileTextImporter.importAutoEQ(
+                text,
+                profileName: URL(fileURLWithPath: curvePath).deletingPathExtension().lastPathComponent
+            )
+            guard convolutionProfile.mode == .convolution else {
+                print("DSP benchmark curve is not an EqualizerAPO GraphicEQ response: \(curvePath)")
+                return
+            }
+        } catch {
+            print("DSP benchmark could not load curve \(curvePath): \(error)")
+            return
+        }
+    } else {
+        convolutionProfile = benchmarkConvolutionProfile()
+    }
+
     let cases = [
         DSPBenchmarkCase(
             name: "Flat parametric",
@@ -458,19 +537,43 @@ private func runDSPBenchmark() {
             sampleRate: 48_000,
             channelCount: 2,
             frameCount: 16
+        ),
+        DSPBenchmarkCase(
+            name: "16k minimum-phase FIR at 48 kHz",
+            profile: convolutionProfile,
+            sampleRate: 48_000,
+            channelCount: 2,
+            frameCount: 16
+        ),
+        DSPBenchmarkCase(
+            name: "16k minimum-phase FIR at 96 kHz",
+            profile: convolutionProfile,
+            sampleRate: 96_000,
+            channelCount: 2,
+            frameCount: 16
+        ),
+        DSPBenchmarkCase(
+            name: "16k minimum-phase FIR at 192 kHz",
+            profile: convolutionProfile,
+            sampleRate: 192_000,
+            channelCount: 2,
+            frameCount: 16
         )
     ]
 
     print("GlassEQ DSP benchmark")
     print("Measures the 16-frame DSP workload; Core Audio buffering and device latency are not included.")
     print("Biquad EQ is in-place and has no fixed block/sample delay; recursive filters still have frequency-dependent phase/group delay.")
+    print("The hybrid minimum-phase FIR also adds no fixed buffering delay: its 512-tap head renders directly while partitioned tail work completes ahead of its deadline.")
     print("")
 
     for benchmarkCase in cases {
         run(benchmarkCase)
     }
-    for transitionCase in cases where transitionCase.name.hasPrefix("31-band graphic")
-        && transitionCase.sampleRate != 96_000 {
+    for transitionCase in cases where (
+        transitionCase.name.hasPrefix("31-band graphic")
+            || transitionCase.usesConvolution
+    ) && transitionCase.sampleRate != 96_000 {
         runTransition(transitionCase)
     }
 }
@@ -483,13 +586,15 @@ private func run(_ benchmarkCase: DSPBenchmarkCase) {
         sampleRate: benchmarkCase.sampleRate
     )
     var samples = originalSamples
-    var processor = EQProcessor(
-        configuration: EQConfiguration(
-            profile: benchmarkCase.profile,
-            sampleRate: benchmarkCase.sampleRate,
-            channelCount: benchmarkCase.channelCount
-        )
-    )
+    guard let renderConfiguration = try? EQRenderConfiguration.prepare(
+        profile: benchmarkCase.profile,
+        sampleRate: benchmarkCase.sampleRate,
+        channelCount: benchmarkCase.channelCount
+    ) else {
+        print("\(benchmarkCase.name): failed to prepare DSP")
+        return
+    }
+    var processor = EQProcessor(renderConfiguration: renderConfiguration)
 
     for _ in 0..<warmupIterations {
         samples = originalSamples
@@ -498,13 +603,25 @@ private func run(_ benchmarkCase: DSPBenchmarkCase) {
 
     let start = DispatchTime.now().uptimeNanoseconds
     var saturatedSamples: UInt64 = 0
+    var callbackDurations = benchmarkCase.usesConvolution
+        ? [UInt64]()
+        : []
+    callbackDurations.reserveCapacity(benchmarkCase.usesConvolution ? iterations : 0)
     for _ in 0..<iterations {
         samples = originalSamples
+        let callbackStart = benchmarkCase.usesConvolution
+            ? DispatchTime.now().uptimeNanoseconds
+            : 0
         saturatedSamples &+= samples.withUnsafeMutableBufferPointer {
             processor.processInterleavedWithDiagnostics(
                 $0,
                 frameCount: benchmarkCase.frameCount,
                 channelCount: benchmarkCase.channelCount
+            )
+        }
+        if benchmarkCase.usesConvolution {
+            callbackDurations.append(
+                DispatchTime.now().uptimeNanoseconds - callbackStart
             )
         }
     }
@@ -521,6 +638,29 @@ private func run(_ benchmarkCase: DSPBenchmarkCase) {
     print(String(format: "  Avg DSP time: %.3f us/buffer", averageMicroseconds))
     print(String(format: "  Callback budget: %.3f us (%.3f%% used)", callbackBudgetMicroseconds, budgetPercent))
     print(String(format: "  Avg per sample: %.3f ns", perSampleNanoseconds))
+    if benchmarkCase.usesConvolution {
+        let sorted = callbackDurations.sorted()
+        let percentileIndex = min(
+            Int((Double(sorted.count - 1) * 0.999).rounded(.up)),
+            sorted.count - 1
+        )
+        let extremePercentileIndex = min(
+            Int((Double(sorted.count - 1) * 0.9999).rounded(.up)),
+            sorted.count - 1
+        )
+        print(String(
+            format: "  p99.9 DSP time: %.3f us/buffer",
+            Double(sorted[percentileIndex]) / 1_000
+        ))
+        print(String(
+            format: "  p99.99 DSP time: %.3f us/buffer",
+            Double(sorted[extremePercentileIndex]) / 1_000
+        ))
+        print(String(
+            format: "  Max DSP time: %.3f us/buffer",
+            Double(sorted.last ?? 0) / 1_000
+        ))
+    }
     print("  Saturated samples during benchmark: \(saturatedSamples)")
     print("")
 }
@@ -533,23 +673,30 @@ private func runTransition(_ benchmarkCase: DSPBenchmarkCase) {
         sampleRate: benchmarkCase.sampleRate
     )
     var samples = originalSamples
+    guard let activeConfiguration = try? EQRenderConfiguration.prepare(
+        profile: benchmarkCase.profile,
+        sampleRate: benchmarkCase.sampleRate,
+        channelCount: benchmarkCase.channelCount
+    ),
+    let incomingConfiguration = try? EQRenderConfiguration.prepare(
+        profile: benchmarkCase.profile,
+        sampleRate: benchmarkCase.sampleRate,
+        channelCount: benchmarkCase.channelCount
+    ) else {
+        print("Whole-bank transition: \(benchmarkCase.name): failed to prepare DSP")
+        return
+    }
     var transition = RealtimeEQTransition(
-        activeProcessor: EQProcessor(configuration: EQConfiguration(
-            profile: benchmarkCase.profile,
-            sampleRate: benchmarkCase.sampleRate,
-            channelCount: benchmarkCase.channelCount
-        )),
+        activeProcessor: EQProcessor(renderConfiguration: activeConfiguration),
         maximumFrameCount: benchmarkCase.frameCount,
         channelCount: benchmarkCase.channelCount,
         sampleRate: benchmarkCase.sampleRate,
         warmupSeconds: 0,
         blendSeconds: 3_600
     )
-    precondition(transition.beginTransition(to: EQProcessor(configuration: EQConfiguration(
-        profile: benchmarkCase.profile,
-        sampleRate: benchmarkCase.sampleRate,
-        channelCount: benchmarkCase.channelCount
-    ))))
+    precondition(transition.beginTransition(to: EQProcessor(
+        renderConfiguration: incomingConfiguration
+    )))
 
     for _ in 0..<warmupIterations {
         samples = originalSamples
@@ -564,14 +711,26 @@ private func runTransition(_ benchmarkCase: DSPBenchmarkCase) {
 
     let start = DispatchTime.now().uptimeNanoseconds
     var saturatedSamples: UInt64 = 0
+    var callbackDurations = benchmarkCase.usesConvolution
+        ? [UInt64]()
+        : []
+    callbackDurations.reserveCapacity(benchmarkCase.usesConvolution ? iterations : 0)
     for _ in 0..<iterations {
         samples = originalSamples
+        let callbackStart = benchmarkCase.usesConvolution
+            ? DispatchTime.now().uptimeNanoseconds
+            : 0
         saturatedSamples &+= samples.withUnsafeMutableBufferPointer {
             transition.processInterleavedWithDiagnostics(
                 $0,
                 frameCount: benchmarkCase.frameCount,
                 channelCount: benchmarkCase.channelCount
             ).saturatedSamples
+        }
+        if benchmarkCase.usesConvolution {
+            callbackDurations.append(
+                DispatchTime.now().uptimeNanoseconds - callbackStart
+            )
         }
     }
     let elapsed = DispatchTime.now().uptimeNanoseconds - start
@@ -594,6 +753,29 @@ private func runTransition(_ benchmarkCase: DSPBenchmarkCase) {
         callbackBudgetMicroseconds,
         budgetPercent
     ))
+    if benchmarkCase.usesConvolution {
+        let sorted = callbackDurations.sorted()
+        let percentileIndex = min(
+            Int((Double(sorted.count - 1) * 0.999).rounded(.up)),
+            sorted.count - 1
+        )
+        let extremePercentileIndex = min(
+            Int((Double(sorted.count - 1) * 0.9999).rounded(.up)),
+            sorted.count - 1
+        )
+        print(String(
+            format: "  p99.9 DSP time: %.3f us/buffer",
+            Double(sorted[percentileIndex]) / 1_000
+        ))
+        print(String(
+            format: "  p99.99 DSP time: %.3f us/buffer",
+            Double(sorted[extremePercentileIndex]) / 1_000
+        ))
+        print(String(
+            format: "  Max DSP time: %.3f us/buffer",
+            Double(sorted.last ?? 0) / 1_000
+        ))
+    }
     print("  Saturated samples during benchmark: \(saturatedSamples)")
     print("")
 }
@@ -619,6 +801,24 @@ private func complexStereoProfile() -> EQProfile {
             EQFilter(kind: .highShelf, frequency: 12_000, gainDB: 2, q: 0.9),
             EQFilter(kind: .peak, frequency: 72, gainDB: 3, q: 5)
         ]
+    )
+}
+
+private func benchmarkConvolutionProfile() -> EQProfile {
+    EQProfile(
+        name: "Benchmark Response Curve",
+        mode: .convolution,
+        preampDB: -6,
+        filters: [],
+        convolution: .magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: 4),
+            EQMagnitudePoint(frequency: 80, gainDB: -2),
+            EQMagnitudePoint(frequency: 250, gainDB: 3),
+            EQMagnitudePoint(frequency: 1_000, gainDB: -4),
+            EQMagnitudePoint(frequency: 4_000, gainDB: 5),
+            EQMagnitudePoint(frequency: 10_000, gainDB: -3),
+            EQMagnitudePoint(frequency: 20_000, gainDB: 1)
+        ]))
     )
 }
 

--- a/Sources/GlassEQSettingsIPC/SettingsIPC.swift
+++ b/Sources/GlassEQSettingsIPC/SettingsIPC.swift
@@ -37,6 +37,7 @@ public enum SettingsProfileKind: String, Codable, Sendable {
     case graphic10
     case graphic31
     case parametric
+    case convolution
 }
 
 public enum SettingsAggregateBufferMode: String, CaseIterable, Codable, Identifiable, Sendable {
@@ -94,6 +95,67 @@ public struct SettingsAggregateBufferDTO: Codable, Equatable, Sendable {
     }
 }
 
+public struct SettingsAudioRenderTimingDTO: Codable, Equatable, Sendable {
+    public var callbackStartLatenessObservations: UInt64
+    public var callbackStartLatenessP9999Nanoseconds: UInt64
+    public var maximumCallbackStartLatenessNanoseconds: UInt64
+    public var directHeadObservations: UInt64
+    public var directHeadP9999Nanoseconds: UInt64
+    public var maximumDirectHeadNanoseconds: UInt64
+    public var tailWorkObservations: UInt64
+    public var tailWorkP9999Nanoseconds: UInt64
+    public var maximumTailWorkNanoseconds: UInt64
+    public var totalRenderObservations: UInt64
+    public var totalRenderP9999Nanoseconds: UInt64
+    public var maximumTotalRenderNanoseconds: UInt64
+    public var completionLatenessObservations: UInt64
+    public var completionLatenessP9999Nanoseconds: UInt64
+    public var maximumCompletionLatenessNanoseconds: UInt64
+    public var tailCompletionObservations: UInt64
+    public var minimumTailCompletionSlackFrames: Int
+    public var tailDeadlineMisses: UInt64
+
+    public init(
+        callbackStartLatenessObservations: UInt64 = 0,
+        callbackStartLatenessP9999Nanoseconds: UInt64 = 0,
+        maximumCallbackStartLatenessNanoseconds: UInt64 = 0,
+        directHeadObservations: UInt64 = 0,
+        directHeadP9999Nanoseconds: UInt64 = 0,
+        maximumDirectHeadNanoseconds: UInt64 = 0,
+        tailWorkObservations: UInt64 = 0,
+        tailWorkP9999Nanoseconds: UInt64 = 0,
+        maximumTailWorkNanoseconds: UInt64 = 0,
+        totalRenderObservations: UInt64 = 0,
+        totalRenderP9999Nanoseconds: UInt64 = 0,
+        maximumTotalRenderNanoseconds: UInt64 = 0,
+        completionLatenessObservations: UInt64 = 0,
+        completionLatenessP9999Nanoseconds: UInt64 = 0,
+        maximumCompletionLatenessNanoseconds: UInt64 = 0,
+        tailCompletionObservations: UInt64 = 0,
+        minimumTailCompletionSlackFrames: Int = 0,
+        tailDeadlineMisses: UInt64 = 0
+    ) {
+        self.callbackStartLatenessObservations = callbackStartLatenessObservations
+        self.callbackStartLatenessP9999Nanoseconds = callbackStartLatenessP9999Nanoseconds
+        self.maximumCallbackStartLatenessNanoseconds = maximumCallbackStartLatenessNanoseconds
+        self.directHeadObservations = directHeadObservations
+        self.directHeadP9999Nanoseconds = directHeadP9999Nanoseconds
+        self.maximumDirectHeadNanoseconds = maximumDirectHeadNanoseconds
+        self.tailWorkObservations = tailWorkObservations
+        self.tailWorkP9999Nanoseconds = tailWorkP9999Nanoseconds
+        self.maximumTailWorkNanoseconds = maximumTailWorkNanoseconds
+        self.totalRenderObservations = totalRenderObservations
+        self.totalRenderP9999Nanoseconds = totalRenderP9999Nanoseconds
+        self.maximumTotalRenderNanoseconds = maximumTotalRenderNanoseconds
+        self.completionLatenessObservations = completionLatenessObservations
+        self.completionLatenessP9999Nanoseconds = completionLatenessP9999Nanoseconds
+        self.maximumCompletionLatenessNanoseconds = maximumCompletionLatenessNanoseconds
+        self.tailCompletionObservations = tailCompletionObservations
+        self.minimumTailCompletionSlackFrames = minimumTailCompletionSlackFrames
+        self.tailDeadlineMisses = tailDeadlineMisses
+    }
+}
+
 public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var capturedFrames: UInt64
     public var playedFrames: UInt64
@@ -110,9 +172,12 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var playbackBufferObservations: UInt64
     public var inputTimestampDiscontinuities: UInt64
     public var outputTimestampDiscontinuities: UInt64
+    public var pairedTimestampDiscontinuities: UInt64
     public var maximumCaptureCallbackFrames: Int
     public var maximumPlaybackCallbackFrames: Int
     public var renderDeadlineMisses: UInt64
+    public var callbackStartStarvations: UInt64
+    public var renderOverruns: UInt64
     public var playbackTimestampDiscontinuities: UInt64
     public var playbackBufferRenegotiations: UInt64
     public var adaptivePlaybackRenderFailures: UInt64
@@ -126,6 +191,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
     public var minimumTapToOutputLatencyNanoseconds: UInt64
     public var maximumTapToOutputLatencyNanoseconds: UInt64
     public var averageTapToOutputLatencyNanoseconds: Double
+    public var renderTiming: SettingsAudioRenderTimingDTO
 
     private enum CodingKeys: String, CodingKey {
         case capturedFrames
@@ -143,9 +209,12 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case playbackBufferObservations
         case inputTimestampDiscontinuities
         case outputTimestampDiscontinuities
+        case pairedTimestampDiscontinuities
         case maximumCaptureCallbackFrames
         case maximumPlaybackCallbackFrames
         case renderDeadlineMisses
+        case callbackStartStarvations
+        case renderOverruns
         case playbackTimestampDiscontinuities
         case playbackBufferRenegotiations
         case adaptivePlaybackRenderFailures
@@ -159,6 +228,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         case minimumTapToOutputLatencyNanoseconds
         case maximumTapToOutputLatencyNanoseconds
         case averageTapToOutputLatencyNanoseconds
+        case renderTiming
     }
 
     public init(
@@ -177,9 +247,12 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         playbackBufferObservations: UInt64 = 0,
         inputTimestampDiscontinuities: UInt64 = 0,
         outputTimestampDiscontinuities: UInt64 = 0,
+        pairedTimestampDiscontinuities: UInt64 = 0,
         maximumCaptureCallbackFrames: Int = 0,
         maximumPlaybackCallbackFrames: Int = 0,
         renderDeadlineMisses: UInt64 = 0,
+        callbackStartStarvations: UInt64 = 0,
+        renderOverruns: UInt64 = 0,
         playbackTimestampDiscontinuities: UInt64 = 0,
         playbackBufferRenegotiations: UInt64 = 0,
         adaptivePlaybackRenderFailures: UInt64 = 0,
@@ -192,7 +265,8 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         tapToOutputLatencyObservations: UInt64 = 0,
         minimumTapToOutputLatencyNanoseconds: UInt64 = 0,
         maximumTapToOutputLatencyNanoseconds: UInt64 = 0,
-        averageTapToOutputLatencyNanoseconds: Double = 0
+        averageTapToOutputLatencyNanoseconds: Double = 0,
+        renderTiming: SettingsAudioRenderTimingDTO = SettingsAudioRenderTimingDTO()
     ) {
         self.capturedFrames = capturedFrames
         self.playedFrames = playedFrames
@@ -209,9 +283,12 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.playbackBufferObservations = playbackBufferObservations
         self.inputTimestampDiscontinuities = inputTimestampDiscontinuities
         self.outputTimestampDiscontinuities = outputTimestampDiscontinuities
+        self.pairedTimestampDiscontinuities = pairedTimestampDiscontinuities
         self.maximumCaptureCallbackFrames = maximumCaptureCallbackFrames
         self.maximumPlaybackCallbackFrames = maximumPlaybackCallbackFrames
         self.renderDeadlineMisses = renderDeadlineMisses
+        self.callbackStartStarvations = callbackStartStarvations
+        self.renderOverruns = renderOverruns
         self.playbackTimestampDiscontinuities = playbackTimestampDiscontinuities
         self.playbackBufferRenegotiations = playbackBufferRenegotiations
         self.adaptivePlaybackRenderFailures = adaptivePlaybackRenderFailures
@@ -225,6 +302,7 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
         self.minimumTapToOutputLatencyNanoseconds = minimumTapToOutputLatencyNanoseconds
         self.maximumTapToOutputLatencyNanoseconds = maximumTapToOutputLatencyNanoseconds
         self.averageTapToOutputLatencyNanoseconds = averageTapToOutputLatencyNanoseconds
+        self.renderTiming = renderTiming
     }
 
     public init(from decoder: any Decoder) throws {
@@ -245,9 +323,12 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             playbackBufferObservations: try container.decodeIfPresent(UInt64.self, forKey: .playbackBufferObservations) ?? 0,
             inputTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .inputTimestampDiscontinuities) ?? 0,
             outputTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .outputTimestampDiscontinuities) ?? 0,
+            pairedTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .pairedTimestampDiscontinuities) ?? 0,
             maximumCaptureCallbackFrames: try container.decodeIfPresent(Int.self, forKey: .maximumCaptureCallbackFrames) ?? 0,
             maximumPlaybackCallbackFrames: try container.decodeIfPresent(Int.self, forKey: .maximumPlaybackCallbackFrames) ?? 0,
             renderDeadlineMisses: try container.decodeIfPresent(UInt64.self, forKey: .renderDeadlineMisses) ?? 0,
+            callbackStartStarvations: try container.decodeIfPresent(UInt64.self, forKey: .callbackStartStarvations) ?? 0,
+            renderOverruns: try container.decodeIfPresent(UInt64.self, forKey: .renderOverruns) ?? 0,
             playbackTimestampDiscontinuities: try container.decodeIfPresent(UInt64.self, forKey: .playbackTimestampDiscontinuities) ?? 0,
             playbackBufferRenegotiations: try container.decodeIfPresent(UInt64.self, forKey: .playbackBufferRenegotiations) ?? 0,
             adaptivePlaybackRenderFailures: try container.decodeIfPresent(UInt64.self, forKey: .adaptivePlaybackRenderFailures) ?? 0,
@@ -260,7 +341,11 @@ public struct SettingsAudioMetricsDTO: Codable, Equatable, Sendable {
             tapToOutputLatencyObservations: try container.decodeIfPresent(UInt64.self, forKey: .tapToOutputLatencyObservations) ?? 0,
             minimumTapToOutputLatencyNanoseconds: try container.decodeIfPresent(UInt64.self, forKey: .minimumTapToOutputLatencyNanoseconds) ?? 0,
             maximumTapToOutputLatencyNanoseconds: try container.decodeIfPresent(UInt64.self, forKey: .maximumTapToOutputLatencyNanoseconds) ?? 0,
-            averageTapToOutputLatencyNanoseconds: try container.decodeIfPresent(Double.self, forKey: .averageTapToOutputLatencyNanoseconds) ?? 0
+            averageTapToOutputLatencyNanoseconds: try container.decodeIfPresent(Double.self, forKey: .averageTapToOutputLatencyNanoseconds) ?? 0,
+            renderTiming: try container.decodeIfPresent(
+                SettingsAudioRenderTimingDTO.self,
+                forKey: .renderTiming
+            ) ?? SettingsAudioRenderTimingDTO()
         )
     }
 }

--- a/Sources/GlassEQSettingsUI/SettingsView.swift
+++ b/Sources/GlassEQSettingsUI/SettingsView.swift
@@ -269,6 +269,7 @@ public struct SettingsView: View {
                 onCreateGraphic31: createGraphic31Profile,
                 onCreateGraphic10: createGraphic10Profile,
                 onCreateParametric: createParametricProfile,
+                onCreateConvolution: createConvolutionProfile,
                 onDuplicate: duplicateSelectedProfile,
                 onDelete: deleteSelectedProfile,
                 canDeleteSelectedProfile: canDeleteSelectedProfile,
@@ -451,6 +452,10 @@ public struct SettingsView: View {
 
     private func createParametricProfile() {
         perform(.createProfile(.parametric))
+    }
+
+    private func createConvolutionProfile() {
+        perform(.createProfile(.convolution))
     }
 
     private func duplicateSelectedProfile() {
@@ -715,6 +720,9 @@ struct EQAnalysisSignature: Equatable, Sendable {
     var leftFilters: [EQFilter]
     var rightPreampDB: Double
     var rightFilters: [EQFilter]
+    var convolution: EQConvolutionSource?
+    var leftConvolution: EQConvolutionSource?
+    var rightConvolution: EQConvolutionSource?
 
     init(profile: EQProfile, sampleRate: Double) {
         self.sampleRate = Self.effectiveSampleRate(sampleRate)
@@ -726,6 +734,9 @@ struct EQAnalysisSignature: Equatable, Sendable {
         self.leftFilters = profile.leftFilters
         self.rightPreampDB = profile.rightPreampDB
         self.rightFilters = profile.rightFilters
+        self.convolution = profile.convolution
+        self.leftConvolution = profile.leftConvolution
+        self.rightConvolution = profile.rightConvolution
     }
 
     static func effectiveSampleRate(_ sampleRate: Double) -> Double {
@@ -759,8 +770,10 @@ struct EQAnalysisSnapshot: Equatable, Sendable {
 
         switch profile.channelMode {
         case .linked:
-            self.linkedPoints = FrequencyResponse.points(
-                for: profile.filters,
+            self.linkedPoints = Self.responsePoints(
+                mode: profile.mode,
+                filters: profile.filters,
+                source: profile.convolution,
                 preampDB: profile.preampDB,
                 sampleRate: sampleRate
             )
@@ -768,17 +781,42 @@ struct EQAnalysisSnapshot: Equatable, Sendable {
             self.rightPoints = []
         case .stereo:
             self.linkedPoints = []
-            self.leftPoints = FrequencyResponse.points(
-                for: profile.leftFilters,
+            self.leftPoints = Self.responsePoints(
+                mode: profile.mode,
+                filters: profile.leftFilters,
+                source: profile.leftConvolution,
                 preampDB: profile.leftPreampDB,
                 sampleRate: sampleRate
             )
-            self.rightPoints = FrequencyResponse.points(
-                for: profile.rightFilters,
+            self.rightPoints = Self.responsePoints(
+                mode: profile.mode,
+                filters: profile.rightFilters,
+                source: profile.rightConvolution,
                 preampDB: profile.rightPreampDB,
                 sampleRate: sampleRate
             )
         }
+    }
+
+    private static func responsePoints(
+        mode: EQMode,
+        filters: [EQFilter],
+        source: EQConvolutionSource?,
+        preampDB: Double,
+        sampleRate: Double
+    ) -> [FrequencyResponsePoint] {
+        if mode == .convolution {
+            return FrequencyResponse.points(
+                for: source,
+                preampDB: preampDB,
+                sampleRate: sampleRate
+            )
+        }
+        return FrequencyResponse.points(
+            for: filters,
+            preampDB: preampDB,
+            sampleRate: sampleRate
+        )
     }
 
     var accessibilitySummary: String {
@@ -828,6 +866,7 @@ private struct ProfileSidebar: View {
     var onCreateGraphic31: () -> Void
     var onCreateGraphic10: () -> Void
     var onCreateParametric: () -> Void
+    var onCreateConvolution: () -> Void
     var onDuplicate: () -> Void
     var onDelete: () -> Void
     var canDeleteSelectedProfile: Bool
@@ -918,6 +957,18 @@ private struct ProfileSidebar: View {
                     .disabled(isReadOnly)
                     .accessibilityLabel(Text(localized("New parametric profile")))
                     .accessibilityHint(Text(localized("Creates a parametric equalizer profile")))
+
+                    Button {
+                        onCreateConvolution()
+                    } label: {
+                        Image(systemName: "waveform.path")
+                            .frame(width: 28, height: 28)
+                            .contentShape(.rect)
+                    }
+                    .help(localized("New response curve profile"))
+                    .disabled(isReadOnly)
+                    .accessibilityLabel(Text(localized("New response curve profile")))
+                    .accessibilityHint(Text(localized("Creates a minimum-phase response curve profile")))
 
                     Spacer()
 
@@ -1298,7 +1349,7 @@ private struct EditorTab: View {
                     }
                     .pickerStyle(.segmented)
                     .labelsHidden()
-                    .frame(maxWidth: 300)
+                    .frame(maxWidth: 420)
                     .accessibilityLabel(Text(localized("Profile type")))
                     .accessibilityValue(Text(draftProfile.mode.title))
                     .accessibilityHint(Text(localized("Changes the equalizer profile type")))
@@ -1381,12 +1432,17 @@ private struct EditorTab: View {
             }
             .cardPanel(padding: 16)
 
-            if draftProfile.mode == .parametric {
+            switch draftProfile.mode {
+            case .parametric:
                 ParametricFilterEditor(filters: activeFiltersBinding)
                     .id("parametric:\(activeEditContextID)")
-            } else {
+            case .graphic10, .graphic31:
                 GraphicFilterEditor(filters: activeFiltersBinding)
                     .id("graphic:\(activeEditContextID)")
+                    .cardPanel(padding: 16)
+            case .convolution:
+                MagnitudeCurveEditor(points: activeMagnitudePointsBinding)
+                    .id("curve:\(activeEditContextID)")
                     .cardPanel(padding: 16)
             }
 
@@ -1451,10 +1507,22 @@ private struct EditorTab: View {
             filters = GraphicEQBands.thirtyOneBand.map {
                 EQFilter(kind: .peak, frequency: $0, gainDB: 0, q: GraphicEQBands.graphicQ)
             }
+        case .convolution:
+            filters = []
         }
         draftProfile.filters = filters
         draftProfile.leftFilters = filters
         draftProfile.rightFilters = filters
+        if mode == .convolution {
+            let source = EQProfile.flatConvolution.convolution
+            draftProfile.convolution = source
+            draftProfile.leftConvolution = source
+            draftProfile.rightConvolution = source
+        } else {
+            draftProfile.convolution = nil
+            draftProfile.leftConvolution = nil
+            draftProfile.rightConvolution = nil
+        }
     }
 
     private var activePreampBinding: Binding<Double> {
@@ -1479,6 +1547,38 @@ private struct EditorTab: View {
         }
     }
 
+    private var activeMagnitudePointsBinding: Binding<[EQMagnitudePoint]> {
+        let source: Binding<EQConvolutionSource?>
+        switch (draftProfile.channelMode, editChannel) {
+        case (.stereo, .left):
+            source = $draftProfile.leftConvolution
+        case (.stereo, .right):
+            source = $draftProfile.rightConvolution
+        default:
+            source = $draftProfile.convolution
+        }
+        return Binding(
+            get: {
+                guard case .magnitudeCurve(let curve) = source.wrappedValue else {
+                    return []
+                }
+                return curve.points
+            },
+            set: { points in
+                let version: UInt16
+                if case .magnitudeCurve(let curve) = source.wrappedValue {
+                    version = curve.synthesisVersion
+                } else {
+                    version = MinimumPhaseFIRCompiler.synthesisVersion
+                }
+                source.wrappedValue = .magnitudeCurve(MagnitudeCurveSource(
+                    synthesisVersion: version,
+                    points: points
+                ))
+            }
+        )
+    }
+
     private var activeEditContextID: String {
         let channel = draftProfile.channelMode == .stereo ? editChannel.rawValue : "linked"
         return "\(draftProfile.id.uuidString):\(channel):\(draftEditGeneration)"
@@ -1493,13 +1593,19 @@ private struct EditorTab: View {
         case .linked:
             let sourceFilters = editChannel == .right ? draftProfile.rightFilters : draftProfile.leftFilters
             let sourcePreamp = editChannel == .right ? draftProfile.rightPreampDB : draftProfile.leftPreampDB
+            let sourceConvolution = editChannel == .right
+                ? draftProfile.rightConvolution
+                : draftProfile.leftConvolution
             draftProfile.filters = sourceFilters
             draftProfile.preampDB = sourcePreamp
+            draftProfile.convolution = sourceConvolution
         case .stereo:
             draftProfile.leftFilters = draftProfile.filters
             draftProfile.rightFilters = draftProfile.filters
             draftProfile.leftPreampDB = draftProfile.preampDB
             draftProfile.rightPreampDB = draftProfile.preampDB
+            draftProfile.leftConvolution = draftProfile.convolution
+            draftProfile.rightConvolution = draftProfile.convolution
             editChannel = .left
         }
 
@@ -1828,6 +1934,94 @@ private struct FrequencyResponseGraph: View {
         let maxDB = 12.0
         let fraction = 1 - ((magnitudeDB - minDB) / (maxDB - minDB))
         return rect.minY + rect.height * fraction
+    }
+}
+
+private struct MagnitudeCurveEditor: View {
+    @Binding var points: [EQMagnitudePoint]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(localized("Response Curve"))
+                    .font(.headline)
+                Spacer()
+                Button {
+                    addPoint()
+                } label: {
+                    Label(localized("Add Point"), systemImage: "plus")
+                        .frame(minHeight: 28)
+                        .contentShape(.rect)
+                }
+                .controlSize(.large)
+                .accessibilityHint(Text(localized("Adds a magnitude point in the largest frequency gap")))
+            }
+
+            Text(localized("GlassEQ interpolates these points in log-frequency space and compiles a 16,384-tap minimum-phase filter when you apply the profile."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            LazyVStack(spacing: 6) {
+                ForEach($points) { $point in
+                    HStack(spacing: 10) {
+                        EditableValueText(
+                            title: localized("Frequency"),
+                            value: $point.frequency,
+                            range: ProfilePersistence.frequencyRange,
+                            display: point.frequency.frequencyLabel,
+                            width: 72
+                        )
+                        Slider(
+                            value: Binding(
+                                get: { point.gainDB },
+                                set: { point.gainDB = quantized($0, step: 0.1) }
+                            ),
+                            in: -24...12
+                        )
+                        .frame(maxWidth: 640)
+                        .accessibilityLabel(Text(localized("Gain at \(point.frequency.frequencyLabel)")))
+                        .accessibilityValue(Text(point.gainDB.dbLabel))
+                        EditableValueText(
+                            title: localized("Gain"),
+                            value: $point.gainDB,
+                            range: ProfilePersistence.gainRange,
+                            display: point.gainDB.dbLabel,
+                            width: 60
+                        )
+                        Button(role: .destructive) {
+                            points.removeAll { $0.id == point.id }
+                        } label: {
+                            Image(systemName: "trash")
+                                .frame(width: 24, height: 24)
+                                .contentShape(.rect)
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(points.count <= 2)
+                        .accessibilityLabel(Text(localized("Delete response point")))
+                        .accessibilityHint(Text(localized("Removes this magnitude point")))
+                    }
+                    .accessibilityElement(children: .contain)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func addPoint() {
+        let sorted = points.sorted { $0.frequency < $1.frequency }
+        let candidates = Set([20.0, 20_000.0] + sorted.map(\.frequency))
+            .filter { ProfilePersistence.frequencyRange.contains($0) }
+            .sorted()
+        let widestGap = zip(candidates, candidates.dropFirst()).max { lhs, rhs in
+            log(lhs.1 / lhs.0) < log(rhs.1 / rhs.0)
+        }
+        let frequency = widestGap.map { sqrt($0.0 * $0.1) } ?? 1_000
+        let gain = MinimumPhaseFIRCompiler.interpolatedGainDB(
+            frequency: frequency,
+            points: sorted
+        )
+        points.append(EQMagnitudePoint(frequency: frequency, gainDB: gain))
+        points.sort { $0.frequency < $1.frequency }
     }
 }
 
@@ -2573,10 +2767,62 @@ private struct OutputTab: View {
                         LabeledContent(localized("Bridge Latency Range"), value: bridgeLatencyRangeLabel)
                     } else {
                         LabeledContent(localized("Render Deadline Misses"), value: localizedInteger(snapshot.metrics.renderDeadlineMisses))
+                        LabeledContent(localized("Start Starvations"), value: localizedInteger(snapshot.metrics.callbackStartStarvations))
+                        LabeledContent(localized("Render Overruns"), value: localizedInteger(snapshot.metrics.renderOverruns))
+                        LabeledContent(localized("Paired Discontinuities"), value: localizedInteger(snapshot.metrics.pairedTimestampDiscontinuities))
+                        LabeledContent(
+                            localized("Callback Start Late p99.99 / Max"),
+                            value: extremeDurationLabel(
+                                observations: snapshot.metrics.renderTiming.callbackStartLatenessObservations,
+                                p9999Nanoseconds: snapshot.metrics.renderTiming.callbackStartLatenessP9999Nanoseconds,
+                                maximumNanoseconds: snapshot.metrics.renderTiming.maximumCallbackStartLatenessNanoseconds
+                            )
+                        )
+                        if snapshot.metrics.renderTiming.directHeadObservations > 0 {
+                            LabeledContent(
+                                localized("FIR Head p99.99 / Max"),
+                                value: extremeDurationLabel(
+                                    observations: snapshot.metrics.renderTiming.directHeadObservations,
+                                    p9999Nanoseconds: snapshot.metrics.renderTiming.directHeadP9999Nanoseconds,
+                                    maximumNanoseconds: snapshot.metrics.renderTiming.maximumDirectHeadNanoseconds
+                                )
+                            )
+                            LabeledContent(
+                                localized("FIR Tail p99.99 / Max"),
+                                value: extremeDurationLabel(
+                                    observations: snapshot.metrics.renderTiming.tailWorkObservations,
+                                    p9999Nanoseconds: snapshot.metrics.renderTiming.tailWorkP9999Nanoseconds,
+                                    maximumNanoseconds: snapshot.metrics.renderTiming.maximumTailWorkNanoseconds
+                                )
+                            )
+                            LabeledContent(
+                                localized("Tail Completion Slack"),
+                                value: tailCompletionSlackLabel
+                            )
+                        }
+                        LabeledContent(
+                            localized("Total Render p99.99 / Max"),
+                            value: extremeDurationLabel(
+                                observations: snapshot.metrics.renderTiming.totalRenderObservations,
+                                p9999Nanoseconds: snapshot.metrics.renderTiming.totalRenderP9999Nanoseconds,
+                                maximumNanoseconds: snapshot.metrics.renderTiming.maximumTotalRenderNanoseconds
+                            )
+                        )
+                        LabeledContent(
+                            localized("Completion Late p99.99 / Max"),
+                            value: extremeDurationLabel(
+                                observations: snapshot.metrics.renderTiming.completionLatenessObservations,
+                                p9999Nanoseconds: snapshot.metrics.renderTiming.completionLatenessP9999Nanoseconds,
+                                maximumNanoseconds: snapshot.metrics.renderTiming.maximumCompletionLatenessNanoseconds
+                            )
+                        )
                         LabeledContent(localized("Input Timestamp Jumps"), value: localizedInteger(snapshot.metrics.inputTimestampDiscontinuities))
                         LabeledContent(localized("Output Timestamp Jumps"), value: localizedInteger(snapshot.metrics.outputTimestampDiscontinuities))
                         LabeledContent(localized("Tap-to-Output Latency"), value: tapToOutputLatencyLabel)
                         LabeledContent(localized("Tap-to-Output Range"), value: tapToOutputLatencyRangeLabel)
+                        Text(localized("Failure categories can overlap. Timing percentiles use bounded realtime histograms and update every 1,024 callbacks."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                     Button(localized("Reset metrics")) {
                         onResetDiagnostics()
@@ -2665,6 +2911,37 @@ private struct OutputTab: View {
         snapshot.metrics.playbackBufferObservations > 0
     }
 
+    private func extremeDurationLabel(
+        observations: UInt64,
+        p9999Nanoseconds: UInt64,
+        maximumNanoseconds: UInt64
+    ) -> String {
+        guard observations > 0 else {
+            return localized("No samples")
+        }
+        let percentile = localizedDecimal(
+            Double(p9999Nanoseconds) / 1_000,
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        )
+        let maximum = localizedDecimal(
+            Double(maximumNanoseconds) / 1_000,
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        )
+        return localized("\(percentile) / \(maximum) us")
+    }
+
+    private var tailCompletionSlackLabel: String {
+        let timing = snapshot.metrics.renderTiming
+        guard timing.tailCompletionObservations > 0 else {
+            return localized("No completed blocks")
+        }
+        return localized(
+            "\(localizedInteger(timing.minimumTailCompletionSlackFrames)) frames, \(localizedInteger(timing.tailDeadlineMisses)) misses"
+        )
+    }
+
     private var bridgeLatencyLabel: String {
         localizedLatency(
             milliseconds: playbackFramesToMilliseconds(
@@ -2722,6 +2999,8 @@ private extension EQMode {
             localized("10-Band")
         case .graphic31:
             localized("31-Band")
+        case .convolution:
+            localized("Response Curve")
         }
     }
 }

--- a/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
+++ b/Tests/GlassEQAppTests/GlassEQAppModelLifecycleTests.swift
@@ -2690,15 +2690,17 @@ struct GlassEQAppModelLifecycleTests {
 
         try model.createProfile(kind: .parametric)
         try model.createProfile(kind: .graphic10)
+        try model.createProfile(kind: .convolution)
         try? await Task.sleep(for: .milliseconds(20))
 
         #expect(!FileManager.default.fileExists(atPath: storeURL.path))
         #expect(await model.flushStoreBeforeQuit())
 
         let loaded = ProfilePersistence.load(from: storeURL).store
-        #expect(loaded.profiles.count == 3)
+        #expect(loaded.profiles.count == 4)
         #expect(loaded.profiles.contains { $0.name == "New Parametric" })
         #expect(loaded.profiles.contains { $0.name == "New 10-Band" })
+        #expect(loaded.profiles.contains { $0.name == "New Response Curve" })
     }
 
     @Test

--- a/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
+++ b/Tests/GlassEQAudioTests/CoreAudioDeviceTests.swift
@@ -81,6 +81,113 @@ struct CoreAudioDeviceTests {
     }
 
     @Test
+    func realtimeOutputDeclickerSmoothsAcrossCallbacks() {
+        var declicker = RealtimeOutputDeclicker(
+            sampleRate: 4,
+            channelCount: 1,
+            durationSeconds: 1
+        )
+        var previous = [Float(2)]
+        previous.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 1, channelCount: 1)
+        }
+
+        declicker.markDiscontinuity()
+        var firstCallback = [Float](repeating: 10, count: 2)
+        firstCallback.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 2, channelCount: 1)
+        }
+        var secondCallback = [Float](repeating: 10, count: 2)
+        secondCallback.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 2, channelCount: 1)
+        }
+
+        #expect(abs(firstCallback[0] - 2) < 0.000_001)
+        #expect(abs(firstCallback[1] - 4.074_074) < 0.000_001)
+        #expect(abs(secondCallback[0] - 7.925_926) < 0.000_001)
+        #expect(abs(secondCallback[1] - 10) < 0.000_001)
+
+        var steadyState = [Float(11)]
+        steadyState.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 1, channelCount: 1)
+        }
+        #expect(steadyState == [11])
+    }
+
+    @Test
+    func realtimeOutputDeclickerTreatsChannelsIndependently() {
+        var declicker = RealtimeOutputDeclicker(
+            sampleRate: 4,
+            channelCount: 2,
+            durationSeconds: 1
+        )
+        var previous: [Float] = [2, -3]
+        previous.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 1, channelCount: 2)
+        }
+
+        declicker.markDiscontinuity()
+        var samples: [Float] = [10, 20, 10, 20, 10, 20, 10, 20]
+        samples.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 4, channelCount: 2)
+        }
+
+        #expect(abs(samples[0] - 2) < 0.000_001)
+        #expect(abs(samples[1] + 3) < 0.000_001)
+        #expect(abs(samples[6] - 10) < 0.000_001)
+        #expect(abs(samples[7] - 20) < 0.000_001)
+    }
+
+    @Test
+    func realtimeOutputDeclickerRestartsFromLastEmittedSample() {
+        var declicker = RealtimeOutputDeclicker(
+            sampleRate: 4,
+            channelCount: 1,
+            durationSeconds: 1
+        )
+        var previous = [Float(2)]
+        previous.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 1, channelCount: 1)
+        }
+
+        declicker.markDiscontinuity()
+        var interrupted = [Float](repeating: 10, count: 2)
+        interrupted.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 2, channelCount: 1)
+        }
+
+        declicker.markDiscontinuity()
+        var restarted = [Float](repeating: -5, count: 4)
+        restarted.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 4, channelCount: 1)
+        }
+
+        #expect(abs(restarted[0] - interrupted[1]) < 0.000_001)
+        #expect(abs(restarted[3] + 5) < 0.000_001)
+    }
+
+    @Test
+    func realtimeOutputDeclickerDoesNotOvershootReversingWaveform() {
+        var declicker = RealtimeOutputDeclicker(
+            sampleRate: 4,
+            channelCount: 1,
+            durationSeconds: 1
+        )
+        var previous = [Float(1)]
+        previous.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 1, channelCount: 1)
+        }
+
+        declicker.markDiscontinuity()
+        var samples: [Float] = [-1, 1, -1, 1]
+        samples.withUnsafeMutableBufferPointer {
+            declicker.apply(to: $0, frameCount: 4, channelCount: 1)
+        }
+
+        #expect(samples.allSatisfy { (-1...1).contains($0) })
+    }
+
+    @Test
     func defaultOutputQueryDoesNotCrash() throws {
         let device = try CoreAudioDeviceQuery.defaultOutputDevice()
 
@@ -670,6 +777,42 @@ struct CoreAudioDeviceTests {
             frameCount: 16,
             sampleRate: 48_000
         ) == 12)
+    }
+
+    @Test
+    func renderOverrunBeginsAfterOneCallbackPeriod() {
+        #expect(!SystemTapAudioEngine.renderOverranPeriod(
+            elapsedNanoseconds: 333_333,
+            frameCount: 16,
+            sampleRate: 48_000
+        ))
+        #expect(SystemTapAudioEngine.renderOverranPeriod(
+            elapsedNanoseconds: 333_334,
+            frameCount: 16,
+            sampleRate: 48_000
+        ))
+    }
+
+    @Test
+    func extremeDurationTrackerPublishesP9999AndResetsWithoutClearingOnControlThread() {
+        let tracker = RealtimeExtremeDurationTracker()
+        for microseconds in 1...1_024 {
+            tracker.record(UInt64(microseconds) * 1_000)
+        }
+
+        let measured = tracker.snapshot()
+        #expect(measured.observations == 1_024)
+        #expect(measured.p9999Nanoseconds == 1_024_000)
+        #expect(measured.maximumNanoseconds == 1_024_000)
+
+        tracker.reset()
+        #expect(tracker.snapshot().observations == 0)
+
+        tracker.record(250)
+        let afterReset = tracker.snapshot()
+        #expect(afterReset.observations == 1)
+        #expect(afterReset.p9999Nanoseconds == 250)
+        #expect(afterReset.maximumNanoseconds == 250)
     }
 
     @Test

--- a/Tests/GlassEQCoreTests/ConvolutionTests.swift
+++ b/Tests/GlassEQCoreTests/ConvolutionTests.swift
@@ -1,0 +1,188 @@
+@testable import GlassEQCore
+import Foundation
+import Testing
+
+@Suite
+struct ConvolutionTests {
+    @Test
+    func flatCurveCompilesToIdentityImpulse() throws {
+        let impulse = try MinimumPhaseFIRCompiler.compile(
+            points: [
+                EQMagnitudePoint(frequency: 20, gainDB: 0),
+                EQMagnitudePoint(frequency: 20_000, gainDB: 0)
+            ],
+            sampleRate: 48_000
+        )
+
+        #expect(abs(impulse[0] - 1) < 0.000_01)
+        #expect(impulse.dropFirst().allSatisfy { abs($0) < 0.000_01 })
+    }
+
+    @Test
+    func curveCompilerMatchesRequestedMagnitude() throws {
+        let points = [
+            EQMagnitudePoint(frequency: 20, gainDB: 6),
+            EQMagnitudePoint(frequency: 1_000, gainDB: -3),
+            EQMagnitudePoint(frequency: 20_000, gainDB: 2)
+        ]
+        let sampleRate = 48_000.0
+        let impulse = try MinimumPhaseFIRCompiler.compile(
+            points: points,
+            sampleRate: sampleRate
+        )
+
+        for frequency in [0.0, 20, 100, 1_000, 8_000, 20_000, 24_000] {
+            let expected = MinimumPhaseFIRCompiler.interpolatedGainDB(
+                frequency: frequency,
+                points: points
+            )
+            let actual = magnitudeDB(
+                impulse: impulse,
+                frequency: frequency,
+                sampleRate: sampleRate
+            )
+            #expect(abs(actual - expected) < 0.05)
+        }
+    }
+
+    @Test
+    func curveEndpointsClampToFirstAndLastGain() {
+        let points = [
+            EQMagnitudePoint(frequency: 20, gainDB: 6),
+            EQMagnitudePoint(frequency: 1_000, gainDB: -3),
+            EQMagnitudePoint(frequency: 20_000, gainDB: 2)
+        ]
+
+        #expect(MinimumPhaseFIRCompiler.interpolatedGainDB(frequency: 0, points: points) == 6)
+        #expect(MinimumPhaseFIRCompiler.interpolatedGainDB(frequency: 24_000, points: points) == 2)
+    }
+
+    @Test
+    func duplicateCurveFrequencyIsRejected() {
+        #expect(throws: MinimumPhaseFIRCompilerError.duplicateFrequency(1_000)) {
+            _ = try MinimumPhaseFIRCompiler.compile(
+                points: [
+                    EQMagnitudePoint(frequency: 1_000, gainDB: 1),
+                    EQMagnitudePoint(frequency: 1_000, gainDB: 2)
+                ],
+                sampleRate: 48_000
+            )
+        }
+    }
+
+    @Test
+    func hybridConvolverPreservesHeadTailSeams() throws {
+        let seamTaps = [510, 511, 512, 513, 514, 767, 768, 769, 1_023, 1_024]
+        var impulse = [Float](repeating: 0, count: 1_025)
+        for (offset, tap) in seamTaps.enumerated() {
+            impulse[tap] = Float(offset + 1) / 10
+        }
+
+        let output = try render(
+            input: [1] + [Float](repeating: 0, count: 1_536),
+            impulse: impulse,
+            chunkSizes: [1, 31, 480, 7, 64, 13, 256]
+        )
+
+        for index in output.indices {
+            let expected = index < impulse.count ? impulse[index] : 0
+            #expect(abs(output[index] - expected) < 0.000_02)
+        }
+    }
+
+    @Test
+    func hybridConvolverMatchesDirectConvolutionAcrossPathologicalChunks() throws {
+        var generator = DeterministicGenerator(state: 0xC0FFEE)
+        let impulse = (0..<1_281).map { index in
+            generator.nextFloat() * exp(-Float(index) / 220) * 0.03
+        }
+        let input = (0..<4_321).map { _ in generator.nextFloat() * 0.5 }
+        let expected = directConvolution(input: input, impulse: impulse)
+        let actual = try render(
+            input: input,
+            impulse: impulse,
+            chunkSizes: [1, 31, 480, 7, 64, 13, 256]
+        )
+
+        #expect(actual.count == expected.count)
+        for index in actual.indices {
+            #expect(abs(actual[index] - expected[index]) < 0.000_05)
+        }
+    }
+
+    private func render(
+        input: [Float],
+        impulse: [Float],
+        chunkSizes: [Int]
+    ) throws -> [Float] {
+        let kernel = try PreparedConvolutionKernel(impulseResponse: impulse)
+        var convolver = try RealtimeHybridConvolver(kernel: kernel)
+        var output = input
+        var timing = EQRenderWorkTiming()
+        var frame = 0
+        var chunkIndex = 0
+        while frame < input.count {
+            let chunk = min(chunkSizes[chunkIndex % chunkSizes.count], input.count - frame)
+            output.withUnsafeMutableBufferPointer { storage in
+                let samples = UnsafeMutableBufferPointer(
+                    start: storage.baseAddress! + frame,
+                    count: chunk
+                )
+                let diagnostics = convolver.processInterleavedChannel(
+                    samples,
+                    frameCount: chunk,
+                    channel: 0,
+                    channelCount: 1,
+                    preampLinearGain: 1
+                )
+                timing.merge(diagnostics.workTiming)
+            }
+            frame += chunk
+            chunkIndex += 1
+        }
+        #expect(timing.tailDeadlineMisses == 0)
+        return output
+    }
+
+    private func directConvolution(
+        input: [Float],
+        impulse: [Float]
+    ) -> [Float] {
+        var output = [Float](repeating: 0, count: input.count)
+        for frame in input.indices {
+            var value: Float = 0
+            let lastTap = min(frame, impulse.count - 1)
+            for tap in 0...lastTap {
+                value += impulse[tap] * input[frame - tap]
+            }
+            output[frame] = value
+        }
+        return output
+    }
+
+    private func magnitudeDB(
+        impulse: [Float],
+        frequency: Double,
+        sampleRate: Double
+    ) -> Double {
+        let omega = 2 * Double.pi * frequency / sampleRate
+        var real = 0.0
+        var imaginary = 0.0
+        for (index, sample) in impulse.enumerated() {
+            let phase = -omega * Double(index)
+            real += Double(sample) * cos(phase)
+            imaginary += Double(sample) * sin(phase)
+        }
+        return 20 * log10(max(hypot(real, imaginary), .leastNonzeroMagnitude))
+    }
+}
+
+private struct DeterministicGenerator {
+    var state: UInt64
+
+    mutating func nextFloat() -> Float {
+        state = state &* 6_364_136_223_846_793_005 &+ 1
+        let normalized = Float((state >> 40) & 0xFFFFFF) / Float(0xFFFFFF)
+        return normalized * 2 - 1
+    }
+}

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -730,6 +730,35 @@ struct EQCoreTests {
     }
 
     @Test
+    func bypassedConvolutionLeavesNearFullScaleSamplesUntouched() {
+        var profile = EQProfile.flatConvolution
+        profile.isBypassed = true
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: profile,
+                sampleRate: 48_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 4,
+            channelCount: 1,
+            sampleRate: 48_000
+        )
+        var samples: [Float] = [1, -1, 0.99, -0.99]
+        let frameCount = samples.count
+
+        let result = samples.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: frameCount,
+                channelCount: 1
+            )
+        }
+
+        #expect(samples == [1, -1, 0.99, -0.99])
+        #expect(result.saturatedSamples == 0)
+    }
+
+    @Test
     func programmeComparisonReferenceKeepsPreampAndDisablesOnlyFilters() {
         let profile = EQProfile(
             name: "Stereo",

--- a/Tests/GlassEQCoreTests/EQCoreTests.swift
+++ b/Tests/GlassEQCoreTests/EQCoreTests.swift
@@ -184,6 +184,32 @@ struct EQCoreTests {
     }
 
     @Test
+    func responseCurveAnalysisUsesCurvePeakAndLogFrequencyInterpolation() {
+        var profile = EQProfile.flatConvolution
+        profile.preampDB = -2
+        profile.convolution = .magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: 0),
+            EQMagnitudePoint(frequency: 200, gainDB: 8),
+            EQMagnitudePoint(frequency: 20_000, gainDB: -3)
+        ]))
+
+        let recommended = EQProfileAnalysis.recommendedPreampDB(
+            profile: profile,
+            sampleRate: 48_000
+        )
+        let response = FrequencyResponse.points(
+            for: profile.convolution,
+            preampDB: profile.preampDB,
+            sampleRate: 48_000,
+            count: 3
+        )
+
+        #expect(recommended == -6.5)
+        #expect(abs(response[0].magnitudeDB + 2) < 0.000_001)
+        #expect(response.count == 3)
+    }
+
+    @Test
     func bypassLeavesSamplesUntouched() {
         var profile = EQProfile(
             name: "Bypass",
@@ -551,6 +577,71 @@ struct EQCoreTests {
     }
 
     @Test
+    func convolutionTransitionWarmsEntireImpulseHistoryBeforeBlending() throws {
+        let active = EQProfile(name: "Active", mode: .parametric, filters: [])
+        var incoming = EQProfile.flatConvolution
+        incoming.preampDB = 6.020_599_913
+        let incomingConfiguration = try EQRenderConfiguration.prepare(
+            profile: incoming,
+            sampleRate: 48_000,
+            channelCount: 1
+        )
+        var transition = RealtimeEQTransition(
+            activeProcessor: EQProcessor(configuration: EQConfiguration(
+                profile: active,
+                sampleRate: 48_000,
+                channelCount: 1
+            )),
+            maximumFrameCount: 480,
+            channelCount: 1,
+            sampleRate: 48_000,
+            warmupSeconds: 0,
+            blendSeconds: 4.0 / 48_000
+        )
+        let didBegin = transition.beginTransition(to: EQProcessor(
+            renderConfiguration: incomingConfiguration
+        ))
+        #expect(didBegin)
+
+        var renderedFrames = 0
+        var observedTailCompletion = false
+        while renderedFrames < PreparedConvolutionKernel.tapCount - 1 {
+            let frameCount = min(
+                480,
+                PreparedConvolutionKernel.tapCount - 1 - renderedFrames
+            )
+            var samples = [Float](repeating: 0.25, count: frameCount)
+            let result = samples.withUnsafeMutableBufferPointer {
+                transition.processInterleavedWithDiagnostics(
+                    $0,
+                    frameCount: frameCount,
+                    channelCount: 1
+                )
+            }
+            #expect(samples.allSatisfy { abs($0 - 0.25) < 0.000_001 })
+            #expect(!result.completedTransition)
+            #expect(result.workTiming.directHeadHostTicks > 0)
+            #expect(result.workTiming.tailDeadlineMisses == 0)
+            observedTailCompletion = observedTailCompletion
+                || result.workTiming.tailCompletionObservations > 0
+            renderedFrames += frameCount
+        }
+        #expect(observedTailCompletion)
+
+        var blend = [Float](repeating: 0.25, count: 4)
+        let blendResult = blend.withUnsafeMutableBufferPointer {
+            transition.processInterleavedWithDiagnostics(
+                $0,
+                frameCount: 4,
+                channelCount: 1
+            )
+        }
+        #expect(abs(blend[0] - 0.25) < 0.000_01)
+        #expect(abs(blend[3] - 0.5) < 0.000_01)
+        #expect(blendResult.completedTransition)
+    }
+
+    @Test
     func wholeBankTransitionAllowsFilterTopologyChanges() {
         let active = EQProfile(name: "Active", mode: .parametric, filters: [])
         let incoming = EQProfile(
@@ -669,6 +760,22 @@ struct EQCoreTests {
         #expect(reference.filters.isEmpty)
         #expect(reference.leftFilters.isEmpty)
         #expect(reference.rightFilters.isEmpty)
+        #expect(!reference.isBypassed)
+    }
+
+    @Test
+    func programmeComparisonReferenceKeepsConvolutionPreampAndDisablesCurve() {
+        var profile = EQProfile.flatConvolution
+        profile.preampDB = -8
+        profile.isBypassed = true
+
+        let reference = profile.programmeComparisonReference
+
+        #expect(reference.preampDB == -8)
+        #expect(reference.mode == .parametric)
+        #expect(reference.convolution == nil)
+        #expect(reference.leftConvolution == nil)
+        #expect(reference.rightConvolution == nil)
         #expect(!reference.isBypassed)
     }
 

--- a/Tests/GlassEQCoreTests/ProfileImporterTests.swift
+++ b/Tests/GlassEQCoreTests/ProfileImporterTests.swift
@@ -22,6 +22,97 @@ struct ProfileImporterTests {
     }
 
     @Test
+    func importsEqualizerAPOGraphicEQAsMagnitudeCurve() throws {
+        let text = """
+        Preamp: -6.2 dB
+        GraphicEQ: 20 -0.2; 100 3.5; 1000 -2.1; 20000 0.4
+        """
+
+        let profile = try EQProfileTextImporter.importAutoEQ(text)
+
+        #expect(profile.mode == .convolution)
+        #expect(profile.preampDB == -6.2)
+        #expect(profile.filters.isEmpty)
+        guard case .magnitudeCurve(let curve) = profile.convolution else {
+            Issue.record("Expected a magnitude-curve convolution source")
+            return
+        }
+        #expect(curve.synthesisVersion == MinimumPhaseFIRCompiler.synthesisVersion)
+        #expect(curve.points.map(\.frequency) == [20, 100, 1_000, 20_000])
+        #expect(curve.points.map(\.gainDB) == [-0.2, 3.5, -2.1, 0.4])
+    }
+
+    @Test
+    func importsUnsortedGraphicEQPointsInFrequencyOrder() throws {
+        let profile = try EQProfileTextImporter.importAutoEQ(
+            "GraphicEQ: 1000 -2; 20 1; 20000 0"
+        )
+
+        guard case .magnitudeCurve(let curve) = profile.convolution else {
+            Issue.record("Expected a magnitude-curve convolution source")
+            return
+        }
+        #expect(curve.points.map(\.frequency) == [20, 1_000, 20_000])
+    }
+
+    @Test
+    func rejectsDuplicateGraphicEQFrequencies() throws {
+        #expect(throws: ProfileImportError.duplicateMagnitudeFrequency(
+            line: 1,
+            frequency: 100
+        )) {
+            _ = try EQProfileTextImporter.importAutoEQ(
+                "GraphicEQ: 20 0; 100 1; 100 -1"
+            )
+        }
+    }
+
+    @Test
+    func graphicEQExportRoundTripsStereoCurvesAndPreamps() throws {
+        let left = EQConvolutionSource.magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: 2),
+            EQMagnitudePoint(frequency: 20_000, gainDB: -1)
+        ]))
+        let right = EQConvolutionSource.magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: -3),
+            EQMagnitudePoint(frequency: 20_000, gainDB: 1.5)
+        ]))
+        let profile = EQProfile(
+            name: "Stereo Curve",
+            mode: .convolution,
+            channelMode: .stereo,
+            preampDB: -4,
+            filters: [],
+            leftPreampDB: -5,
+            leftFilters: [],
+            rightPreampDB: -6,
+            rightFilters: [],
+            leftConvolution: left,
+            rightConvolution: right
+        )
+
+        let exported = EQProfileTextExporter.exportEqualizerAPO(profile)
+        let imported = try EQProfileTextImporter.importAutoEQ(exported)
+
+        #expect(imported.mode == .convolution)
+        #expect(imported.channelMode == .stereo)
+        #expect(imported.preampDB == -4)
+        #expect(imported.leftPreampDB == -5)
+        #expect(imported.rightPreampDB == -6)
+        guard case .magnitudeCurve(let importedLeft) = imported.leftConvolution,
+              case .magnitudeCurve(let importedRight) = imported.rightConvolution,
+              case .magnitudeCurve(let expectedLeft) = left,
+              case .magnitudeCurve(let expectedRight) = right else {
+            Issue.record("Expected stereo magnitude curves")
+            return
+        }
+        #expect(importedLeft.points.map(\.frequency) == expectedLeft.points.map(\.frequency))
+        #expect(importedLeft.points.map(\.gainDB) == expectedLeft.points.map(\.gainDB))
+        #expect(importedRight.points.map(\.frequency) == expectedRight.points.map(\.frequency))
+        #expect(importedRight.points.map(\.gainDB) == expectedRight.points.map(\.gainDB))
+    }
+
+    @Test
     func ignoresDisabledEqualizerAPOFilters() throws {
         let text = """
         Filter 1: OFF PK Fc 1000 Hz Gain 6 dB Q 1

--- a/Tests/GlassEQCoreTests/ProfileImporterTests.swift
+++ b/Tests/GlassEQCoreTests/ProfileImporterTests.swift
@@ -68,6 +68,22 @@ struct ProfileImporterTests {
     }
 
     @Test
+    func rejectsMixedGraphicEQAndFilterDirectives() throws {
+        let text = """
+        Preamp: -4 dB
+        GraphicEQ: 20 0; 1000 3; 20000 0
+        Filter 1: ON PK Fc 1000 Hz Gain -2 dB Q 1
+        """
+
+        #expect(throws: ProfileImportError.mixedEqualizerAPOFormats(
+            graphicEQLine: 2,
+            filterLine: 3
+        )) {
+            _ = try EQProfileTextImporter.importAutoEQ(text)
+        }
+    }
+
+    @Test
     func graphicEQExportRoundTripsStereoCurvesAndPreamps() throws {
         let left = EQConvolutionSource.magnitudeCurve(MagnitudeCurveSource(points: [
             EQMagnitudePoint(frequency: 20, gainDB: 2),

--- a/Tests/GlassEQCoreTests/ProfileImporterTests.swift
+++ b/Tests/GlassEQCoreTests/ProfileImporterTests.swift
@@ -84,6 +84,24 @@ struct ProfileImporterTests {
     }
 
     @Test
+    func importsGraphicEQWithDisabledParametricFilter() throws {
+        let text = """
+        GraphicEQ: 20 0; 1000 3; 20000 0
+        Filter 1: OFF PK Fc 1000 Hz Gain -2 dB Q 1
+        """
+
+        let profile = try EQProfileTextImporter.importAutoEQ(text)
+
+        #expect(profile.mode == .convolution)
+        guard case .magnitudeCurve(let curve) = profile.convolution else {
+            Issue.record("Expected a magnitude-curve convolution source")
+            return
+        }
+        #expect(curve.points.map(\.frequency) == [20, 1_000, 20_000])
+        #expect(curve.points.map(\.gainDB) == [0, 3, 0])
+    }
+
+    @Test
     func graphicEQExportRoundTripsStereoCurvesAndPreamps() throws {
         let left = EQConvolutionSource.magnitudeCurve(MagnitudeCurveSource(points: [
             EQMagnitudePoint(frequency: 20, gainDB: 2),

--- a/Tests/GlassEQCoreTests/ProfilePersistenceTests.swift
+++ b/Tests/GlassEQCoreTests/ProfilePersistenceTests.swift
@@ -94,6 +94,126 @@ struct ProfilePersistenceTests {
     }
 
     @Test
+    func loadMigratesSchemaOneConvolutionStore() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        var convolutionProfile = EQProfile.flatConvolution
+        convolutionProfile.name = "Room Curve"
+        let store = ProfileStore(
+            schemaVersion: 1,
+            profiles: ProfileStore.defaultProfiles + [convolutionProfile],
+            outputMappings: [
+                OutputDeviceProfileMapping(
+                    outputDeviceUID: "speaker",
+                    profileID: convolutionProfile.id
+                )
+            ],
+            fallbackProfileID: convolutionProfile.id
+        )
+        let schemaOneData = try ProfilePersistence.encoder.encode(store)
+        try schemaOneData.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        var expectedStore = store
+        expectedStore.schemaVersion = ProfileStore.currentSchemaVersion
+        #expect(result.status == .loaded)
+        #expect(result.store == expectedStore)
+        #expect(try ProfilePersistence.decode(Data(contentsOf: url)) == expectedStore)
+        #expect(try Data(contentsOf: url) != schemaOneData)
+    }
+
+    @Test
+    func loadMigratesSchemaLessStore() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let profile = EQProfile(name: "Legacy", mode: .parametric, filters: [])
+        let store = ProfileStore(
+            schemaVersion: 1,
+            profiles: [profile],
+            fallbackProfileID: profile.id
+        )
+        var object = try #require(
+            JSONSerialization.jsonObject(with: ProfilePersistence.encoder.encode(store)) as? [String: Any]
+        )
+        object.removeValue(forKey: "schemaVersion")
+        let schemaLessData = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try schemaLessData.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        var expectedStore = store
+        expectedStore.schemaVersion = ProfileStore.currentSchemaVersion
+        #expect(result.status == .loaded)
+        #expect(result.store == expectedStore)
+        #expect(try ProfilePersistence.decode(Data(contentsOf: url)) == expectedStore)
+        #expect(try Data(contentsOf: url) != schemaLessData)
+    }
+
+    @Test
+    func loadLeavesSchemaOneStoreUntouchedWhenMigrationWriteFails() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let profile = EQProfile(name: "Schema One", mode: .parametric, filters: [])
+        let store = ProfileStore(
+            schemaVersion: 1,
+            profiles: [profile],
+            fallbackProfileID: profile.id
+        )
+        let schemaOneData = try ProfilePersistence.encoder.encode(store)
+        try schemaOneData.write(to: url)
+
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o555],
+            ofItemAtPath: directory.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: directory.path
+            )
+        }
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        #expect(result.status == .loaded)
+        #expect(result.store == store)
+        #expect(try Data(contentsOf: url) == schemaOneData)
+        #expect(!FileManager.default.fileExists(
+            atPath: ProfilePersistence.invalidStoreBackupURL(for: url, timestamp: timestamp).path
+        ))
+    }
+
+    @Test
+    func loadFutureSchemaWithUnknownModeDoesNotModifyStore() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let profile = EQProfile(name: "Future", mode: .parametric, filters: [])
+        var profileObject = try profileJSONObject(profile)
+        profileObject["mode"] = "future-mode"
+        let data = try rawStoreData(
+            schemaVersion: ProfileStore.currentSchemaVersion + 1,
+            profiles: [profileObject],
+            outputMappings: [],
+            fallbackProfileID: profile.id
+        )
+        try data.write(to: url)
+
+        let result = ProfilePersistence.load(from: url, timestamp: timestamp)
+
+        #expect(result.store.profiles == ProfileStore.defaultProfiles)
+        #expect(result.status == .unsupportedSchemaVersion(
+            version: ProfileStore.currentSchemaVersion + 1,
+            maximumSupported: ProfileStore.currentSchemaVersion
+        ))
+        #expect(try Data(contentsOf: url) == data)
+    }
+
+    @Test
     func loadRepairsInvalidProfileWithoutDroppingValidProfiles() throws {
         let url = try temporaryStoreURL()
         defer { removeTemporaryStoreDirectory(for: url) }
@@ -374,6 +494,25 @@ struct ProfilePersistenceTests {
     }
 
     @Test
+    func saveWritesCurrentSchemaVersion() throws {
+        let url = try temporaryStoreURL()
+        defer { removeTemporaryStoreDirectory(for: url) }
+        let profile = EQProfile(name: "Schema One", mode: .parametric, filters: [])
+        let store = ProfileStore(
+            schemaVersion: 1,
+            profiles: [profile],
+            fallbackProfileID: profile.id
+        )
+
+        try ProfilePersistence.save(store, to: url)
+
+        let savedStore = try ProfilePersistence.decode(Data(contentsOf: url))
+        #expect(savedStore.schemaVersion == ProfileStore.currentSchemaVersion)
+        #expect(savedStore.profiles == store.profiles)
+        #expect(savedStore.fallbackProfileID == store.fallbackProfileID)
+    }
+
+    @Test
     func decodeRejectsInvalidFilterBoundsAndCounts() throws {
         let invalidFrequency = EQProfile(
             name: "Invalid Frequency",
@@ -558,6 +697,7 @@ struct ProfilePersistenceTests {
     }
 
     private func rawStoreData(
+        schemaVersion: Int = ProfileStore.currentSchemaVersion,
         profiles: [[String: Any]],
         outputMappings: [OutputDeviceProfileMapping],
         fallbackProfileID: UUID
@@ -566,7 +706,7 @@ struct ProfilePersistenceTests {
             with: ProfilePersistence.encoder.encode(outputMappings)
         )
         let object: [String: Any] = [
-            "schemaVersion": ProfileStore.currentSchemaVersion,
+            "schemaVersion": schemaVersion,
             "profiles": profiles,
             "outputMappings": try #require(mappingObject as? [[String: Any]]),
             "fallbackProfileID": fallbackProfileID.uuidString

--- a/Tests/GlassEQCoreTests/ProfilePersistenceTests.swift
+++ b/Tests/GlassEQCoreTests/ProfilePersistenceTests.swift
@@ -457,6 +457,78 @@ struct ProfilePersistenceTests {
         )
     }
 
+    @Test
+    func convolutionProfileRoundTripsMagnitudeCurveSource() throws {
+        var profile = EQProfile.flatConvolution
+        profile.name = "Room Curve"
+        profile.preampDB = -5.5
+        profile.convolution = .magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: 4),
+            EQMagnitudePoint(frequency: 1_000, gainDB: -2),
+            EQMagnitudePoint(frequency: 20_000, gainDB: 1)
+        ]))
+        let store = ProfileStore(profiles: [profile], fallbackProfileID: profile.id)
+
+        let decoded = try ProfilePersistence.decode(ProfilePersistence.encode(store))
+
+        #expect(decoded == store)
+    }
+
+    @Test
+    func decodeRejectsConvolutionProfileWithoutSource() throws {
+        let profile = EQProfile(
+            name: "Missing Curve",
+            mode: .convolution,
+            filters: []
+        )
+
+        try expectValidationFailure(
+            ProfileStore(profiles: [profile], fallbackProfileID: profile.id),
+            expected: .missingConvolutionSource(
+                profileID: profile.id,
+                channel: "linked"
+            )
+        )
+    }
+
+    @Test
+    func decodeRejectsUnsupportedConvolutionSynthesisVersion() throws {
+        var profile = EQProfile.flatConvolution
+        profile.convolution = .magnitudeCurve(MagnitudeCurveSource(
+            synthesisVersion: MinimumPhaseFIRCompiler.synthesisVersion + 1,
+            points: [
+                EQMagnitudePoint(frequency: 20, gainDB: 0),
+                EQMagnitudePoint(frequency: 20_000, gainDB: 0)
+            ]
+        ))
+
+        try expectValidationFailure(
+            ProfileStore(profiles: [profile], fallbackProfileID: profile.id),
+            expected: .unsupportedSynthesisVersion(
+                profileID: profile.id,
+                version: MinimumPhaseFIRCompiler.synthesisVersion + 1
+            )
+        )
+    }
+
+    @Test
+    func decodeRejectsConvolutionCurveWithDuplicateFrequency() throws {
+        var profile = EQProfile.flatConvolution
+        profile.convolution = .magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 100, gainDB: 1),
+            EQMagnitudePoint(frequency: 100, gainDB: -1)
+        ]))
+
+        try expectValidationFailure(
+            ProfileStore(profiles: [profile], fallbackProfileID: profile.id),
+            expected: .duplicateMagnitudeFrequency(
+                profileID: profile.id,
+                channel: "linked",
+                frequency: 100
+            )
+        )
+    }
+
     private func expectValidationFailure(
         _ store: ProfileStore,
         expected: ProfileStoreValidationError

--- a/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
+++ b/Tests/GlassEQSettingsIPCTests/SettingsIPCTests.swift
@@ -340,21 +340,48 @@ struct SettingsIPCTests {
         #expect(metrics.maximumCaptureCallbackFrames == 0)
         #expect(metrics.maximumPlaybackCallbackFrames == 0)
         #expect(metrics.renderDeadlineMisses == 0)
+        #expect(metrics.callbackStartStarvations == 0)
+        #expect(metrics.renderOverruns == 0)
+        #expect(metrics.pairedTimestampDiscontinuities == 0)
         #expect(metrics.droppedInputFrames == 0)
         #expect(metrics.tapToOutputLatencyObservations == 0)
         #expect(metrics.minimumTapToOutputLatencyNanoseconds == 0)
         #expect(metrics.maximumTapToOutputLatencyNanoseconds == 0)
         #expect(metrics.averageTapToOutputLatencyNanoseconds == 0)
+        #expect(metrics.renderTiming == SettingsAudioRenderTimingDTO())
     }
 
     @Test
     func audioMetricsRoundTripTapToOutputLatency() throws {
         let metrics = SettingsAudioMetricsDTO(
+            pairedTimestampDiscontinuities: 4,
             renderDeadlineMisses: 7,
+            callbackStartStarvations: 5,
+            renderOverruns: 2,
             tapToOutputLatencyObservations: 500,
             minimumTapToOutputLatencyNanoseconds: 1_250_000,
             maximumTapToOutputLatencyNanoseconds: 2_750_000,
-            averageTapToOutputLatencyNanoseconds: 1_500_000
+            averageTapToOutputLatencyNanoseconds: 1_500_000,
+            renderTiming: SettingsAudioRenderTimingDTO(
+                callbackStartLatenessObservations: 10_000,
+                callbackStartLatenessP9999Nanoseconds: 125_000,
+                maximumCallbackStartLatenessNanoseconds: 330_000,
+                directHeadObservations: 10_000,
+                directHeadP9999Nanoseconds: 4_000,
+                maximumDirectHeadNanoseconds: 12_000,
+                tailWorkObservations: 10_000,
+                tailWorkP9999Nanoseconds: 3_000,
+                maximumTailWorkNanoseconds: 9_000,
+                totalRenderObservations: 10_000,
+                totalRenderP9999Nanoseconds: 15_000,
+                maximumTotalRenderNanoseconds: 42_000,
+                completionLatenessObservations: 10_000,
+                completionLatenessP9999Nanoseconds: 0,
+                maximumCompletionLatenessNanoseconds: 8_000,
+                tailCompletionObservations: 625,
+                minimumTailCompletionSlackFrames: 16,
+                tailDeadlineMisses: 0
+            )
         )
 
         let data = try JSONEncoder().encode(metrics)
@@ -392,6 +419,21 @@ struct SettingsIPCTests {
             profile: profile,
             sampleRate: 44_100
         ))
+    }
+
+    @Test
+    func settingsAnalysisTracksResponseCurveChanges() {
+        var profile = EQProfile.flatConvolution
+        let flat = EQAnalysisSnapshot(profile: profile, sampleRate: 48_000)
+        profile.convolution = .magnitudeCurve(MagnitudeCurveSource(points: [
+            EQMagnitudePoint(frequency: 20, gainDB: 6),
+            EQMagnitudePoint(frequency: 20_000, gainDB: -2)
+        ]))
+        let shaped = EQAnalysisSnapshot(profile: profile, sampleRate: 48_000)
+
+        #expect(flat.signature != shaped.signature)
+        #expect(abs((shaped.linkedPoints.first?.magnitudeDB ?? 0) - 6) < 0.000_001)
+        #expect(shaped.recommendedPreampDB == -6.5)
     }
 
     @Test


### PR DESCRIPTION
- Parametric filters cannot reproduce every measured headphone correction accurately, especially when users already have dense response curves. Minimum-phase convolution provides that correction without adding a separate fixed tap-to-output buffer.
- This adds prepared convolution banks under the same realtime transition contract as biquads and records the aggregate-clock evidence that constrains the design.
- This pull request is stacked on pr/programme-loudness-ab.