### PR TITLE
docs: adopt GPLv3 and define the GlassEQ trademark policy

### DIFF
--- a/Docs/Distribution.md
+++ b/Docs/Distribution.md
@@ -15,6 +15,15 @@ The script produces:
 - `.build/release-app/GlassEQ.app`
 - `.build/dist/GlassEQ-alpha-0.9.2-macos26-arm64.zip`
 
+The release script requires a clean Git checkout so the packaged source matches the binaries it builds. The downloadable ZIP contains:
+
+- `GlassEQ.app`, with the GPL text embedded at `Contents/Resources/LICENSE`.
+- `LICENSE`, containing the full GPLv3 text.
+- `SOURCE.md`, identifying the exact Git commit and build inputs.
+- `GlassEQ-alpha-0.9.2-source.tar.gz`, containing the machine-readable Corresponding Source for that commit.
+
+The source archive is generated from the same clean commit used for the build. The script verifies the license inside the app, at the ZIP root, and inside the source archive before writing the release checksum. Do not publish an app-only ZIP. A future DMG or other download format must provide the same license and Corresponding Source access.
+
 The bundle is ad hoc-signed with `codesign --sign -`. It is not Developer ID signed and is not notarized, so this command should reject it:
 
 ```sh
@@ -88,8 +97,9 @@ codesign --verify --strict --verbose=2 .build/release-app/GlassEQ.app/Contents/H
 codesign --verify --strict --verbose=2 .build/release-app/GlassEQ.app
 codesign -d --entitlements :- .build/release-app/GlassEQ.app
 spctl --assess --type execute --verbose=4 .build/release-app/GlassEQ.app
+unzip -Z1 .build/dist/GlassEQ-alpha-0.9.2-macos26-arm64.zip
 ```
 
-`codesign --verify` should pass. The entitlements output should include `com.apple.security.app-sandbox`, `com.apple.security.device.audio-input`, `com.apple.security.files.user-selected.read-only`, and `com.apple.security.network.client`, all set to `true`. `spctl` should reject the ad hoc-signed alpha because it is not Developer ID signed or notarized.
+`codesign --verify` should pass. The entitlements output should include `com.apple.security.app-sandbox`, `com.apple.security.device.audio-input`, `com.apple.security.files.user-selected.read-only`, and `com.apple.security.network.client`, all set to `true`. The ZIP listing should include `GlassEQ.app`, `LICENSE`, `SOURCE.md`, and the release's source archive. `spctl` should reject the ad hoc-signed alpha because it is not Developer ID signed or notarized.
 
 For manual sandbox verification, launch the packaged app and open Activity Monitor, then enable the `Sandbox` column. GlassEQ should show `Yes`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,674 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2026 Juho Koskela
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ swift run GlassEQDiagnostics 2
 ./Scripts/build-release-app.sh
 ```
 
-The script builds a release app bundle, embeds the app icon, ad hoc-signs the bundle, and writes a zip under `.build/dist/`.
+The script builds a release app bundle, embeds the app icon and GPL text, ad hoc-signs the bundle, and writes a ZIP under `.build/dist/`. The ZIP also contains the full license, the exact Git revision and build inputs, and a machine-readable Corresponding Source archive generated from the clean commit used for the build.
 
 Gatekeeper assessment is *expected to fail* because the alpha is not Developer ID signed or notarized:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A native macOS equalizer that processes your **entire system audio** in real tim
 
 [![macOS 26](https://img.shields.io/badge/macOS-26-black)](#supported-target)
 [![Apple Silicon](https://img.shields.io/badge/arch-Apple%20Silicon-black)](#supported-target)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-%E2%9D%A4-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/juhokoskela)
 
 **[Download the latest GlassEQ alpha](https://github.com/juhokoskela/GlassEQ/releases/latest)** for macOS 26 and Apple Silicon. See the installation notes below.
@@ -90,7 +90,7 @@ During normal listening GlassEQ is just a menu bar app and the audio engine, con
 
 ## Support the project
 
-GlassEQ is free and MIT-licensed. The biggest thing standing between the current alpha and a build that opens without the Gatekeeper workaround is an Apple Developer Program membership ($99/year), which is required to ship a **Developer ID-signed, notarized** app.
+GlassEQ's source is released under GPL-3.0-or-later. The current alpha is ad hoc-signed and still needs the Gatekeeper workaround described above. Sponsorship helps cover the Apple Developer Program membership and other release costs required for a **Developer ID-signed, notarized** app.
 
 If you'd like to help get there, the **Sponsor** button at the top of this repository goes directly toward that cost. Every bit helps move GlassEQ from "ad hoc-signed alpha" to "double-click to open."
 
@@ -153,6 +153,8 @@ GlassEQ intentionally does not implement per-app routing, a virtual output selec
 
 ## License
 
-GlassEQ is released under the MIT License.
+Unless otherwise noted, GlassEQ's source code and documentation are released under the [GNU General Public License, version 3 or later](LICENSE).
+
+The GlassEQ name, logo, app icon, and other product branding are trademarks of Juho Koskela. The source license does not grant permission to brand an independently built or modified distribution as GlassEQ. See the [GlassEQ trademark policy](TRADEMARKS.md).
 
 Copyright (c) 2026 Juho Koskela.

--- a/Scripts/build-release-app.sh
+++ b/Scripts/build-release-app.sh
@@ -36,6 +36,8 @@ NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/.build/release-app}"
 ICON_FILE="$ROOT_DIR/Sources/GlassEQApp/Resources/GlassEQ.icns"
 MIGRATION_PLIST="$ROOT_DIR/Sources/GlassEQApp/Resources/container-migration.plist"
+LICENSE_FILE="$ROOT_DIR/LICENSE"
+SOURCE_REPOSITORY_URL="https://github.com/juhokoskela/GlassEQ"
 
 fail() {
     echo "error: $*" >&2
@@ -147,8 +149,85 @@ derive_paths() {
     SETTINGS_MACOS_DIR="$SETTINGS_CONTENTS_DIR/MacOS"
     SETTINGS_RESOURCES_DIR="$SETTINGS_CONTENTS_DIR/Resources"
     SETTINGS_INFO_PLIST="$SETTINGS_CONTENTS_DIR/Info.plist"
+    PACKAGE_DIR="$BUILD_DIR/package"
+    PACKAGE_APP_DIR="$PACKAGE_DIR/$APP_NAME.app"
+    PACKAGE_SETTINGS_APP_DIR="$PACKAGE_APP_DIR/Contents/Helpers/$SETTINGS_APP_NAME.app"
+    SOURCE_ARCHIVE_NAME="$APP_NAME-$RELEASE_LABEL-source.tar.gz"
+    SOURCE_ARCHIVE_PATH="$PACKAGE_DIR/$SOURCE_ARCHIVE_NAME"
+    SOURCE_NOTICE_PATH="$PACKAGE_DIR/SOURCE.md"
     ZIP_PATH="$DIST_DIR/$APP_NAME-$RELEASE_LABEL-macos26-$ARCH.zip"
     CHECKSUM_PATH="$ZIP_PATH.sha256"
+}
+
+capture_source_revision() {
+    local source_status
+
+    [[ -f "$LICENSE_FILE" ]] || fail "release checkout is missing LICENSE"
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "release builds require a Git checkout"
+    [[ ! -f "$ROOT_DIR/.gitmodules" ]] || fail "release source packaging does not yet support Git submodules"
+
+    source_status="$(git status --porcelain=v1 --untracked-files=all)"
+    [[ -z "$source_status" ]] || fail "release builds require a clean checkout so the Corresponding Source matches the binary"
+
+    SOURCE_REVISION="$(git rev-parse --verify HEAD)"
+}
+
+verify_source_revision_unchanged() {
+    local current_revision
+    local source_status
+
+    current_revision="$(git rev-parse --verify HEAD)"
+    [[ "$current_revision" == "$SOURCE_REVISION" ]] || fail "Git HEAD changed during the release build"
+
+    source_status="$(git status --porcelain=v1 --untracked-files=all)"
+    [[ -z "$source_status" ]] || fail "the checkout changed during the release build"
+}
+
+create_source_archive() {
+    local source_root="$APP_NAME-$RELEASE_LABEL-source"
+
+    git archive \
+        --format=tar.gz \
+        --prefix="$source_root/" \
+        --output="$SOURCE_ARCHIVE_PATH" \
+        "$SOURCE_REVISION"
+
+    tar -tzf "$SOURCE_ARCHIVE_PATH" | grep -Fx "$source_root/Package.swift" >/dev/null ||
+        fail "Corresponding Source archive is missing Package.swift"
+    tar -tzf "$SOURCE_ARCHIVE_PATH" | grep -Fx "$source_root/Scripts/build-release-app.sh" >/dev/null ||
+        fail "Corresponding Source archive is missing the release script"
+    tar -xOzf "$SOURCE_ARCHIVE_PATH" "$source_root/LICENSE" | cmp -s - "$LICENSE_FILE" ||
+        fail "Corresponding Source archive does not contain the release license"
+
+    {
+        echo "# GlassEQ Corresponding Source"
+        echo
+        echo "This distribution was built from Git commit \`$SOURCE_REVISION\`."
+        echo
+        echo "The complete machine-readable Corresponding Source is included as \`$SOURCE_ARCHIVE_NAME\`."
+        echo
+        echo "Official repository: $SOURCE_REPOSITORY_URL"
+        echo
+        echo "Build inputs: version $VERSION, build $BUILD, channel $RELEASE_CHANNEL, architecture $ARCH, release label $RELEASE_LABEL."
+        echo
+        echo "GlassEQ is licensed under GPL-3.0-or-later. See \`LICENSE\` for the full license."
+    } > "$SOURCE_NOTICE_PATH"
+}
+
+verify_release_archive() {
+    local source_root="$APP_NAME-$RELEASE_LABEL-source"
+
+    unzip -tq "$ZIP_PATH" >/dev/null || fail "release archive failed its integrity check"
+    unzip -Z1 "$ZIP_PATH" | grep -Fx "$APP_NAME.app/" >/dev/null || fail "release archive is missing $APP_NAME.app"
+    unzip -Z1 "$ZIP_PATH" | grep -Fx "LICENSE" >/dev/null || fail "release archive is missing LICENSE"
+    unzip -Z1 "$ZIP_PATH" | grep -Fx "SOURCE.md" >/dev/null || fail "release archive is missing SOURCE.md"
+    unzip -Z1 "$ZIP_PATH" | grep -Fx "$SOURCE_ARCHIVE_NAME" >/dev/null || fail "release archive is missing Corresponding Source"
+    unzip -p "$ZIP_PATH" LICENSE | cmp -s - "$LICENSE_FILE" || fail "release archive contains the wrong license"
+    unzip -p "$ZIP_PATH" "$APP_NAME.app/Contents/Resources/LICENSE" | cmp -s - "$LICENSE_FILE" ||
+        fail "the packaged app contains the wrong license"
+    unzip -p "$ZIP_PATH" "$SOURCE_ARCHIVE_NAME" |
+        tar -xOzf - "$source_root/LICENSE" |
+        cmp -s - "$LICENSE_FILE" || fail "packaged Corresponding Source contains the wrong license"
 }
 
 copy_spm_resources() {
@@ -220,6 +299,8 @@ if is_dry_run; then
     exit 0
 fi
 
+capture_source_revision
+
 if [[ ! -f "$ICON_FILE" ]]; then
     swift "$ROOT_DIR/Scripts/generate-app-icon.swift" >/dev/null
 fi
@@ -238,6 +319,7 @@ cp "$SETTINGS_EXECUTABLE_SOURCE" "$SETTINGS_MACOS_DIR/$SETTINGS_APP_NAME"
 cp "$ROOT_DIR/Sources/GlassEQApp/Info.plist" "$INFO_PLIST"
 cp "$ROOT_DIR/Sources/GlassEQSettings/Info.plist" "$SETTINGS_INFO_PLIST"
 cp "$ICON_FILE" "$RESOURCES_DIR/GlassEQ.icns"
+cp "$LICENSE_FILE" "$RESOURCES_DIR/LICENSE"
 cp "$ICON_FILE" "$SETTINGS_RESOURCES_DIR/GlassEQ.icns"
 cp "$MIGRATION_PLIST" "$RESOURCES_DIR/container-migration.plist"
 copy_spm_resources "$BUILD_BIN_DIR" "$APP_NAME" "$APP_TARGET" "$RESOURCES_DIR"
@@ -324,12 +406,27 @@ if [[ "$RELEASE_CHANNEL" == "production" ]]; then
     spctl --assess --type execute --verbose=4 "$APP_DIR"
 fi
 
+verify_source_revision_unchanged
+rm -rf "$PACKAGE_DIR"
+mkdir -p "$PACKAGE_DIR"
+ditto "$APP_DIR" "$PACKAGE_APP_DIR"
+codesign --verify --strict --verbose=2 "$PACKAGE_SETTINGS_APP_DIR" >/dev/null
+codesign --verify --strict --verbose=2 "$PACKAGE_APP_DIR" >/dev/null
+if [[ "$RELEASE_CHANNEL" == "production" ]]; then
+    xcrun stapler validate "$PACKAGE_APP_DIR"
+fi
+cp "$LICENSE_FILE" "$PACKAGE_DIR/LICENSE"
+create_source_archive
+
 rm -f "$ZIP_PATH"
-ditto -c -k --keepParent --norsrc --noextattr --noqtn --noacl "$APP_DIR" "$ZIP_PATH"
+ditto -c -k --norsrc --noextattr --noqtn --noacl "$PACKAGE_DIR" "$ZIP_PATH"
+verify_release_archive
 shasum -a 256 "$ZIP_PATH" > "$CHECKSUM_PATH"
 
 echo "App: $APP_DIR"
 echo "Zip: $ZIP_PATH"
+echo "Source revision: $SOURCE_REVISION"
+echo "Corresponding Source: $SOURCE_ARCHIVE_NAME (inside the release Zip)"
 echo "Checksum: $CHECKSUM_PATH"
 cat "$CHECKSUM_PATH"
 echo

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,73 @@
+# GlassEQ trademark policy
+
+Last updated: September 1, 2026
+
+## Purpose
+
+GlassEQ is open-source software. Its source license gives you broad rights to use, study, modify, and redistribute the software. Those rights do not make third-party builds official GlassEQ releases.
+
+This policy keeps that distinction clear. Users should be able to tell whether Juho Koskela built, signed, published, and supports the software they receive.
+
+## Covered marks
+
+The GlassEQ name, logo, app icon, wordmark, and other distinctive product branding are trademarks of Juho Koskela. This policy refers to them collectively as the GlassEQ marks.
+
+The GNU General Public License governs the covered source code and other copyrighted material. It does not grant permission under trademark law to use the GlassEQ marks as branding for a third-party distribution.
+
+## Uses that do not require permission
+
+You may use the GlassEQ word mark to:
+
+- Truthfully refer or link to the official GlassEQ project.
+- State that another project is based on GlassEQ, derived from GlassEQ, or compatible with GlassEQ when that statement is accurate.
+- Discuss, review, criticize, or report on GlassEQ.
+- Show unaltered screenshots of GlassEQ for those purposes.
+
+These uses must not suggest that Juho Koskela publishes, endorses, certifies, or supports your project, product, or service. Do not use the GlassEQ logo or app icon as your own branding, and do not display a GlassEQ mark more prominently than your own name or branding.
+
+The following attribution is appropriate where one is useful:
+
+> "GlassEQ" and the GlassEQ logo are trademarks of Juho Koskela. This project is not affiliated with or endorsed by the GlassEQ project.
+
+## Redistributing official builds
+
+You may redistribute an exact, unmodified copy of an official GlassEQ binary release under its existing GlassEQ branding. An official release is a binary originally published and signed by Juho Koskela.
+
+When redistributing an official release, you must:
+
+- Preserve the binary, code signature, notices, installer, and bundled contents without alteration.
+- Identify the release as an unmodified copy of an official GlassEQ release.
+- Make clear that you are the redistributor and are not affiliated with Juho Koskela.
+- Preserve the original source-code offer and license information.
+- Avoid implying that your distribution includes official support, a commercial license, or access to the official update service.
+
+Re-signing, repackaging, bundling other software, changing defaults, modifying the installer, or changing any bundled file makes the distribution a third-party build. The rebranding requirements below then apply.
+
+## Third-party builds and modified versions
+
+You may privately build and modify GlassEQ under the GNU General Public License. If you distribute a build that Juho Koskela did not publish and sign, you must give it distinct branding.
+
+A third-party distribution must:
+
+- Use a product name that does not contain GlassEQ or a confusingly similar variation.
+- Replace the GlassEQ logo, app icon, wordmark, and other user-facing GlassEQ branding.
+- Use its own executable name, bundle identifier, update feed, download service, website, and support contact.
+- State clearly that it is an independent project based on GlassEQ and is not an official GlassEQ release.
+- Preserve all copyright, source-license, and third-party attribution notices required by their licenses.
+
+You may retain accurate references to GlassEQ in source history, copyright notices, license notices, technical documentation, and statements describing the origin of the modified work.
+
+## Uses that require written permission
+
+Written permission from Juho Koskela is required to:
+
+- Distribute a third-party build under the GlassEQ name or with any GlassEQ logo or app icon.
+- Use a GlassEQ mark in the name of another application, company, service, domain, social-media account, or package listing.
+- Use a GlassEQ mark on merchandise or in advertising that suggests sponsorship or endorsement.
+- Present a third-party signing certificate, update service, download, or support offering as official GlassEQ infrastructure.
+
+## No restriction on lawful reference
+
+This policy does not limit rights that applicable law grants without permission, including lawful descriptive or nominative use of a trademark. It does not change the permissions or obligations of the GNU General Public License.
+
+For trademark permission beyond this policy, contact Juho Koskela at contact@juhokoskela.fi.


### PR DESCRIPTION
GlassEQ is moving toward a v1 release where the source remains open while the signed, notarized distribution is an official product with distinct branding. 
The existing MIT license did not require redistributed modifications to remain open, and it did not explain how third-party builds may use the GlassEQ identity.

This change:
- Relicenses the project under GPL-3.0-or-later so redistributed modifications remain available under the same copyleft terms.
- Reserves the GlassEQ name, logo, app icon, and product branding for builds published and signed by Juho Koskela.
- Allows exact copies of official releases and truthful references to GlassEQ while requiring independently built or modified distributions to use their own branding.
- Updates the README so the source-license and trademark boundary is clear before v1.

This does not change application behavior or restrict private builds and modifications, which are permitted by the GPL.